### PR TITLE
add the log error info where get flink client

### DIFF
--- a/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/KubernetesRetriever.scala
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/KubernetesRetriever.scala
@@ -98,10 +98,9 @@ object KubernetesRetriever extends Logger {
     } match {
       case Success(v) => v
       case Failure(e) =>
-        logError(s"Get flinkClient error.the error is:$e")
-        null
+        logError(s"Get flinkClient error, the error is:$e")
+        throw e
     }
-
   }
 
 

--- a/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/KubernetesRetriever.scala
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/KubernetesRetriever.scala
@@ -19,6 +19,7 @@
 
 package com.streamxhub.streamx.flink.kubernetes
 
+import com.streamxhub.streamx.common.util.Logger
 import com.streamxhub.streamx.common.util.Utils.{tryWithResource, tryWithResourceException}
 import com.streamxhub.streamx.flink.kubernetes.enums.FlinkK8sExecuteMode
 import com.streamxhub.streamx.flink.kubernetes.model.ClusterKey
@@ -38,7 +39,7 @@ import scala.util.Try
 /**
  * author:Al-assad
  */
-object KubernetesRetriever {
+object KubernetesRetriever extends Logger{
 
   // see org.apache.flink.client.cli.ClientOptions.CLIENT_TIMEOUT}
   val FLINK_CLIENT_TIMEOUT_SEC = 30L
@@ -89,9 +90,18 @@ object KubernetesRetriever {
     val clientFactory: ClusterClientFactory[String] = clusterClientServiceLoader.getClusterClientFactory(flinkConfig)
     val clusterProvider: KubernetesClusterDescriptor = clientFactory.createClusterDescriptor(flinkConfig)
       .asInstanceOf[KubernetesClusterDescriptor]
-    val flinkClient: ClusterClient[String] = clusterProvider
-      .retrieve(flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID))
-      .getClusterClient
+
+    var flinkClient: ClusterClient[String] = null
+    try{
+         flinkClient = clusterProvider
+        .retrieve(flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID))
+        .getClusterClient
+    } catch {
+      case ex: Exception => {
+        logError(s"Get flinkClient error.the error is:$ex")
+      }
+    }
+
     flinkClient
   }
 

--- a/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/KubernetesRetriever.scala
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/KubernetesRetriever.scala
@@ -34,12 +34,12 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions
 import java.time.Duration
 import javax.annotation.Nullable
 import scala.collection.JavaConverters._
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 /**
  * author:Al-assad
  */
-object KubernetesRetriever extends Logger{
+object KubernetesRetriever extends Logger {
 
   // see org.apache.flink.client.cli.ClientOptions.CLIENT_TIMEOUT}
   val FLINK_CLIENT_TIMEOUT_SEC = 30L
@@ -91,18 +91,17 @@ object KubernetesRetriever extends Logger{
     val clusterProvider: KubernetesClusterDescriptor = clientFactory.createClusterDescriptor(flinkConfig)
       .asInstanceOf[KubernetesClusterDescriptor]
 
-    var flinkClient: ClusterClient[String] = null
-    try{
-         flinkClient = clusterProvider
+    Try {
+      clusterProvider
         .retrieve(flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID))
         .getClusterClient
-    } catch {
-      case ex: Exception => {
-        logError(s"Get flinkClient error.the error is:$ex")
-      }
+    } match {
+      case Success(v) => v
+      case Failure(e) =>
+        logError(s"Get flinkClient error.the error is:$e")
+        null
     }
 
-    flinkClient
   }
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #523 

Problem Summary:

because of various of  reasons,we can not get the k8s client info so that we can not get the flink job status, but streamx do not print the error info,so I add the log , we can solve the problem by the logs.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

