### PR TITLE
flink from docker not from download

### DIFF
--- a/deploy/docker/compose/Dockerfile
+++ b/deploy/docker/compose/Dockerfile
@@ -43,11 +43,6 @@ RUN wget "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.t
     && rm "node-v$NODE_VERSION-linux-x64.tar.gz" \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-RUN wget "https://mirrors.cloud.tencent.com/apache/flink/flink-$FLINK_VERSION/flink-$FLINK_VERSION-bin-$SCALA_VERSION.tgz" \
-    && mkdir ./flink \
-    && tar zxvf "flink-$FLINK_VERSION-bin-$SCALA_VERSION.tgz" -C ./flink --strip-components=1 \
-    && rm "flink-$FLINK_VERSION-bin-$SCALA_VERSION.tgz"
-
 RUN echo Y|apt-get update \
     && echo Y|apt-get install iputils-ping \
     && echo Y|apt-get install vim \

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
     depends_on:
       - database
     volumes:
-      - flink:/streamx/flink/flink1.14.5
+      - flink1.14.5:/streamx/flink/flink1.14.5
     restart: unless-stopped
 
   database:
@@ -58,7 +58,7 @@ services:
       - "8081:8081"
     command: jobmanager
     volumes:
-      - flink:/opt/flink
+      - flink1.14.5:/opt/flink
     environment:
       - |
         FLINK_PROPERTIES=
@@ -81,4 +81,4 @@ services:
 
 volumes:
   mysql-data:
-  flink:
+  flink1.14.5:

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -27,6 +27,8 @@ services:
       - 10000:10000
     depends_on:
       - database
+    volumes:
+      - flink:/streamx/flink/flink1.14.5
     restart: unless-stopped
 
   database:
@@ -55,6 +57,8 @@ services:
     ports:
       - "8081:8081"
     command: jobmanager
+    volumes:
+      - flink:/opt/flink
     environment:
       - |
         FLINK_PROPERTIES=
@@ -77,3 +81,4 @@ services:
 
 volumes:
   mysql-data:
+  flink:


### PR DESCRIPTION
example of multi version support

```
  streamx-server:
    build:
      context: ../..
      dockerfile: deploy/docker/compose/Dockerfile
      args:
        DB: database
    ports:
      - 10000:10000
    depends_on:
      - database
    volumes:
      - flink1.14.5:/streamx/flink/flink1.14.5           <- share volumes from flink1.14.5
      - flink1.13.6:/streamx/flink/flink1.13.6           <- share volumes from flink1.13.6
    restart: unless-stopped
```

```
// flink1.14.5
 jobmanager:
    image: flink:1.14.5-scala_2.12
    ports:
      - "8081:8081"
    command: jobmanager
    volumes:
      - flink1.14.5:/opt/flink    <- monut to volume flink1.14.5

// flink1.13.6
 jobmanager2:
    image: flink:1.13.6-scala_2.12
    ports:
      - "8081:8081"
    command: jobmanager
    volumes:
      - flink1.13.6:/opt/flink    <- monut to volume flink1.13.6
```

```
volumes:
  mysql-data:
  flink1.14.5:           <- volume from flink1.14.5 container
  flink1.13.6:           <- volume from flink1.13.6 container
```


Setting up Flink Home on StreamX Web Ui
```
/streamx/flink/{FLINK_DIR}
```
from ui
<img width="1892" alt="image" src="https://user-images.githubusercontent.com/10026498/184083441-5fe01c69-5261-4699-9e75-e9555fe7125d.png">


from `/streamx/flink` dir
<img width="807" alt="image" src="https://user-images.githubusercontent.com/10026498/184083560-24ffc2cb-c1ca-46d0-b492-242340c20359.png">
