### PR TITLE
[Bug] Fix the help when user/role name already exists

### DIFF
--- a/streampark-console/streampark-console-webapp/src/views/system/role/RoleAdd.vue
+++ b/streampark-console/streampark-console-webapp/src/views/system/role/RoleAdd.vue
@@ -49,7 +49,7 @@
           v-decorator="[
             'remark',
             {rules: [
-              { max: 50, message: '长度不能超过50个字符'}
+              { max: 50, message: 'Description should not be longer than 50 characters'}
             ]}]" />
       </a-form-item>
       <a-form-item
@@ -153,7 +153,7 @@ export default {
         this.menuSelectHelp = ''
       } else {
         this.menuSelectStatus = 'error'
-        this.menuSelectHelp = '请选择相应的权限'
+        this.menuSelectHelp = 'Please select the permission.'
       }
     },
     handleExpand (expandedKeys) {
@@ -161,14 +161,12 @@ export default {
     },
     handleSubmit () {
       const checkedArr = this.selectedKeysAndHalfCheckedKeys
-      if (this.validateStatus !== 'success') {
-        this.handleRoleNameBlur()
-      } else if (checkedArr.length === 0) {
+      if (checkedArr.length === 0) {
         this.menuSelectStatus = 'error'
-        this.menuSelectHelp = '请选择相应的权限'
+        this.menuSelectHelp = 'Please select the permission.'
       } else {
         this.form.validateFields((err, values) => {
-          if (!err) {
+          if (!err && this.validateStatus === 'success') {
             this.loading = true
             const role = this.form.getFieldsValue()
             role.menuId = checkedArr.join(',')
@@ -193,7 +191,7 @@ export default {
       if (roleName.length) {
         if (roleName.length > 10) {
           this.validateStatus = 'error'
-          this.help = '角色名称不能超过10个字符'
+          this.help = 'Role name should not be longer than 10 characters'
         } else {
           this.validateStatus = 'validating'
           checkName({
@@ -204,13 +202,13 @@ export default {
               this.help = ''
             } else {
               this.validateStatus = 'error'
-              this.help = '抱歉，该角色名称已存在'
+              this.help = 'Sorry, the role name already exists'
             }
           })
         }
       } else {
         this.validateStatus = 'error'
-        this.help = '角色名称不能为空'
+        this.help = 'Role name cannot be empty'
       }
     }
   },

--- a/streampark-console/streampark-console-webapp/src/views/system/user/UserAdd.vue
+++ b/streampark-console/streampark-console-webapp/src/views/system/user/UserAdd.vue
@@ -183,9 +183,6 @@ export default {
     },
 
     handleSubmit() {
-      if (this.validateStatus !== 'success') {
-        this.handleUserNameBlur()
-      }
       this.form.validateFields((err, user) => {
         if (!err && this.validateStatus === 'success') {
           user.roleId = user.roleId.join(',')
@@ -207,10 +204,10 @@ export default {
       if (username.length) {
         if (username.length > 20) {
           this.validateStatus = 'error'
-          this.help = '用户名不能超过10个字符'
+          this.help = 'User name should not be longer than 20 characters'
         } else if (username.length < 4) {
           this.validateStatus = 'error'
-          this.help = '用户名不能少于4个字符'
+          this.help = 'Team name should not be less than 4 characters'
         } else {
           this.validateStatus = 'validating'
           checkUserName({
@@ -221,13 +218,13 @@ export default {
               this.help = ''
             } else {
               this.validateStatus = 'error'
-              this.help = '抱歉，该用户名已存在'
+              this.help = 'Sorry, the user name already exists'
             }
           })
         }
       } else {
         this.validateStatus = 'error'
-        this.help = '用户名不能为空'
+        this.help = 'User name cannot be empty'
       }
     }
   },


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1634 

Problem Summary:

The help should be `抱歉，该用户名已存在`, but the help is `用户名不能为空`.

![image](https://user-images.githubusercontent.com/38427477/190870318-4ab9ecfa-08b4-44ff-8232-783d2ec655ba.png)

The help should be `抱歉，该角色名称已存在`, but the help is `角色名称不能为空`.

![image](https://user-images.githubusercontent.com/38427477/190870399-2fa4b1c1-c655-43e2-b451-7518f5f841ca.png)




The help is right with this PR.

![image](https://user-images.githubusercontent.com/38427477/190870992-75a7c6d0-ac76-4cee-b661-eb36cc1203e8.png)


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.


## Purpose of this pull request

Fix the help when user/role name already exists