### PR TITLE
[Bug]Fixed some job properties are not replicated bug When copy a job

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
@@ -623,7 +623,7 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
         newApp.setClusterId(oldApp.getExecutionModeEnum() == ExecutionMode.KUBERNETES_NATIVE_SESSION ? oldApp.getClusterId() : jobName);
         args = args != null && !"".equals(args) ? args : oldApp.getArgs();
         newApp.setArgs(args);
-        newApp.setVersionId(100000L);
+        newApp.setVersionId(oldApp.getVersionId());
 
         newApp.setFlinkClusterId(oldApp.getFlinkClusterId());
         newApp.setRestartSize(oldApp.getRestartSize());
@@ -660,6 +660,7 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
 
         newApp.setJar(oldApp.getJar());
         newApp.setJarCheckSum(oldApp.getJarCheckSum());
+        newApp.setTags(oldApp.getTags());
 
         boolean saved = save(newApp);
         if (saved) {


### PR DESCRIPTION
<!--

Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

<!-- REMOVE this line if no issue to close -->
### What problem does this PR solve?
Fixed some job properties are not replicated bug When copy a job
#### Issue Number: [1553](https://github.com/apache/incubator-streampark/issues/1553) 
#### Problem Summary:
When copying a job, some job properties are not replicated and there are some bug.
For example：
tags and ModifiedTime is empty
Versionid directly wrote as 10000L and there will be flink-home version error when use postgres as database
### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.


## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
