### PR TITLE
[Bug] Fix the wrong run status due to the jobId isn't updated

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
@@ -1394,6 +1394,7 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
                     applicationLog.setJobManagerUrl(submitResponse.jobManagerUrl());
                 }
                 application.setFlameGraph(appParam.getFlameGraph());
+                application.setJobId(submitResponse.jobId());
                 applicationLog.setYarnAppId(submitResponse.clusterId());
                 application.setStartTime(new Date());
                 application.setEndTime(null);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1647 

Problem Summary:

The Run status is always starting for standalone mode.

### What is changed and how it works?

Update the jobId when job is started

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.


## Purpose of this pull request

Fix the wrong run status due to the jobId isn't updated