### PR TITLE
[Feature]Add streamx to get k8s' deployment logging capabilities

### DIFF
--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/base/util/MoreFutures.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/base/util/MoreFutures.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2019 The StreamX Project
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.streamxhub.streamx.console.base.util;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class MoreFutures {
+    private MoreFutures() {
+    }
+
+    public static <T> T await(CompletionStage<T> stage) {
+        CompletableFuture<T> future = stage.toCompletableFuture();
+
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    public static <T> T deref(CompletionStage<T> stage, long timeout, TimeUnit unit) {
+        CompletableFuture<T> future = stage.toCompletableFuture();
+
+        try {
+            return future.get(timeout, unit);
+        } catch (TimeoutException | InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    public static <T> T derefUsingDefaultTimeout(CompletionStage<T> stage) {
+        return deref(stage, 5L, TimeUnit.SECONDS);
+    }
+
+    public static <T> CompletionStage<T> exceptionallyCompose(CompletionStage<T> stage, Function<Throwable, ? extends CompletionStage<T>> fn) {
+        return stage.thenApply((res) -> {
+            return CompletableFuture.completedFuture(res);
+        }).exceptionally((Function<Throwable, ? extends CompletableFuture<T>>) fn).thenCompose(Function.identity());
+    }
+
+    public static <T> CompletableFuture<T> completeImmediately(Supplier<T> supplier) {
+        try {
+            return CompletableFuture.completedFuture(supplier.get());
+        } catch (Throwable e) {
+            CompletableFuture<T> f = new CompletableFuture();
+            f.completeExceptionally(e);
+            return f;
+        }
+    }
+
+    public static <T> CompletableFuture<T> completedExceptionally(Throwable cause) {
+        CompletableFuture<T> future = new CompletableFuture();
+        future.completeExceptionally(cause);
+        return future;
+    }
+
+    public static <T> ScheduledFuture<T> completedScheduledFuture(T value) {
+        return new CompletedScheduledFuture(value);
+    }
+
+    private static final class CompletedScheduledFuture<T> implements ScheduledFuture<T> {
+        private final T value;
+
+        private CompletedScheduledFuture(T value) {
+            this.value = value;
+        }
+
+        public long getDelay(TimeUnit unit) {
+            return 0L;
+        }
+
+        public int compareTo(Delayed o) {
+            return Long.compare(0L, o.getDelay(TimeUnit.MILLISECONDS));
+        }
+
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return false;
+        }
+
+        public boolean isCancelled() {
+            return false;
+        }
+
+        public boolean isDone() {
+            return true;
+        }
+
+        public T get() throws InterruptedException, ExecutionException {
+            return this.value;
+        }
+
+        public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return this.value;
+        }
+    }
+}

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/ApplicationController.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/ApplicationController.java
@@ -52,7 +52,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import springfox.documentation.annotations.ApiIgnore;
@@ -333,17 +332,5 @@ public class ApplicationController {
                                @ApiParam("Number of log lines skipped loading") @RequestParam(value = "skipLineNum", required = false) Integer skipLineNum,
                                @ApiParam("Number of log lines loaded at once") @RequestParam(value = "limit", required = false) Integer limit) {
         return RestResponse.success(MoreFutures.derefUsingDefaultTimeout(loggerService.queryLog(namespac, jobName, skipLineNum, limit)));
-    }
-
-    /**
-     * download log file
-     *
-     * @return log file content
-     */
-    @PostMapping(value = "/download")
-    @ResponseBody
-    public RestResponse downloadTaskLog(Application app) {
-        byte[] logBytes = loggerService.getLogBytes(app);
-        return RestResponse.success(logBytes);
     }
 }

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/ApplicationController.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/ApplicationController.java
@@ -26,6 +26,7 @@ import com.streamxhub.streamx.console.base.domain.RestRequest;
 import com.streamxhub.streamx.console.base.domain.RestResponse;
 import com.streamxhub.streamx.console.base.exception.ApplicationException;
 import com.streamxhub.streamx.console.base.exception.InternalException;
+import com.streamxhub.streamx.console.base.util.MoreFutures;
 import com.streamxhub.streamx.console.core.annotation.ApiAccess;
 import com.streamxhub.streamx.console.core.entity.AppControl;
 import com.streamxhub.streamx.console.core.entity.Application;
@@ -36,18 +37,22 @@ import com.streamxhub.streamx.console.core.service.AppBuildPipeService;
 import com.streamxhub.streamx.console.core.service.ApplicationBackUpService;
 import com.streamxhub.streamx.console.core.service.ApplicationLogService;
 import com.streamxhub.streamx.console.core.service.ApplicationService;
+import com.streamxhub.streamx.console.core.service.impl.LoggerServiceImpl;
 import com.streamxhub.streamx.flink.packer.pipeline.PipelineStatus;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import springfox.documentation.annotations.ApiIgnore;
@@ -81,6 +86,8 @@ public class ApplicationController {
     @Autowired
     private AppBuildPipeService appBuildPipeService;
 
+    @Autowired
+    private LoggerServiceImpl loggerService;
     @ApiAccess
     @PostMapping("get")
     @RequiresPermissions("app:detail")
@@ -319,4 +326,24 @@ public class ApplicationController {
         }
     }
 
