### PR TITLE
Fix the wrong button icon

### DIFF
--- a/streamx-console/streamx-console-webapp/src/views/flink/app/View.vue
+++ b/streamx-console/streamx-console-webapp/src/views/flink/app/View.vue
@@ -510,7 +510,7 @@
               shape="circle"
               size="small"
               class="control-button ctl-btn-color">
-              <a-icon type="cloud-sync"/>
+              <a-icon type="pause-circle"/>
             </a-button>
           </a-tooltip>
 


### PR DESCRIPTION
Signed-off-by: Al-assad yulin.ying@outlook.com

The Cancel Task button icon is displayed incorrectly, as follows.
<img width="1171" alt="iShot2021-12-24 14 48 44" src="https://user-images.githubusercontent.com/22493821/147333593-67904548-22c8-4ed9-af5d-d6c6c8dab953.png">
It should be modified to be:
<img width="1196" alt="iShot2021-12-24 14 51 13" src="https://user-images.githubusercontent.com/22493821/147333693-f35c4f65-5bdb-4081-a032-5dc1f9596ccc.png">

