### PR TITLE
[improve] When pr contains only md file shouldn't trigger maven compile.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,19 @@ name: Maven Package Test
 
 on:
   push:
-    branches: [ dev ]
+    branches:
+      - dev
+    paths-ignore:
+      - '**.md'
+      - 'deploy/**'
+      - 'script/**'
+      - 'streamx-console/streamx-console-webapp/**'
   pull_request:
-    branches: [ dev ]
+    paths-ignore:
+      - '**.md'
+      - 'deploy/**'
+      - 'script/**'
+      - 'streamx-console/streamx-console-webapp/**'
 
 jobs:
   build:


### PR DESCRIPTION
 When pr contains only md file shouldn't trigger maven compile.
