### PR TITLE
[Bug] Fix the bug about the owner is missed when application is running

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
@@ -485,6 +485,8 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             if (app == null) {
                 return record;
             }
+            app.setNickName(record.getNickName());
+            app.setUserName(record.getUserName());
             app.setFlinkVersion(record.getFlinkVersion());
             app.setProjectName(record.getProjectName());
             return app;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1571 

Problem Summary:

Fix the bug about the owner is missed when application is running, and you can get detailed bug in #1571 

### What is changed and how it works?

The root cause of this bug:

#### Why are other jobs normal and running job can’t show the owner?

`ApplicationMapper.page`  will join userName and nickName from `t_user` table, so other jobs are normal.

Running job will return Application from `FlinkTrackingTask.TRACKING_MAP`.

#### Why does the `FlinkTrackingTask.TRACKING_MAP` miss the userName?

1. Get app by `getById` within `ApplicationServiceImpl#start`, it just include the fields within `t_flink_app` table. The userName should be joined from `t_user` table.
2. `ApplicationServiceImpl#start -> FlinkTrackingTask.addTracking(application);` add this app to `FlinkTrackingTask.TRACKING_MAP`.

So the `FlinkTrackingTask.TRACKING_MAP` miss the userName for all apps.


#### Solution1

The `ApplicationMapper.page` get app from `FlinkTrackingTask.TRACKING_MAP`, it should `setNickName and setUserName`.

#### Solution2

`ApplicationServiceImpl#start` shouldn't call `getById` to get Application. it should join some fields from other tables.

#### Discussion

Currently, I choose solution1, it is easier than solution2, and don't need extra join.

But I have some concerns:
1. I don't know whether other code also getApplication from `FlinkTrackingTask.TRACKING_MAP`. If yes, solution2 is more strong. I haven't seen other callers yet.
2. For solution1, I just `setNickName and setUserName`, should other fields be set as well?

Please correct me, if there are any mistakes.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.


## Purpose of this pull request

Fix the bug about owner is missed when application is running
