### PR TITLE
[hotfix] fix yarn mode upload jar to incorrect hdfs dir. (#805)

### DIFF
--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ApplBuildPipeServiceImpl.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ApplBuildPipeServiceImpl.java
@@ -194,8 +194,13 @@ public class ApplBuildPipeServiceImpl
                                 fsOperator.copy(uploadJar, app.getAppLib(), false, true);
                                 break;
                             case APACHE_FLINK:
-                                fsOperator.mkdirs(appHome);
-                                fsOperator.copy(uploadJar, appHome, false, true);
+                                if (ExecutionMode.isYarnMode(app.getExecutionMode())) {
+                                    fsOperator.mkdirs(app.getAppLib());
+                                    fsOperator.copy(uploadJar, app.getAppLib(), false, true);
+                                } else {
+                                    fsOperator.mkdirs(appHome);
+                                    fsOperator.copy(uploadJar, appHome, false, true);
+                                }
                                 break;
                             default:
                                 throw new IllegalArgumentException("[StreamX] unsupported ApplicationType of custom code: "


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #805  <!-- REMOVE this line if no issue to close -->

Problem Summary: Use custom code upload jar mode to submit job , mention about jar file not exists

