### PR TITLE
[Improve] Improved Flink SQL syntax validation to accurately display error locations

### DIFF
--- a/streamx-console/streamx-console-service/pom.xml
+++ b/streamx-console/streamx-console-service/pom.xml
@@ -377,19 +377,6 @@
             <version>2.5.0</version>
         </dependency>
 
-        <!--flink-->
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-common</artifactId>
-            <version>${flink.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.flink</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <dependency>
             <groupId>com.streamxhub.streamx</groupId>
             <artifactId>streamx-common_${scala.binary.version}</artifactId>

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/FlinkSqlController.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/FlinkSqlController.java
@@ -68,12 +68,11 @@ public class FlinkSqlController {
                 .put("type", flinkSqlValidationResult.failedType().getValue())
                 .put("start", flinkSqlValidationResult.lineStart())
                 .put("end", flinkSqlValidationResult.lineEnd());
-            //语法异常
-            if (flinkSqlValidationResult.failedType().equals(FlinkSqlValidationFailedType.SYNTAX_ERROR)) {
-                //记录第几行出错.
+
+            if (flinkSqlValidationResult.errorLine() > 0) {
                 response
-                    .put("line", flinkSqlValidationResult.errorLine())
-                    .put("column ", flinkSqlValidationResult.errorColumn());
+                    .put("start", flinkSqlValidationResult.errorLine())
+                    .put("end", flinkSqlValidationResult.errorLine() + 1);
             }
             return response;
         } else {

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/FlinkSqlController.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/FlinkSqlController.java
@@ -19,7 +19,6 @@
 
 package com.streamxhub.streamx.console.core.controller;
 
-import com.streamxhub.streamx.common.enums.FlinkSqlValidationFailedType;
 import com.streamxhub.streamx.console.base.domain.RestResponse;
 import com.streamxhub.streamx.console.base.exception.ServiceException;
 import com.streamxhub.streamx.console.core.entity.Application;

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/FlinkSqlController.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/FlinkSqlController.java
@@ -66,14 +66,14 @@ public class FlinkSqlController {
                 .data(false)
                 .message(exception)
                 .put("type", flinkSqlValidationResult.failedType().getValue())
-                .put("start", flinkSqlValidationResult.errorLineStart())
-                .put("end", flinkSqlValidationResult.errorLineEnd());
+                .put("start", flinkSqlValidationResult.lineStart())
+                .put("end", flinkSqlValidationResult.lineEnd());
             //语法异常
             if (flinkSqlValidationResult.failedType().equals(FlinkSqlValidationFailedType.SYNTAX_ERROR)) {
                 //记录第几行出错.
                 response
-                    .put("line", flinkSqlValidationResult.errorLineStart())
-                    .put("column ", flinkSqlValidationResult.errorLineEnd());
+                    .put("line", flinkSqlValidationResult.errorLine())
+                    .put("column ", flinkSqlValidationResult.errorColumn());
             }
             return response;
         } else {

--- a/streamx-console/streamx-console-webapp/src/views/flink/app/Add.vue
+++ b/streamx-console/streamx-console-webapp/src/views/flink/app/Add.vue
@@ -1672,8 +1672,6 @@
           flinkSql: {
             defaultValue: '',
             value: null,
-            errorLine: null,
-            errorColumn: null,
             errorMsg: null,
             errorStart: null,
             errorEnd: null,

--- a/streamx-console/streamx-console-webapp/src/views/flink/app/AddEdit.js
+++ b/streamx-console/streamx-console-webapp/src/views/flink/app/AddEdit.js
@@ -194,7 +194,7 @@ export function syntaxError(vue) {
                     break
                 }
             }
-            //清空
+
             monaco.editor.setModelMarkers(model, 'sql', [{
                     startLineNumber: startLineNumber,
                     endLineNumber: endLineNumber + 1,

--- a/streamx-console/streamx-console-webapp/src/views/flink/app/AddEdit.js
+++ b/streamx-console/streamx-console-webapp/src/views/flink/app/AddEdit.js
@@ -69,7 +69,7 @@ export function initFlinkSqlEditor(vue) {
     controller.flinkSql.value = arguments[1] || controller.flinkSql.defaultValue
     const option = Object.assign({}, globalOption(vue))
     option.value = controller.flinkSql.value
-    option.minimap = {enabled: false}
+    option.minimap = {enabled: true}
     controller.editor.flinkSql = monaco.editor.create(document.querySelector('#flink-sql'), option)
     //输入事件触发...
     controller.editor.flinkSql.onDidChangeModelContent(() => {
@@ -149,10 +149,8 @@ export function verifySQL(vue) {
                 syntaxError(vue)
             } else {
                 controller.flinkSql.success = false
-                controller.flinkSql.errorLine = resp.line
-                controller.flinkSql.errorColumn = resp.column
-                controller.flinkSql.errorStart = resp.start
-                controller.flinkSql.errorEnd = resp.end
+                controller.flinkSql.errorStart = parseInt(resp.start)
+                controller.flinkSql.errorEnd = parseInt(resp.end)
                 switch (resp.type) {
                     case 4:
                         controller.flinkSql.errorMsg = 'Unsupported sql'
@@ -183,25 +181,13 @@ export function syntaxError(vue) {
     monaco.editor.setModelMarkers(model, 'sql', [])
     if (!controller.flinkSql.success) {
         try {
-            const startFind = model.findMatches(controller.flinkSql.errorStart)
-            const endFind = model.findMatches(controller.flinkSql.errorEnd)
-            const startLineNumber = startFind[0].range.startLineNumber
-            let endLineNumber = startLineNumber
-            for (let i = 0; i < endFind.length; i++) {
-                const find = endFind[i]
-                if (find.range.endLineNumber >= startLineNumber) {
-                    endLineNumber = find.range.endLineNumber
-                    break
-                }
-            }
-
-            monaco.editor.setModelMarkers(model, 'sql', [{
-                    startLineNumber: startLineNumber,
-                    endLineNumber: endLineNumber + 1,
-                    severity: monaco.MarkerSeverity.Error,
-                    message: controller.flinkSql.errorMsg
-                }]
-            )
+          monaco.editor.setModelMarkers(model, 'sql', [{
+              startLineNumber: controller.flinkSql.errorStart,
+              endLineNumber: controller.flinkSql.errorEnd,
+              severity: monaco.MarkerSeverity.Error,
+              message: controller.flinkSql.errorMsg
+            }]
+          )
         } catch (e) {
         }
     }

--- a/streamx-console/streamx-console-webapp/src/views/flink/app/EditStreamX.vue
+++ b/streamx-console/streamx-console-webapp/src/views/flink/app/EditStreamX.vue
@@ -133,7 +133,7 @@
           </a-input>
         </a-form-item>
 
-        <a-form-item 
+        <a-form-item
           v-if="app.executionMode === 6 || executionMode === 6"
           label="Kubernetes ClusterId"
           :label-col="{lg: {span: 5}, sm: {span: 7}}"
@@ -156,7 +156,7 @@
           </a-input>
         </a-form-item>
 
-        <a-form-item 
+        <a-form-item
           v-if="app.executionMode === 5 || executionMode === 5"
           label="Kubernetes ClusterId"
           :label-col="{lg: {span: 5}, sm: {span: 7}}"
@@ -1782,8 +1782,6 @@ export default {
         },
         flinkSql: {
           value: null,
-          errorLine: null,
-          errorColumn: null,
           errorMsg: null,
           errorStart: null,
           errorEnd: null,

--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/FlinkSqlValidator.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/FlinkSqlValidator.scala
@@ -28,7 +28,7 @@ import org.apache.flink.sql.parser.validate.FlinkSqlConformance
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api.SqlDialect.{DEFAULT, HIVE}
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
-import org.apache.flink.table.api.{EnvironmentSettings, SqlParserException, ValidationException}
+import org.apache.flink.table.api.EnvironmentSettings
 import org.apache.flink.table.planner.delegation.FlinkSqlParserFactories
 import org.apache.flink.table.planner.utils.TableConfigUtils
 
@@ -81,8 +81,8 @@ object FlinkSqlValidator extends Logger {
                 failedType = FlinkSqlValidationFailedType.VERIFY_FAILED,
                 lineStart = call.lineStart,
                 lineEnd = call.lineEnd,
-                exception = s"$args is not a valid table/sql config",
-                sql = sql.replaceFirst(";|$", ";")
+                sql = sql.replaceFirst(";|$", ";"),
+                exception = s"$args is not a valid table/sql config"
               )
             }
           }
@@ -116,8 +116,8 @@ object FlinkSqlValidator extends Logger {
                   lineEnd = call.lineEnd,
                   errorLine = if (call.lineStart > 1) call.lineStart + line.toInt else line.toInt,
                   errorColumn = column.toInt,
-                  exception = causedBy,
-                  sql = call.originSql
+                  sql = call.originSql,
+                  exception = causedBy
                 )
               } else {
                 return FlinkSqlValidationResult(
@@ -125,8 +125,8 @@ object FlinkSqlValidator extends Logger {
                   failedType = FlinkSqlValidationFailedType.SYNTAX_ERROR,
                   lineStart = call.lineStart,
                   lineEnd = call.lineEnd,
-                  exception = causedBy,
-                  sql = call.originSql
+                  sql = call.originSql,
+                  exception = causedBy
                 )
               }
             case _ =>

--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/SqlCommandParser.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/SqlCommandParser.scala
@@ -21,7 +21,6 @@ package com.streamxhub.streamx.flink.core
 import com.streamxhub.streamx.common.enums.FlinkSqlValidationFailedType
 import com.streamxhub.streamx.common.util.{Logger, SqlSplitter}
 import enumeratum.EnumEntry
-import org.apache.flink.table.api.ValidationException
 
 import java.util.regex.{Matcher, Pattern}
 import java.lang.{Boolean => JavaBool}
@@ -40,9 +39,9 @@ object SqlCommandParser extends Logger {
         if (validationCallback != null) {
           validationCallback(
             FlinkSqlValidationResult(
-              false,
-              FlinkSqlValidationFailedType.VERIFY_FAILED,
-              sqlEmptyError
+              success = false,
+              failedType = FlinkSqlValidationFailedType.VERIFY_FAILED,
+              exception = sqlEmptyError
             )
           )
           null
@@ -58,11 +57,11 @@ object SqlCommandParser extends Logger {
               if (validationCallback != null) {
                 validationCallback(
                   FlinkSqlValidationResult(
-                    false,
-                    FlinkSqlValidationFailedType.UNSUPPORTED_SQL,
-                    s"unsupported sql",
-                    stmt._1,
-                    stmt._2,
+                    success = false,
+                    failedType = FlinkSqlValidationFailedType.UNSUPPORTED_SQL,
+                    lineStart = stmt._1,
+                    lineEnd = stmt._2,
+                    exception = s"unsupported sql",
                     sql = stmt._3
                   )
                 )
@@ -77,9 +76,9 @@ object SqlCommandParser extends Logger {
             if (validationCallback != null) {
               validationCallback(
                 FlinkSqlValidationResult(
-                  false,
-                  FlinkSqlValidationFailedType.VERIFY_FAILED,
-                  "flink sql syntax error, no executable sql"
+                  success = false,
+                  failedType = FlinkSqlValidationFailedType.VERIFY_FAILED,
+                  exception = "flink sql syntax error, no executable sql"
                 )
               )
               null
@@ -415,7 +414,10 @@ case class SqlCommandCall(lineStart: Int,
 
 case class FlinkSqlValidationResult(success: JavaBool = true,
                                     failedType: FlinkSqlValidationFailedType = null,
-                                    exception: String = null,
-                                    errorLineStart: Int = 0,
-                                    errorLineEnd: Int = 0,
-                                    sql: String = null)
+                                    lineStart: Int = 0,
+                                    lineEnd: Int = 0,
+                                    errorLine: Int = 0,
+                                    errorColumn: Int = 0,
+                                    sql: String = null,
+                                    exception: String = null
+                                   )

--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.12/src/main/scala/com/streamxhub/streamx/flink/core/TableExt.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.12/src/main/scala/com/streamxhub/streamx/flink/core/TableExt.scala
@@ -57,5 +57,4 @@ object TableExt {
 
   }
 
-
 }


### PR DESCRIPTION
The current flinksql verification function is relatively simple, especially the front-end displays the statement error location information, and does not clearly indicate the line where the specific error is located, which brings a lot of inconvenience to the development and inspection of the task. This part can be improved to accurately display the error line number

### What problem does this PR solve?

Issue Number: close #1146

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/streamxhub/streamx/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
