### PR TITLE
[Bug]Solve the problem of poor judgment of initialization status

### DIFF
--- a/streamx-flink/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/K8sDeploymentRelated.java
+++ b/streamx-flink/streamx-flink-kubernetes/src/main/java/com/streamxhub/streamx/flink/kubernetes/K8sDeploymentRelated.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019 The StreamX Project
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.streamxhub.streamx.flink.kubernetes;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.util.List;
+import java.util.Map;
+
+public class K8sDeploymentRelated {
+
+    public static Boolean getDeploymentStatusChanges(String nameSpce, String deploymentName){
+        try (KubernetesClient client = new DefaultKubernetesClient()){
+            Map<String, String> matchLabels = client.apps()
+                .deployments()
+                .inNamespace(nameSpce)
+                .withName(deploymentName)
+                .get()
+                .getSpec()
+                .getSelector()
+                .getMatchLabels();
+            List<Pod> items = client.pods().inNamespace(nameSpce).withLabels(matchLabels).list().getItems();
+            return items.get(0).getStatus().getContainerStatuses().get(0).getLastState().getTerminated() != null;
+        }
+    }
+
+    public static void deleteTaskDeployment(String nameSpce, String deploymentName){
+        try (KubernetesClient client = new DefaultKubernetesClient()){
+            client.apps().deployments().inNamespace(nameSpce).withName(deploymentName).delete();
+        }
+    }
+
+    public static Integer getTheNumberOfTaskDeploymentRetries(String nameSpce, String deploymentName){
+        try (KubernetesClient client = new DefaultKubernetesClient()){
+            Map<String, String> matchLabels = client.apps()
+                .deployments()
+                .inNamespace(nameSpce)
+                .withName(deploymentName)
+                .get()
+                .getSpec()
+                .getSelector()
+                .getMatchLabels();
+            List<Pod> items = client.pods().inNamespace(nameSpce).withLabels(matchLabels).list().getItems();
+            return items.get(0).getStatus().getContainerStatuses().get(0).getRestartCount();
+        }
+    }
+
+    public static Boolean isTheK8sConnectionNormal(){
+        try (KubernetesClient client = new DefaultKubernetesClient()){
+            return client != null;
+        }
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to StreamX! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
During on k8s mode usage, when a task is submitted to k8s and the task fails to run/task fails to initialize, the status change on the streamx page remains in the initialized state.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/streamxhub/streamx/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.


## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
