### PR TITLE
[Bug] Fix h2 interceptor without `et`

### DIFF
--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/base/mybatis/interceptor/H2SQLPrepareInterceptor.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/base/mybatis/interceptor/H2SQLPrepareInterceptor.java
@@ -89,6 +89,9 @@ public class H2SQLPrepareInterceptor extends JsqlParserSupport implements Interc
             Object parameterObject = boundSql.getParameterObject();
             if (parameterObject instanceof MapperMethod.ParamMap<?>) {
                 MapperMethod.ParamMap<?> paramMap = (MapperMethod.ParamMap<?>) parameterObject;
+                if (!paramMap.containsKey(Constants.ENTITY)) {
+                    return;
+                }
                 Object entity = paramMap.get(Constants.ENTITY);
                 if (Objects.nonNull(entity) && paramMap.containsKey(Constants.WRAPPER)) {
                     TableInfo tableInfo = TableInfoHelper.getTableInfo(entity.getClass());
@@ -124,5 +127,4 @@ public class H2SQLPrepareInterceptor extends JsqlParserSupport implements Interc
             }
         }
     }
-
 }


### PR DESCRIPTION
<!--

Thank you for contributing to StreamX! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary：

when called `com.streamxhub.streamx.console.core.service.ApplicationService#updateTracking` method that used *mapper.xml，instead of updateWrapper，throw exception like: can not found `et` in the paramMap

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/streamxhub/streamx/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.


## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
