### PR TITLE
[Bug] deploy/docker/docker-compose.yaml should use replicas replace scale.

### DIFF
--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -58,19 +58,22 @@ services:
     environment:
       - |
         FLINK_PROPERTIES=
-        jobmanager.rpc.address: jobmanager        
+        jobmanager.rpc.address: jobmanager
+    restart: unless-stopped
 
   taskmanager:
     image: flink:1.14.5-scala_2.12
     depends_on:
       - jobmanager
     command: taskmanager
-    scale: 1
+    deploy:
+      replicas: 1
     environment:
       - |
         FLINK_PROPERTIES=
         jobmanager.rpc.address: jobmanager
-        taskmanager.numberOfTaskSlots: 2
+        taskmanager.numberOfTaskSlots: 10
+    restart: unless-stopped
 
 volumes:
   mysql-data:


### PR DESCRIPTION
Issue Number: close #1323 

Problem Summary: deploy/docker/docker-compose.yaml should use replicas replace scale.because of `version: '3.8'`.