### PR TITLE
modify the alert url for k8s and yarn

### DIFF
--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/AlertServiceImpl.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/AlertServiceImpl.java
@@ -19,6 +19,7 @@
 
 package com.streamxhub.streamx.console.core.service.impl;
 
+import com.streamxhub.streamx.common.enums.ExecutionMode;
 import com.streamxhub.streamx.common.util.DateUtils;
 import com.streamxhub.streamx.common.util.HadoopUtils;
 import com.streamxhub.streamx.common.util.Utils;
@@ -37,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
+
 import java.io.File;
 import java.io.StringWriter;
 import java.net.URL;
@@ -161,8 +163,14 @@ public class AlertServiceImpl implements AlertService {
             duration = application.getEndTime().getTime() - application.getStartTime().getTime();
         }
         duration = duration / 1000 / 60;
-        String format = "%s/proxy/%s/";
-        String url = String.format(format, HadoopUtils.getRMWebAppURL(false), application.getAppId());
+
+        // TODO: modify url for both k8s and yarn execute mode, the k8s mode is different from yarn, when the flink job failed ,
+        //  the k8s pod is missing , so we should look for  a more reasonable url for k8s
+        String url = "";
+        if (ExecutionMode.isYarnMode(application.getExecutionMode())) {
+            String format = "%s/proxy/%s/";
+            url = String.format(format, HadoopUtils.getRMWebAppURL(false), application.getAppId());
+        }
 
         MailTemplate template = new MailTemplate();
         template.setJobName(application.getJobName());


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

modify url for both k8s and yarn execute mode, the k8s mode is different from yarn, when the flink job failed ,
the k8s pod is missing , so we should look for  a more reasonable url for k8s in the future

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

