### PR TITLE
[Bug]Solve the problem of poor judgment of initialization status

### DIFF
--- a/streamx-plugin/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/K8sDeploymentRelated.java
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/K8sDeploymentRelated.java
@@ -42,4 +42,10 @@ public class K8sDeploymentRelated {
             return items.get(0).getStatus().getContainerStatuses().get(0).getLastState().getTerminated() != null;
         }
     }
+
+    public static void deleteTaskDeployment(String nameSpce, String deploymentName){
+        try (KubernetesClient client = new DefaultKubernetesClient()){
+            client.apps().deployments().inNamespace(nameSpce).withName(deploymentName).delete();
+        }
+    }
 }

--- a/streamx-plugin/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/K8sDeploymentRelated.java
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/K8sDeploymentRelated.java
@@ -63,4 +63,10 @@ public class K8sDeploymentRelated {
             return items.get(0).getStatus().getContainerStatuses().get(0).getRestartCount();
         }
     }
+
+    public static Boolean isTheK8sConnectionNormal(){
+        try (KubernetesClient client = new DefaultKubernetesClient()){
+            return client != null;
+        }
+    }
 }

--- a/streamx-plugin/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/K8sDeploymentRelated.java
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/K8sDeploymentRelated.java
@@ -48,4 +48,19 @@ public class K8sDeploymentRelated {
             client.apps().deployments().inNamespace(nameSpce).withName(deploymentName).delete();
         }
     }
+
+    public static Integer getTheNumberOfTaskDeploymentRetries(String nameSpce, String deploymentName){
+        try (KubernetesClient client = new DefaultKubernetesClient()){
+            Map<String, String> matchLabels = client.apps()
+                .deployments()
+                .inNamespace(nameSpce)
+                .withName(deploymentName)
+                .get()
+                .getSpec()
+                .getSelector()
+                .getMatchLabels();
+            List<Pod> items = client.pods().inNamespace(nameSpce).withLabels(matchLabels).list().getItems();
+            return items.get(0).getStatus().getContainerStatuses().get(0).getRestartCount();
+        }
+    }
 }

--- a/streamx-plugin/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/K8sDeploymentRelated.java
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/K8sDeploymentRelated.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 The StreamX Project
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.streamxhub.streamx.flink.kubernetes;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.util.List;
+import java.util.Map;
+
+public class K8sDeploymentRelated {
+
+    public static Boolean getDeploymentStatusChanges(String nameSpce, String deploymentName){
+        try (KubernetesClient client = new DefaultKubernetesClient()){
+            Map<String, String> matchLabels = client.apps()
+                .deployments()
+                .inNamespace(nameSpce)
+                .withName(deploymentName)
+                .get()
+                .getSpec()
+                .getSelector()
+                .getMatchLabels();
+            List<Pod> items = client.pods().inNamespace(nameSpce).withLabels(matchLabels).list().getItems();
+            return items.get(0).getStatus().getContainerStatuses().get(0).getLastState().getTerminated() != null;
+        }
+    }
+}

--- a/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
@@ -24,7 +24,7 @@ import com.streamxhub.streamx.flink.kubernetes.enums.FlinkJobState
 import com.streamxhub.streamx.flink.kubernetes.enums.FlinkK8sExecuteMode.{APPLICATION, SESSION}
 import com.streamxhub.streamx.flink.kubernetes.event.FlinkJobStatusChangeEvent
 import com.streamxhub.streamx.flink.kubernetes.model._
-import com.streamxhub.streamx.flink.kubernetes.{ChangeEventBus, FlinkTrackController, JobStatusWatcherConfig, KubernetesRetriever}
+import com.streamxhub.streamx.flink.kubernetes.{ChangeEventBus, FlinkTrackController, JobStatusWatcherConfig, K8sDeploymentRelated, KubernetesRetriever}
 import io.fabric8.kubernetes.client.Watcher.Action
 import org.apache.hc.client5.http.fluent.Request
 import org.apache.hc.core5.util.Timeout
