### PR TITLE
improve: more notifications settings in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,7 +39,7 @@ github:
 
 notifications:
   commits:      commits@streampark.apache.org
-  issues:       commits@streampark.apache.org
-  pullrequests: commits@streampark.apache.org
-  pullrequests_status:  commits@streampark.apache.org
-  pullrequests_comment: commits@streampark.apache.org
+  issues:       issues@streampark.apache.org
+  pullrequests: issues@streampark.apache.org
+  jobs:         builds@streampark.apache.org
+  discussions:  dev@streampark.apache.org


### PR DESCRIPTION
Dispatch notification in fine-grained.

Also, we may need one more commit to trigger the watcher for applying this change. IIRC the initialization happened before repo transformation.

And default branch `dev` may not be recognized by the automation. Will file an issue on INFRA to fix it if it's the case.