### PR TITLE
[BUG]kerberos getLoginUser error.#1030

### DIFF
--- a/streamx-common/src/main/scala/com/streamxhub/streamx/common/util/HadoopUtils.scala
+++ b/streamx-common/src/main/scala/com/streamxhub/streamx/common/util/HadoopUtils.scala
@@ -206,6 +206,7 @@ object HadoopUtils extends Logger {
     Try {
       UserGroupInformation.setConfiguration(hadoopConf)
       val ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, keytab)
+      UserGroupInformation.setLoginUser(ugi)
       logInfo("kerberos authentication successful")
       ugi
     }.recover { case e => throw e }


### PR DESCRIPTION
通过配置的kerberos去login
UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, keytab)
但是没有去setLoginUser，会导致后面getLoginUser出错，识别成系统用户。
还会导致tgtRefreshTime识别为0导致Non-positive period
