### PR TITLE
Do not set parallelism for StreamExecutionEnvironment

### DIFF
--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.12/src/main/scala/com/streamxhub/streamx/flink/core/FlinkStreamingInitializer.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.12/src/main/scala/com/streamxhub/streamx/flink/core/FlinkStreamingInitializer.scala
@@ -165,12 +165,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
   def initStreamEnv(): Unit = {
     localStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment
     //init env...
-    Try(parameter.get(KEY_FLINK_PARALLELISM()).toInt).getOrElse {
-      Try(parameter.get(CoreOptions.DEFAULT_PARALLELISM.key()).toInt).getOrElse(CoreOptions.DEFAULT_PARALLELISM.defaultValue().toInt)
-    } match {
-      case p if p > 0 => localStreamEnv.setParallelism(p)
-      case _ => throw new IllegalArgumentException("[StreamX] parallelism must be > 0. ")
-    }
     val interval = Try(parameter.get(KEY_FLINK_WATERMARK_INTERVAL).toInt).getOrElse(0)
     if (interval > 0) {
       localStreamEnv.getConfig.setAutoWatermarkInterval(interval)

--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.13/src/main/scala/com/streamxhub/streamx/flink/core/FlinkStreamingInitializer.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.13/src/main/scala/com/streamxhub/streamx/flink/core/FlinkStreamingInitializer.scala
@@ -164,12 +164,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
   def initStreamEnv(): Unit = {
     localStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment
     //init env...
-    Try(parameter.get(KEY_FLINK_PARALLELISM()).toInt).getOrElse {
-      Try(parameter.get(CoreOptions.DEFAULT_PARALLELISM.key()).toInt).getOrElse(CoreOptions.DEFAULT_PARALLELISM.defaultValue().toInt)
-    } match {
-      case p if p > 0 => localStreamEnv.setParallelism(p)
-      case _ => throw new IllegalArgumentException("[StreamX] parallelism must be > 0. ")
-    }
     val interval = Try(parameter.get(KEY_FLINK_WATERMARK_INTERVAL).toInt).getOrElse(0)
     if (interval > 0) {
       localStreamEnv.getConfig.setAutoWatermarkInterval(interval)

--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.14/src/main/scala/com/streamxhub/streamx/flink/core/FlinkStreamingInitializer.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.14/src/main/scala/com/streamxhub/streamx/flink/core/FlinkStreamingInitializer.scala
@@ -164,12 +164,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
   def initStreamEnv(): Unit = {
     localStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment
     //init env...
-    Try(parameter.get(KEY_FLINK_PARALLELISM()).toInt).getOrElse {
-      Try(parameter.get(CoreOptions.DEFAULT_PARALLELISM.key()).toInt).getOrElse(CoreOptions.DEFAULT_PARALLELISM.defaultValue().toInt)
-    } match {
-      case p if p > 0 => localStreamEnv.setParallelism(p)
-      case _ => throw new IllegalArgumentException("[StreamX] parallelism must be > 0. ")
-    }
     val interval = Try(parameter.get(KEY_FLINK_WATERMARK_INTERVAL).toInt).getOrElse(0)
     if (interval > 0) {
       localStreamEnv.getConfig.setAutoWatermarkInterval(interval)


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

for flink sql mode,if we set the parallelism for StreamExecutionEnvironment ,  and when user set the parallelism on web ui,
it will be add to flink configuration, so it  will do not effective，so I think we should remove the setting for StreamExecutionEnvironment .


