### PR TITLE
[Bug] Fixed Tags display bug when tag is empty

### DIFF
--- a/streampark-console/streampark-console-webapp/src/views/flink/app/View.vue
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/View.vue
@@ -320,7 +320,7 @@
         <template
           slot="tags"
           slot-scope="text, record">
-          <a-tooltip>
+          <a-tooltip v-if="record.tags">
             <span v-for="(tag,index) in record.tags.split(',')" :key="'tag-'.concat(index)">
               <a-tag color="blue" class="app-tag">{{ tag }}</a-tag>
             </span>


### PR DESCRIPTION
<!--

Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->
### What problem does this PR solve?
Issue Number: [1552](https://github.com/apache/incubator-streampark/issues/1552)
### Problem Summary:
 It is not determined whether it is empty when traversing the tags
### What is changed and how it works?
after this bug fixed,the webui is :
![image](https://user-images.githubusercontent.com/33364356/189038917-d4dec77c-c404-4c8c-85d1-80fbc6357756.png)


Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.


## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
