### PR TITLE
[Enhancement-770] When adding invalid flink env, print stdout and return error.

### DIFF
--- a/streamx-common/src/main/scala/com/streamxhub/streamx/common/domain/FlinkVersion.scala
+++ b/streamx-common/src/main/scala/com/streamxhub/streamx/common/domain/FlinkVersion.scala
@@ -18,12 +18,11 @@
  */
 package com.streamxhub.streamx.common.domain
 
-import com.streamxhub.streamx.common.util.CommandUtils
-import org.apache.commons.lang3.StringUtils
+import com.streamxhub.streamx.common.util.{CommandUtils, Logger}
 
 import java.io.File
 import java.net.{URL => NetURL}
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.function.Consumer
 import java.util.regex.Pattern
 import scala.collection.JavaConversions._
@@ -32,7 +31,7 @@ import scala.collection.JavaConversions._
  * @param flinkHome actual flink home that must be a readable local path
  * @author benjobs
  */
-class FlinkVersion(val flinkHome: String) extends java.io.Serializable {
+class FlinkVersion(val flinkHome: String) extends java.io.Serializable with Logger {
 
   private[this] lazy val FLINK_VER_PATTERN = Pattern.compile("^(\\d+\\.\\d+)(\\.)?.*$")
 
@@ -64,26 +63,24 @@ class FlinkVersion(val flinkHome: String) extends java.io.Serializable {
       s"cd ${flinkLib.getAbsolutePath}",
       s"java -classpath ${flinkDistJar.getAbsolutePath} org.apache.flink.client.cli.CliFrontend --version"
     )
+    val success = new AtomicBoolean(false)
+    val buffer = new StringBuilder
     CommandUtils.execute(cmd, new Consumer[String]() {
       override def accept(out: String): Unit = {
+        buffer.append(out).append("\n")
         val matcher = FLINK_VERSION_PATTERN.matcher(out)
         if (matcher.find) {
+          success.set(true)
           flinkVersion.set(matcher.group(1))
         }
       }
     })
-    val version = flinkVersion.get
-    doCheckVersion(version)
-    version
-  }
-
-  def doCheckVersion(version: String): Unit = {
-    if (StringUtils.isEmpty(version)) {
-      throw new IllegalStateException("[StreamX] parse flink version failed.")
+    logInfo(buffer.toString())
+    if (!success.get()) {
+      throw new IllegalStateException(s"[StreamX] parse flink version failed. $buffer")
     }
-    if (version.split("\\.").length != 3) {
-      throw new IllegalStateException("[StreamX] parse illegal version.")
-    }
+    buffer.clear()
+    flinkVersion.get
   }
 
   // flink major version, like "1.13", "1.14"


### PR DESCRIPTION

<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #770  <!-- REMOVE this line if no issue to close -->

Problem Summary: When adding invalid flink env, print stdout and return error.
