### PR TITLE
add restart and finished state for alert email

### DIFF
--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/K8sFlinkChangeEventListener.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/K8sFlinkChangeEventListener.java
@@ -106,7 +106,8 @@ public class K8sFlinkChangeEventListener {
 
         // email alerts when necessary
         FlinkAppState state = FlinkAppState.of(app.getState());
-        if (FlinkAppState.FAILED.equals(state) || FlinkAppState.LOST.equals(state)) {
+        if (FlinkAppState.FAILED.equals(state) || FlinkAppState.LOST.equals(state)
+            || FlinkAppState.RESTARTING.equals(state) || FlinkAppState.FINISHED.equals(state)) {
             Application finalApp = app;
             executor.execute(() -> alertService.alert(finalApp, state));
         }


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

1. when the job is RESTART state, an exception occurred in the job , I think we should send a alert email to the user.
2. In general, the streaming job do not appear in the FINISHED state. If the FINISHED state appears, there may be an exception. For batch jobs, if the FINISHED status appears, I think we should send an email to inform users that the job  has been finished.




### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

