### PR TITLE
fix: buildFlinkImage pullImageCmd

### DIFF
--- a/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/docker/DockerTool.scala
+++ b/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/docker/DockerTool.scala
@@ -50,9 +50,11 @@ object DockerTool extends Logger {
     tryWithResourceException(DockerRetriever.newDockerClient()) {
       dockerClient =>
         // pull docker image
-        val pullImageCmd = dockerClient.pullImageCmd(dockerFileTemplate.flinkBaseImage).withAuthConfig(authConf.toDockerAuthConf)
+        val pullImageCmd = dockerClient.pullImageCmd(dockerFileTemplate.flinkBaseImage)
+          .withRegistry(authConf.registerAddress)
+          .withAuthConfig(authConf.toDockerAuthConf)
         pullImageCmd.start().awaitCompletion()
-        logInfo(s"[streamx-packer] docker pull image ${dockerFileTemplate.flinkBaseImage} successfully.")
+        logInfo(s"[streamx-packer] docker pull image ${formatTag(dockerFileTemplate.flinkBaseImage, authConf.registerAddress)} successfully.")
         // build docker image
         val buildImageCmd = dockerClient.buildImageCmd()
           .withBaseDirectory(projectDir)
@@ -97,15 +99,24 @@ object DockerTool extends Logger {
     }
   }
 
-
   /**
    * compile image tag with namespace and remote address.
    */
   private def compileTag(tag: String, registerAddress: String): String = {
-    var tagName = if (tag.contains("/")) tag else s"$DOCKER_IMAGE_NAMESPACE/$tag"
-    if (registerAddress.nonEmpty && !tagName.startsWith(registerAddress))
-      tagName = s"$registerAddress/$tagName"
-    tagName
+    formatTag(if (tag.contains("/")) tag else s"$DOCKER_IMAGE_NAMESPACE/$tag", registerAddress)
+  }
+
+  /**
+   * format image tag with namespace and remote address.
+   *
+   * e.g.
+   * tag     registry-1.docker.io -> registry-1.docker.io/library/tag
+   * tag/tag registry-1.docker.io -> registry-1.docker.io/tag/tag
+   */
+  private def formatTag(tag: String, registerAddress: String): String = {
+    if (registerAddress.nonEmpty && !tag.startsWith(registerAddress)) {
+      s"$registerAddress${if (tag.contains("/")) "/" else "/library/"}$tag"
+    } else tag
   }
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

#363 这个 pr 导致报错 

```
Caused by: com.github.dockerjava.api.exception.DockerClientException: Could not pull image: Head "https://registry-1.docker.io/v2/library/flink/manifests/1.12.5-scala_2.11-java8": unauthorized: incorrect username or password
```

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

