### PR TITLE
[Improve]When the flink task on k8s keeps restarting, streampark won'…

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
@@ -79,6 +79,7 @@ import org.apache.streampark.console.core.task.FlinkTrackingTask;
 import org.apache.streampark.flink.core.conf.ParameterCli;
 import org.apache.streampark.flink.kubernetes.IngressController;
 import org.apache.streampark.flink.kubernetes.K8sFlinkTrackMonitor;
+import org.apache.streampark.flink.kubernetes.helper.KubernetesDeploymentHelper;
 import org.apache.streampark.flink.kubernetes.model.FlinkMetricCV;
 import org.apache.streampark.flink.kubernetes.model.TrackId;
 import org.apache.streampark.flink.packer.pipeline.BuildResult;
@@ -905,6 +906,13 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
         if (startFuture == null && cancelFuture == null) {
             this.updateToStopped(app);
         }
+        if (isKubernetesApp(app)) {
+            KubernetesDeploymentHelper.watchPodTerminatedLog(app.getK8sNamespace(), app.getJobName());
+            KubernetesDeploymentHelper.deleteTaskDeployment(app.getK8sNamespace(), app.getJobName());
+            KubernetesDeploymentHelper.deleteTaskConfigMap(app.getK8sNamespace(), app.getJobName());
+            IngressController.deleteIngress(app.getK8sNamespace(), app.getJobName());
+        }
+
     }
 
     @Override

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/helper/KubernetesDeploymentHelper.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/helper/KubernetesDeploymentHelper.scala
@@ -108,4 +108,17 @@ object KubernetesDeploymentHelper extends Logger {
       }.getOrElse(null)
     }(error => throw error)
   }
+
+  def deleteTaskConfigMap(nameSpace: String, deploymentName: String): Boolean = {
+    tryWithResource(KubernetesRetriever.newK8sClient()) { client =>
+      Try {
+        val r = client.configMaps()
+          .inNamespace(nameSpace)
+          .withLabel("app", deploymentName)
+          .delete
+        Boolean.unbox(r)
+      }.getOrElse(false)
+    }
+  }
+
 }


### PR DESCRIPTION

<!--

Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

-->

## What problem does this PR solve?

When the flink task on k8s keeps restarting, streampark won't be able to do anything about it


## What is changed and how it works?

He will delete the deployment, ingress, congifmap of the task, and also save the error log for problem tracing
