### PR TITLE
[Bug] When Flink is started in the on yarn mode, the total task and r…

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkTrackingTask.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkTrackingTask.java
@@ -324,12 +324,11 @@ public class FlinkTrackingTask {
             }
         }
         application.setDuration(jobOverview.getDuration());
+        application.setTotalTask(jobOverview.getTasks().getTotal());
+        application.setOverview(jobOverview.getTasks());
 
         // get overview info at the first start time
         if (STARTING_CACHE.getIfPresent(application.getId()) != null) {
-            application.setTotalTask(jobOverview.getTasks().getTotal());
-            application.setOverview(jobOverview.getTasks());
-
             FlinkCluster flinkCluster = getFlinkCluster(application);
             Overview override = httpOverview(application, flinkCluster);
             if (override != null && override.getSlotsTotal() > 0) {


### PR DESCRIPTION
…unning task indicators are not accurately obtained #1632

<!--

Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [[Bug] When Flink is started in the on yarn mode, the total task and running task indicators are not accurately obtained #1632](https://github.com/apache/incubator-streampark/issues/1632) <!-- REMOVE this line if not applicable -->


Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.


## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
