### PR TITLE
[minor] workspace dir replace with tmp

### DIFF
--- a/streamx-console/streamx-console-service/src/main/resources/application.yml
+++ b/streamx-console/streamx-console-service/src/main/resources/application.yml
@@ -72,7 +72,7 @@ streamx:
   hadoop-user-name: hdfs
   # 本地的工作空间,用于存放项目源码,构建的目录等.
   workspace:
-    local: /opt/streamx_workspace
+    local: /tmp/streamx_workspace
     remote: hdfs:///streamx   # support hdfs:///streamx/ 、 /streamx 、hdfs://host:ip/streamx/
 
   # remote docker register namespace for streamx


### PR DESCRIPTION
The user may not have the read and write permission for the /opt directory.
we can use tmp instead.

<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