@@ -256,7 +256,8 @@ class FlinkJobStatusWatcher(conf: JobStatusWatcherConfig = JobStatusWatcherConfi
       if (trackController.canceling.has(trackId)) FlinkJobState.CANCELED else {
         // whether deployment exists on kubernetes cluster
         val isDeployExists = KubernetesRetriever.isDeploymentExists(trackId.clusterId, trackId.namespace)
-        if (isDeployExists) {
+        val DeployStateOfTheError = K8sDeploymentRelated.getDeploymentStatusChanges(trackId.namespace, trackId.clusterId)
+        if (isDeployExists && !DeployStateOfTheError) {
           FlinkJobState.K8S_INITIALIZING
         } else {
           val deployEvent = trackController.k8sDeploymentEvents.get(K8sEventKey(trackId.namespace, trackId.clusterId))

--- a/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
@@ -258,10 +258,11 @@ class FlinkJobStatusWatcher(conf: JobStatusWatcherConfig = JobStatusWatcherConfi
         val isDeployExists = KubernetesRetriever.isDeploymentExists(trackId.clusterId, trackId.namespace)
         val deployStateOfTheError = K8sDeploymentRelated.getDeploymentStatusChanges(trackId.namespace, trackId.clusterId)
         val numRetries = K8sDeploymentRelated.getTheNumberOfTaskDeploymentRetries(trackId.namespace, trackId.clusterId)
+        val isConnection = K8sDeploymentRelated.isTheK8sConnectionNormal()
         if (isDeployExists && !deployStateOfTheError) {
           FlinkJobState.K8S_INITIALIZING
         }
-        else if (deployStateOfTheError && numRetries > 3) {
+        else if (deployStateOfTheError && isConnection) {
           K8sDeploymentRelated.deleteTaskDeployment(trackId.namespace, trackId.clusterId)
           FlinkJobState.FAILED
         } else {

--- a/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
+++ b/streamx-plugin/streamx-flink-kubernetes/src/main/scala/com/streamxhub/streamx/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
@@ -25,7 +25,6 @@ import com.streamxhub.streamx.flink.kubernetes.enums.FlinkK8sExecuteMode.{APPLIC
 import com.streamxhub.streamx.flink.kubernetes.event.FlinkJobStatusChangeEvent
 import com.streamxhub.streamx.flink.kubernetes.model._
 import com.streamxhub.streamx.flink.kubernetes.{ChangeEventBus, FlinkTrackController, JobStatusWatcherConfig, K8sDeploymentRelated, KubernetesRetriever}
-import io.fabric8.kubernetes.client.Watcher.Action
 import org.apache.hc.client5.http.fluent.Request
 import org.apache.hc.core5.util.Timeout
 import org.json4s.{DefaultFormats, JNothing, JNull}
@@ -36,7 +35,6 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.{Executors, ScheduledFuture, TimeUnit}
 import javax.annotation.Nonnull
 import javax.annotation.concurrent.ThreadSafe
-import scala.collection.JavaConversions._
 import scala.concurrent.duration.DurationLong
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.language.{implicitConversions, postfixOps}
@@ -257,7 +255,6 @@ class FlinkJobStatusWatcher(conf: JobStatusWatcherConfig = JobStatusWatcherConfi
         // whether deployment exists on kubernetes cluster
         val isDeployExists = KubernetesRetriever.isDeploymentExists(trackId.clusterId, trackId.namespace)
         val deployStateOfTheError = K8sDeploymentRelated.getDeploymentStatusChanges(trackId.namespace, trackId.clusterId)
-        val numRetries = K8sDeploymentRelated.getTheNumberOfTaskDeploymentRetries(trackId.namespace, trackId.clusterId)
         val isConnection = K8sDeploymentRelated.isTheK8sConnectionNormal()
         if (isDeployExists && !deployStateOfTheError) {
           FlinkJobState.K8S_INITIALIZING


### PR DESCRIPTION
Solve the problem：
During on k8s mode usage, when a task is submitted to k8s and the task fails to run/task fails to initialize, the status change on the streamx page remains in the initialized state.