### PR TITLE
[Bug] Fix the wrong duration

### DIFF
--- a/streampark-console/streampark-console-webapp/src/utils/filter.js
+++ b/streampark-console/streampark-console-webapp/src/utils/filter.js
@@ -45,10 +45,10 @@ Vue.filter('duration', function duration (ms) {
   const hh = mi * 60
   const dd = hh * 24
 
-  const day = parseFloat(ms / dd).toFixed(0)
-  const hour = parseFloat((ms - day * dd) / hh).toFixed(0)
-  const minute = parseFloat((ms - day * dd - hour * hh) / mi).toFixed(0)
-  const seconds = parseFloat((ms - day * dd - hour * hh - minute * mi) / ss).toFixed(0)
+  const day = Math.floor(ms / dd)
+  const hour = Math.floor((ms - day * dd) / hh)
+  const minute = Math.floor((ms - day * dd - hour * hh) / mi)
+  const seconds = Math.floor((ms - day * dd - hour * hh - minute * mi) / ss)
   if (day > 0) {
     return day + 'd ' + hour + 'h ' + minute + 'm ' + seconds + 's'
   } else if (hour > 0) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1584 

Problem Summary:

Fix the wrong duration, it should use the `Math.floor`, that is, `Returns the greatest integer less than or equal to its numeric argument.`

<img width="854" alt="image" src="https://user-images.githubusercontent.com/38427477/189811847-ec18a7ba-35a6-4557-ab8c-4a9f9a739f34.png">


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.


## Purpose of this pull request

Fix the wrong duration