### PR TITLE
Separate docker image pull and build process

### DIFF
--- a/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/docker/DockerTool.scala
+++ b/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/docker/DockerTool.scala
@@ -1,6 +1,7 @@
 package com.streamxhub.streamx.flink.packer.docker
 
 import com.github.dockerjava.api.command.PushImageCmd
+import com.github.dockerjava.api.exception.InternalServerErrorException
 import com.google.common.collect.Sets
 import com.streamxhub.streamx.common.conf.ConfigConst.DOCKER_IMAGE_NAMESPACE
 import com.streamxhub.streamx.common.util.Logger
@@ -48,23 +49,31 @@ object DockerTool extends Logger {
     // build and push docker image
     tryWithResourceException(DockerRetriever.newDockerClient()) {
       dockerClient =>
+        // pull docker image
+        val pullImageCmd = dockerClient.pullImageCmd(dockerFileTemplate.flinkBaseImage).withAuthConfig(authConf.toDockerAuthConf)
+        pullImageCmd.start().awaitCompletion()
+        logInfo(s"[streamx-packer] docker pull image ${dockerFileTemplate.flinkBaseImage} successfully.")
         // build docker image
         val buildImageCmd = dockerClient.buildImageCmd()
-          .withPull(true)
           .withBaseDirectory(projectDir)
           .withDockerfile(dockerfile)
           .withTags(Sets.newHashSet(tagName))
-        buildImageCmd.start().awaitCompletion()
-        logInfo(s"[streamx-packer] docker image built successfully, tag=${tagName}")
+        val imageId = buildImageCmd.start().awaitImageId()
+        logInfo(s"[streamx-packer] docker image built successfully, imageId=${imageId}, tag=${tagName}")
         // push docker image
         if (push) {
           val pushCmd: PushImageCmd = dockerClient.pushImageCmd(tagName).withAuthConfig(authConf.toDockerAuthConf)
           pushCmd.start().awaitCompletion()
           logInfo(s"[streamx-packer] docker image push successfully, tag=${tagName}, registerAddr=${authConf.registerAddress}")
         }
-    }(
-      exception => throw new Exception("[streamx-packer] build and push flink job docker image fail", exception)
-    )
+    } {
+      case cause: InternalServerErrorException =>
+        logError(s"[streamx] pull flink base docker image failed, imageTag=${dockerFileTemplate.flinkBaseImage}", cause)
+        throw new Exception(s"[streamx] pull flink base docker image failed, imageTag=${dockerFileTemplate.flinkBaseImage}", cause)
+      case cause =>
+        logError("[streamx-packer] build and push flink job docker image failed.", cause)
+        throw new Exception("[streamx-packer] build and push flink job docker image failed.", cause)
+    }
     tagName
   }
 


### PR DESCRIPTION
### What problem does this PR solve?

When an incorrect flink-base-image was specified to submit flink-job on flink-k8s application mode, the associated error log is vague and does not provide sufficient error information.

### What is changed ?
Separate the docker image pull and build process on DockerTool.

