### PR TITLE
Fixed issue #562. The parameter jvm-metaspace.size setting …

### DIFF
--- a/streamx-console/streamx-console-webapp/src/views/flink/app/Option.js
+++ b/streamx-console/streamx-console-webapp/src/views/flink/app/Option.js
@@ -408,7 +408,7 @@ export default [
         name: 'taskmanager.memory.jvm-metaspace.size',
         placeholder: 'JVM Metaspace Size for the TaskExecutors',
         description: 'JVM Metaspace Size for the TaskExecutors',
-        unit: null,
+        unit: 'mb',
         group: 'taskmanager-memory',
         type: 'number',
         min: 1,


### PR DESCRIPTION
The parameter jvm-metaspace.size setting is invalid, the unit should be MB, but it is actually bytes

PR Title Format:
1. Fix jobmanager_memory_jvm_metaspace_size unit to mb

### What problem does this PR solve?

Issue Number: close #562

Problem Summary:

### What is changed and how it works?

What's Changed: Change jobmanager_memory_jvm_metaspace_size unit null to mb

