### PR TITLE
修复配置flink-history后，任务失败状态同步错误bug

### DIFF
--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/FlinkTrackingTask.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/FlinkTrackingTask.java
@@ -254,7 +254,7 @@ public class FlinkTrackingTask {
      */
     private void getFromFlinkRestApi(Application application, StopFrom stopFrom) throws Exception {
         JobsOverview jobsOverview = application.httpJobsOverview();
-        Optional<JobsOverview.Job> optional = jobsOverview.getJobs().stream().findFirst();
+        Optional<JobsOverview.Job> optional = jobsOverview.getJobs().size() > 1 ? jobsOverview.getJobs().stream().filter(a -> StringUtils.equals(application.getJobId(), a.getId())).findFirst() : jobsOverview.getJobs().stream().findFirst();
 
         if (optional.isPresent()) {
 

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/FlinkTrackingTask.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/FlinkTrackingTask.java
@@ -40,6 +40,7 @@ import com.streamxhub.streamx.console.core.service.ApplicationService;
 import com.streamxhub.streamx.console.core.service.SavePointService;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;


### PR DESCRIPTION

修改前
obsOverview.getJobs().stream().findFirst()

修改后
Optional<JobsOverview.Job> optional = jobsOverview.getJobs().size() > 1 ? jobsOverview.getJobs().stream().filter(a -> StringUtils.equals(application.getJobId(), a.getId())).findFirst() : jobsOverview.getJobs().stream().findFirst();

说明：
  当配置flink-history 后，通过接口获取非running 中的任务数据时，记录是混合所有任务记录，并且没有顺序，所以当每次都获取第一条数据时，并不能对应到当前任务数据状态，导致数据状态更新错误，修改后增加了jid的对比，获取当前任务的数据并且更新任务状态，解决此问题。
 刚开始解决这个问题的时候，jobsOverview.getJobs().stream().filter(a -> StringUtils.equals(application.getJobId(), a.getId())).findFirst() 仅仅用了这一行代码，并没有判断jobs.size(),发现启动任务的时候，数据库中的jid 并不是当前执行任务jid，还没有更新到数据库中，所以无法匹配到jid，任务状态无法匹配，建议可以在启动任务后，直接将任务的jid 更新到数据库中，并不是是通过这个任务更新到数据库中