### PR TITLE
bug fix: explain statement does't work due to incorrect sql parameters

### DIFF
--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/FlinkSqlExecutor.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/FlinkSqlExecutor.scala
@@ -152,7 +152,7 @@ object FlinkSqlExecutor extends Logger {
           }
           callback(builder.toString())
         case EXPLAIN =>
-          val tableResult = context.executeSql(sql)
+          val tableResult = context.executeSql(args)
           val r = tableResult.collect().next().getField(0).toString
           callback(r)
         case INSERT_INTO | INSERT_OVERWRITE => insertArray += args

--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/SqlCommandParser.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/SqlCommandParser.scala
@@ -310,7 +310,7 @@ object SqlCommand extends enumeratum.Enum[SqlCommand] {
    */
   case object EXPLAIN extends SqlCommand(
     "explain plan for",
-    "EXPLAIN\\s+PLAN\\s+FOR\\s+(SELECT\\s+.*|INSERT\\s+.*)"
+    "(EXPLAIN\\s+PLAN\\s+FOR\\s+(SELECT\\s+.*|INSERT\\s+.*))"
   )
 
   case object SET extends SqlCommand(


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #374 

Problem Summary:  
- 将explain sql对应的key当作sql语句进行提交，导致explain语句执行不正确

### What is changed and how it works?

What's Changed:   
- 解析正确的expalin语句进行提交

How it Works:  
- 通过StreamX提交Explain 语句进行测试
