### PR TITLE
[Feat] init storage service for jar upload/download to support flink on native k8s mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <module>streamx-spark</module>
         <module>streamx-plugin</module>
         <module>streamx-console</module>
+        <module>streamx-storage-service</module>
     </modules>
     <url>https://github.com/streamxhub/streamx</url>
 

--- a/streamx-storage-service/pom.xml
+++ b/streamx-storage-service/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>streamx</artifactId>
+        <groupId>com.streamxhub.streamx</groupId>
+        <version>1.2.4</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>streamx-storage-service</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/streamx-storage-service/src/main/java/com/streamxhub/streamx/Main.java
+++ b/streamx-storage-service/src/main/java/com/streamxhub/streamx/Main.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 The StreamX Project
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.streamxhub.streamx;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world!");
+    }
+}

--- a/streamx-storage-service/src/main/java/com/streamxhub/streamx/storage/StorageService.java
+++ b/streamx-storage-service/src/main/java/com/streamxhub/streamx/storage/StorageService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 The StreamX Project
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.streamxhub.streamx.storage;
+
+public interface StorageService {
+    byte[] getData(String objectPath);
+
+    Boolean putData(String objectPath, byte[] data);
+}


### PR DESCRIPTION
init module `streamx-storage-service`.

We will use this module to support flink job on native k8s mode in uploading and downloading jar files to/from remote storage, such as OSS/HDFS, etc.