### PR TITLE
fix: transform table connectorformat resources

### DIFF
--- a/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/maven/MavenTool.scala
+++ b/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/maven/MavenTool.scala
@@ -50,7 +50,8 @@ object MavenTool extends Logger {
       req.setJars(jarSet)
       req.setUberJar(uberJar)
       req.setFilters(Lists.newArrayList())
-      req.setResourceTransformers(Lists.newArrayList())
+      // ref https://ci.apache.org/projects/flink/flink-docs-master/docs/connectors/table/overview/#transform-table-connectorformat-resources
+      req.setResourceTransformers(Lists.newArrayList(new ServicesResourceTransformer()))
       req.setRelocators(Lists.newArrayList())
       req
     }


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

![W3LQ@$UF2$62%H@V`3PB2L3](https://user-images.githubusercontent.com/31752986/137697287-6a5e6465-933a-438d-a78b-066e456453ff.png)

Caused by: org.apache.flink.table.api.NoMatchingTableFactoryException:
Could not find a suitable table factory for 'org.apache.flink.table.factories.TableSourceFactory' in the classpath.

Problem Summary:

ref [transform-table-connectorformat-resources](https://ci.apache.org/projects/flink/flink-docs-master/docs/connectors/table/overview/#transform-table-connectorformat-resources)

Flink uses Java’s Service Provider Interfaces (SPI) to load the table connector/format factories by their identifiers. Since the SPI resource file named org.apache.flink.table.factories.Factory for every table connector/format is under the same directory META-INF/services, these resource files will override each other when build the uber-jar of the project which uses more than one table connector/format, which will cause Flink to fail to load table connector/format factories.

### What is changed and how it works?

What's Changed:

How it Works:

