### PR TITLE
fix: outFatJarPath should be a file

### DIFF
--- a/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/maven/MavenTool.scala
+++ b/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/maven/MavenTool.scala
@@ -33,7 +33,7 @@ object MavenTool extends Logger {
   @throws[Exception] def buildFatJar(@Nonnull jarLibs: Set[String], @Nonnull outFatJarPath: String): File = {
     // check userJarPath
     val uberJar = new File(outFatJarPath)
-    require(!uberJar.isDirectory, s"[streamx-packer] outFatJarPath($outFatJarPath) should be a file.")
+    require(outFatJarPath.endsWith(".jar") && !uberJar.isDirectory, s"[streamx-packer] outFatJarPath($outFatJarPath) should be a JAR file.")
     // resolve all jarLibs
     val jarSet = new util.HashSet[File]
     jarLibs.map(lib => new File(lib))


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

这是原来的逻辑，判断不是文件夹才进行编译。否则文件名会冲突

```scala
if (uberJar.isDirectory) {
  throw new Exception(s"[streamx-packer] outFatJarPath($outFatJarPath) should be a file.")
}
```

这是现在的逻辑 这个[PR](https://github.com/streamxhub/streamx/commit/a53a054d60799142432a260c8532b44b62c3a163)引入的 Bug
```scala
require(uberJar.isFile, s"[streamx-packer] outFatJarPath($outFatJarPath) should be a file.")
```

应该改为

```scala
require(!uberJar.isDirectory, s"[streamx-packer] outFatJarPath($outFatJarPath) should be a file.")
```

