### PR TITLE
fix:[Bug] When streamx stops a task, start savepoint, but the savepoi…

### DIFF
--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/ApplicationController.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/ApplicationController.java
@@ -42,6 +42,7 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
@@ -303,6 +304,17 @@ public class ApplicationController {
             restResponse.data(false).message(error);
         }
         return restResponse;
+    }
+
+    @PostMapping("checkSavepointPath")
+    public RestResponse checkSavepointPath(Application app) throws Exception {
+        String error = applicationService.checkSavepointPath(app);
+
+        if (StringUtils.isBlank(error)) {
+            return RestResponse.create().data(true);
+        } else {
+            return RestResponse.create().data(false).message(error);
+        }
     }
 
 }

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/ApplicationService.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/ApplicationService.java
@@ -53,6 +53,8 @@ public interface ApplicationService extends IService<Application> {
 
     AppExistsState checkExists(Application app);
 
+    String checkSavepointPath(Application app) throws Exception;
+
     void cancel(Application app) throws Exception;
 
     void updateTracking(Application application);

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ApplicationServiceImpl.java
@@ -1040,6 +1040,59 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
     }
 
     @Override
+    @RefreshCache
+    public String checkSavepointPath(Application appParam) throws Exception {
+        Application application = getById(appParam.getId());
+
+        String savepointPath = FlinkSubmitter
+            .extractDynamicOptionAsJava(application.getDynamicOptions())
+            .get(ConfigConst.KEY_FLINK_STATE_SAVEPOINTS_DIR().substring(6));
+
+        if (StringUtils.isBlank(savepointPath)) {
+            if (ExecutionMode.isRemoteMode(application.getExecutionMode())) {
+                FlinkCluster cluster = flinkClusterService.getById(application.getFlinkClusterId());
+                assert cluster != null;
+                Map<String, String> config = cluster.getFlinkConfig();
+                if (!config.isEmpty()) {
+                    savepointPath = config.get(ConfigConst.KEY_FLINK_STATE_SAVEPOINTS_DIR().substring(6));
+                }
+            } else if (application.isStreamXJob() || application.isFlinkSqlJob()) {
+                ApplicationConfig applicationConfig = configService.getEffective(application.getId());
+                if (applicationConfig != null) {
+                    Map<String, String> map = applicationConfig.readConfig();
+                    boolean checkpointEnable = Boolean.parseBoolean(map.get(ConfigConst.KEY_FLINK_CHECKPOINTS_ENABLE()));
+                    if (checkpointEnable) {
+                        savepointPath = map.get(ConfigConst.KEY_FLINK_STATE_SAVEPOINTS_DIR());
+                    }
+                }
+            } else if (ExecutionMode.isYarnMode(application.getExecutionMode())) {
+                FlinkEnv flinkEnv = flinkEnvService.getById(application.getVersionId());
+                savepointPath = flinkEnv.convertFlinkYamlAsMap().get(ConfigConst.KEY_FLINK_STATE_SAVEPOINTS_DIR().substring(6));
+            }
+        }
+
+        if (StringUtils.isNotBlank(savepointPath)) {
+            final URI uri = URI.create(savepointPath);
+            final String scheme = uri.getScheme();
+            final String pathPart = uri.getPath();
+
+            String error = "";
+
+            if (scheme == null) {
+                error = "This state.savepoints.dir value "+ savepointPath + " scheme (hdfs://, file://, etc) of  is null. Please specify the file system scheme explicitly in the URI.";
+            } else if (pathPart == null) {
+                error = "This state.savepoints.dir value "+ savepointPath + " path part to store the checkpoint data in is null. Please specify a directory path for the checkpoint data.";
+            } else if (pathPart.length() == 0 || pathPart.equals("/")) {
+                error = "This state.savepoints.dir value "+ savepointPath + " Cannot use the root directory for checkpoints.";
+            }
+
+            return error;
+        } else {
+            return "When custom savepoint is not set, state.savepoints.dir needs to be set in Dynamic Option or flick-conf.yaml of application";
+        }
+    }
+
+    @Override
     public void updateTracking(Application appParam) {
         this.baseMapper.updateTracking(appParam);
     }

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ApplicationServiceImpl.java
@@ -1079,11 +1079,11 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             String error = "";
 
             if (scheme == null) {
-                error = "This state.savepoints.dir value "+ savepointPath + " scheme (hdfs://, file://, etc) of  is null. Please specify the file system scheme explicitly in the URI.";
+                error = "This state.savepoints.dir value " + savepointPath + " scheme (hdfs://, file://, etc) of  is null. Please specify the file system scheme explicitly in the URI.";
             } else if (pathPart == null) {
-                error = "This state.savepoints.dir value "+ savepointPath + " path part to store the checkpoint data in is null. Please specify a directory path for the checkpoint data.";
+                error = "This state.savepoints.dir value " + savepointPath + " path part to store the checkpoint data in is null. Please specify a directory path for the checkpoint data.";
             } else if (pathPart.length() == 0 || pathPart.equals("/")) {
-                error = "This state.savepoints.dir value "+ savepointPath + " Cannot use the root directory for checkpoints.";
+                error = "This state.savepoints.dir value " + savepointPath + " Cannot use the root directory for checkpoints.";
             }
 
             return error;