+    @ApiOperation(value = "APP detail")
+    @PostMapping(value = "/detail")
+    public RestResponse detail(@ApiParam("K8s name spaces") @RequestParam(value = "namespac", required = false) String namespac,
+                               @ApiParam("Job name") @RequestParam(value = "jobName", required = false) String jobName,
+                               @ApiParam("Number of log lines skipped loading") @RequestParam(value = "skipLineNum", required = false) Integer skipLineNum,
+                               @ApiParam("Number of log lines loaded at once") @RequestParam(value = "limit", required = false) Integer limit) {
+        return RestResponse.success(MoreFutures.derefUsingDefaultTimeout(loggerService.queryLog(namespac, jobName, skipLineNum, limit)));
+    }
+
+    /**
+     * download log file
+     *
+     * @return log file content
+     */
+    @PostMapping(value = "/download")
+    @ResponseBody
+    public RestResponse downloadTaskLog(Application app) {
+        byte[] logBytes = loggerService.getLogBytes(app);
+        return RestResponse.success(logBytes);
+    }
 }

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/log/LogClientService.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/log/LogClientService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019 The StreamX Project
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.streamxhub.streamx.console.core.log;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** log client */
+@Slf4j
+public class LogClientService {
+    public String rollViewLog(String path, int skipLineNum, int limit){
+        String result = "";
+        try {
+            List<String> lines = readPartFileContent(path, skipLineNum, limit);
+            StringBuilder builder = new StringBuilder();
+            lines.forEach(line -> builder.append(line).append("\r\n"));
+            return builder.toString();
+        } catch (Exception e) {
+            log.error("roll view log error", e);
+        }
+        return result;
+    }
+
+    /**
+     * read part file content，can skip any line and read some lines
+     *
+     * @param filePath file path
+     * @param skipLine skip line
+     * @param limit read lines limit
+     * @return part file content
+     */
+    private List<String> readPartFileContent(String filePath,
+                                             int skipLine,
+                                             int limit){
+        File file = new File(filePath);
+        if (file.exists() && file.isFile()) {
+            try (Stream<String> stream = Files.lines(Paths.get(filePath))) {
+                return stream.skip(skipLine).limit(limit).collect(Collectors.toList());
+            } catch (IOException e) {
+                log.error("read file error", e);
+            }
+        } else {
+            log.info("file path: {} not exists", filePath);
+        }
+        return Collections.emptyList();
+    }
+}

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/LoggerServiceImpl.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/LoggerServiceImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019 The StreamX Project
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.streamxhub.streamx.console.core.service.impl;
+
+import com.streamxhub.streamx.console.core.entity.Application;
+import com.streamxhub.streamx.console.core.log.LogClientService;
+import com.streamxhub.streamx.console.core.service.ApplicationService;
+import com.streamxhub.streamx.flink.kubernetes.watch.FlinkJobWatch;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * log service
+ */
+@Service
+@Slf4j
+public class LoggerServiceImpl {
+    @Autowired
+    private ApplicationService applicationService;
+
+    private final LogClientService logClient;
+
+    public LoggerServiceImpl(){
+        logClient = new LogClientService();
+    }
+
+    /**
+     * view log
+     *
+     * @param skipLineNum skip line number
+     * @param limit       limit
+     * @return log string data
+     */
+    public CompletionStage<String> queryLog(String namespac,String jobName, int skipLineNum, int limit) {
+        return CompletableFuture.supplyAsync(() ->
+            FlinkJobWatch.jobDeploymentsWatch(namespac, jobName)
+        ).thenApply(path -> logClient.rollViewLog(String.valueOf(path), skipLineNum, limit));
+    }
+
+    public byte[] getLogBytes(Application app) {
+        return null;
+    }
+}

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/LoggerServiceImpl.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/LoggerServiceImpl.java
@@ -53,7 +53,7 @@ public class LoggerServiceImpl {
      * @param limit       limit
      * @return log string data
      */
-    public CompletionStage<String> queryLog(String namespac,String jobName, int skipLineNum, int limit) {
+    public CompletionStage<String> queryLog(String namespac, String jobName, int skipLineNum, int limit) {
         return CompletableFuture.supplyAsync(() ->
             FlinkJobWatch.jobDeploymentsWatch(namespac, jobName)
         ).thenApply(path -> logClient.rollViewLog(String.valueOf(path), skipLineNum, limit));

--- a/streamx-plugin/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/watch/FlinkJobWatch.java
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/watch/FlinkJobWatch.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 The StreamX Project
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.streamxhub.streamx.flink.kubernetes.watch;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.io.File;
+import java.io.IOException;
+
+public class FlinkJobWatch {
+
+    public static String jobDeploymentsWatch(String nameSpace, String jobName){
+        try (KubernetesClient client = new DefaultKubernetesClient()){
+            String log = client.apps().deployments()
+                .inNamespace(nameSpace)
+                .withName(jobName).getLog();
+
+            File dir = new File("");
+            String projectPath = dir.getCanonicalPath();
+
+            String path = projectPath + "/" + nameSpace + "_" + jobName + ".log";
+            File file = new File(path);
+            Files.asCharSink(file, Charsets.UTF_8).write(log);
+            return path;
+        } catch (IOException e) {
+            return null;
+        }
+
+    }
+}


### PR DESCRIPTION
Problem solving:
streamx deploys flink on k8s deployments, during which deployment detail logs are not available