### PR TITLE
fix: commandUtils execute on windows

### DIFF
--- a/streamx-common/src/main/scala/com/streamxhub/streamx/common/util/CommandUtils.scala
+++ b/streamx-common/src/main/scala/com/streamxhub/streamx/common/util/CommandUtils.scala
@@ -66,7 +66,7 @@ object CommandUtils extends Logger {
       require(commands != null && commands.nonEmpty)
       logDebug(s"Command execute:\n${commands.mkString("\n")} ")
       val process = Utils.isWindows match {
-        case x if x => Runtime.getRuntime.exec("cmd /c ", null, null)
+        case x if x => Runtime.getRuntime.exec("cmd /k ", null, null)
         case _ => Runtime.getRuntime.exec("/bin/bash ", null, null)
       }
       val out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(process.getOutputStream)), true)


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Windows 开发环境，设置 Flink Home 时，多行命令执行失败，无法找到 Flink 版本，导致数据库添加数据失败
将  cmd /c 改为 cmd /k 解决 Windows 下无法执行多条命令的问题

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
```scala
Runtime.getRuntime.exec("cmd /k", null, null)
val out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(process.getOutputStream)), true)
commands.foreach(out.println)
```

或者
```scala
Runtime.getRuntime.exec("cmd /c " + commands.mkString(" & "), null, null)
```