### PR TITLE
[Bug] Fix the wrong duration

### DIFF
--- a/streampark-console/streampark-console-webapp/src/utils/filter.js
+++ b/streampark-console/streampark-console-webapp/src/utils/filter.js
@@ -37,7 +37,7 @@ Vue.filter('moment', function (dataStr, pattern = 'YYYY-MM-DD HH:mm:ss') {
 })
 
 Vue.filter('duration', function duration (ms) {
-  if (ms === 0 || ms === undefined || ms === null) {
+  if (ms === '0' || ms === undefined || ms === null) {
     return ''
   }
   const ss = 1000
@@ -45,10 +45,10 @@ Vue.filter('duration', function duration (ms) {
   const hh = mi * 60
   const dd = hh * 24
 
-  const day = parseInt(ms / dd)
-  const hour = parseInt((ms - day * dd) / hh)
-  const minute = parseInt((ms - day * dd - hour * hh) / mi)
-  const seconds = parseInt((ms - day * dd - hour * hh - minute * mi) / ss)
+  const day = parseFloat(ms / dd).toFixed(0)
+  const hour = parseFloat((ms - day * dd) / hh).toFixed(0)
+  const minute = parseFloat((ms - day * dd - hour * hh) / mi).toFixed(0)
+  const seconds = parseFloat((ms - day * dd - hour * hh - minute * mi) / ss).toFixed(0)
   if (day > 0) {
     return day + 'd ' + hour + 'h ' + minute + 'm ' + seconds + 's'
   } else if (hour > 0) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1576 

Problem Summary:

The duration is wrong when duration < 87ms. It usually happens when a job fails to start.


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.


## Purpose of this pull request

The duration is wrong when duration < 87ms. It usually happens when a job fails to start.
