### PR TITLE
Fix wrong create table sql of project

### DIFF
--- a/streamx-console/streamx-console-service/src/assembly/script/final.sql
+++ b/streamx-console/streamx-console-service/src/assembly/script/final.sql
@@ -214,7 +214,7 @@ CREATE TABLE `t_flink_project` (
 `USER_NAME` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
 `PASSWORD` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
 `POM` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
-`BUILD_ARGS` varchar(255) DEFAULT '-1',
+`BUILD_ARGS` varchar(255) DEFAULT NULL,
 `TYPE` tinyint DEFAULT NULL,
 `REPOSITORY` tinyint DEFAULT NULL,
 `DATE` datetime DEFAULT NULL,


### PR DESCRIPTION
What problem does this PR solve?
Problem Summary:
Fix wrong create table sql of project

What is changed and how it works?
change the file of streamx-console/streamx-console-service/src/assembly/script/final.sql

before:

BUILD_ARGS varchar(255) DEFAULT '-1',

after:
BUILD_ARGS varchar(255) DEFAULT NULL,

How it Works:
test completed