--- a/streamx-console/streamx-console-webapp/src/api/application.js
+++ b/streamx-console/streamx-console-webapp/src/api/application.js
@@ -124,3 +124,7 @@ export function checkJar(params) {
 export function verifySchema(params) {
   return http.post(api.Application.VERIFY_SCHEMA, params)
 }
+
+export function checkSavepointPath (params) {
+  return http.post(api.Application.CHECK_SAVEPOINT_PATH, params)
+}

--- a/streamx-console/streamx-console-webapp/src/api/index.js
+++ b/streamx-console/streamx-console-webapp/src/api/index.js
@@ -84,7 +84,8 @@ export default {
     OPTION_LOG: '/flink/app/optionlog',
     DOWN_LOG: '/flink/app/downlog',
     CHECK_JAR: '/flink/app/checkjar',
-    VERIFY_SCHEMA: '/flink/app/verifySchema'
+    VERIFY_SCHEMA: '/flink/app/verifySchema',
+    CHECK_SAVEPOINT_PATH: '/flink/app/checkSavepointPath'
   },
   Config: {
     GET: '/flink/conf/get',

--- a/streamx-console/streamx-console-webapp/src/views/flink/app/View.vue
+++ b/streamx-console/streamx-console-webapp/src/views/flink/app/View.vue
@@ -1075,6 +1075,7 @@ import {history, latest} from '@api/savepoint'
 import {flamegraph} from '@api/metrics'
 import {weburl} from '@api/setting'
 import {build, detail as buildDetail} from '@/api/appBuild'
+import {checkSavepointPath} from '@api/application'
 import {activeURL} from '@/api/flinkCluster'
 import {Terminal} from 'xterm'
 import 'xterm/css/xterm.css'
@@ -1722,9 +1723,20 @@ export default {
           }
         })
       } else {
-        this.handleStopAction(stopReq)
+        checkSavepointPath({
+            'id': this.application.id
+        }).then((resp) => {
+          if (resp.data === true) {
+            this.handleStopAction(stopReq)
+          } else {
+            this.$swal.fire(
+                'Failed',
+                resp.message,
+                'error'
+            )
+          }
+        })
       }
-
     },
 
     handleStopAction(stopReq) {


### PR DESCRIPTION
…nt path is not required

<!--

Thank you for contributing to StreamX! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [Bug](https://github.com/streamxhub/streamx/issues/1144) <!-- REMOVE this line if not applicable -->


Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/streamxhub/streamx/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
This pull request fix "[Bug] When streamx stops a task, start savepoint, but the savepoint path is not required"