### PR TITLE
[Improve] Make sure this role is not bound by the user before removing the role

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/RoleController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/RoleController.java
@@ -84,7 +84,7 @@ public class RoleController {
     @DeleteMapping("delete")
     @RequiresPermissions("role:delete")
     public RestResponse deleteRole(Long roleId) {
-        this.roleService.removeById(roleId);
+        this.roleService.deleteRole(roleId);
         return RestResponse.success();
     }
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/RoleMenuServie.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/RoleMenuServie.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public interface RoleMenuServie extends IService<RoleMenu> {
 
-    void deleteRoleMenusByRoleId(String[] roleIds);
+    void deleteRoleMenusByRoleId(Long roleId);
 
     void deleteRoleMenusByMenuId(String[] menuIds);
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/RoleService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/RoleService.java
@@ -38,7 +38,7 @@ public interface RoleService extends IService<Role> {
 
     void createRole(Role role);
 
-    void deleteRoles(String[] roleIds) throws Exception;
+    void deleteRole(Long roleId);
 
-    void updateRole(Role role) throws Exception;
+    void updateRole(Role role);
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserRoleService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserRoleService.java
@@ -29,6 +29,6 @@ public interface UserRoleService extends IService<UserRole> {
 
     void deleteUserRolesByUserId(String[] userIds);
 
-    List<String> findUserIdsByRoleId(String[] roleIds);
+    List<Long> findUserIdsByRoleId(Long roleId);
 
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/RoleMenuServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/RoleMenuServiceImpl.java
@@ -37,9 +37,8 @@ public class RoleMenuServiceImpl extends ServiceImpl<RoleMenuMapper, RoleMenu>
 
     @Override
     @Transactional
-    public void deleteRoleMenusByRoleId(String[] roleIds) {
-        List<String> list = Arrays.asList(roleIds);
-        baseMapper.delete(new LambdaQueryWrapper<RoleMenu>().in(RoleMenu::getRoleId, list));
+    public void deleteRoleMenusByRoleId(Long roleId) {
+        baseMapper.delete(new LambdaQueryWrapper<RoleMenu>().eq(RoleMenu::getRoleId, roleId));
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/RoleServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/RoleServiceImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.streampark.console.system.service.impl;
 
+import org.apache.streampark.common.util.AssertUtils;
 import org.apache.streampark.console.base.domain.Constant;
 import org.apache.streampark.console.base.domain.RestRequest;
 import org.apache.streampark.console.system.entity.Role;
@@ -42,6 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -93,16 +95,18 @@ public class RoleServiceImpl extends ServiceImpl<RoleMapper, Role> implements Ro
     }
 
     @Override
-    public void deleteRoles(String[] roleIds) throws Exception {
-        List<String> list = Arrays.asList(roleIds);
-        baseMapper.deleteBatchIds(list);
-        this.roleMenuService.deleteRoleMenusByRoleId(roleIds);
-        this.userRoleService.deleteUserRolesByRoleId(roleIds);
+    public void deleteRole(Long roleId) {
+        Role role = Optional.ofNullable(this.getById(roleId))
+            .orElseThrow(() -> new IllegalArgumentException(String.format("Role id [%s] not found", roleId)));
+        List<Long> userIdsByRoleId = userRoleService.findUserIdsByRoleId(roleId);
+        AssertUtils.isTrue(userIdsByRoleId == null || userIdsByRoleId.isEmpty(),
+            String.format("There are some users are bound to role %s , please unbind it first.", role.getRoleName()));
+        this.removeById(roleId);
+        this.roleMenuService.deleteRoleMenusByRoleId(roleId);
     }
 
     @Override
-    public void updateRole(Role role) throws Exception {
-        String[] roleId = {String.valueOf(role.getRoleId())};
+    public void updateRole(Role role) {
         role.setModifyTime(new Date());
         baseMapper.updateById(role);
         roleMenuMapper.delete(

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserRoleServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserRoleServiceImpl.java
@@ -49,12 +49,12 @@ public class UserRoleServiceImpl extends ServiceImpl<UserRoleMapper, UserRole>
     }
 
     @Override
-    public List<String> findUserIdsByRoleId(String[] roleIds) {
+    public List<Long> findUserIdsByRoleId(Long roleId) {
         List<UserRole> list =
             baseMapper.selectList(
-                new LambdaQueryWrapper<UserRole>().in(UserRole::getRoleId, (Object) roleIds));
+                new LambdaQueryWrapper<UserRole>().eq(UserRole::getRoleId, roleId));
         return list.stream()
-            .map(userRole -> String.valueOf(userRole.getUserId()))
+            .map(UserRole::getUserId)
             .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: close #1727 

Problem Summary:

1. Make sure this role is not bound by the user before removing the role
2. when delete a role, delete menu mapping of this role


## What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

## Purpose of this pull request

1. Make sure this role is not bound by the user before removing the role
2. when delete a role, delete menu mapping of this role