### PR TITLE
[Bug] after flink 1.15 error when verify SQL script bug fix

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkSqlServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkSqlServiceImpl.java
@@ -45,7 +45,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.function.Function;
 
 @Slf4j
 @Service
@@ -117,7 +116,7 @@ public class FlinkSqlServiceImpl extends ServiceImpl<FlinkSqlMapper, FlinkSql> i
 
     @Override
     public List<FlinkSql> history(Application application) {
-        LambdaQueryWrapper<FlinkSql> wrapper = new LambdaQueryWrapper();
+        LambdaQueryWrapper<FlinkSql> wrapper = new LambdaQueryWrapper<>();
         wrapper.eq(FlinkSql::getAppId, application.getId())
             .orderByDesc(FlinkSql::getVersion);
 
@@ -185,7 +184,7 @@ public class FlinkSqlServiceImpl extends ServiceImpl<FlinkSqlMapper, FlinkSql> i
     @Override
     public FlinkSqlValidationResult verifySql(String sql, Long versionId) {
         FlinkEnv flinkEnv = flinkEnvService.getById(versionId);
-        return FlinkShimsProxy.proxy(flinkEnv.getFlinkVersion(), (Function<ClassLoader, FlinkSqlValidationResult>) classLoader -> {
+        return FlinkShimsProxy.proxyVerifySql(flinkEnv.getFlinkVersion(), classLoader -> {
             try {
                 Class<?> clazz = classLoader.loadClass("org.apache.streampark.flink.core.FlinkSqlValidator");
                 Method method = clazz.getDeclaredMethod("verifySql", String.class);
@@ -200,9 +199,5 @@ public class FlinkSqlServiceImpl extends ServiceImpl<FlinkSqlMapper, FlinkSql> i
             }
             return null;
         });
-    }
-
-    private boolean isFlinkSqlBacked(FlinkSql sql) {
-        return backUpService.isFlinkSqlBacked(sql.getAppId(), sql.getId());
     }
 }

--- a/streampark-flink/streampark-flink-proxy/src/main/scala/org/apache/streampark/flink/proxy/FlinkShimsProxy.scala
+++ b/streampark-flink/streampark-flink-proxy/src/main/scala/org/apache/streampark/flink/proxy/FlinkShimsProxy.scala
@@ -57,7 +57,7 @@ object FlinkShimsProxy extends Logger {
    * Get shimsClassLoader to execute for scala API
    *
    * @param flinkVersion flinkVersion
-   * @param func         execute function
+   * @param func execute function
    * @tparam T
    * @return
    */
@@ -70,7 +70,7 @@ object FlinkShimsProxy extends Logger {
    * Get shimsClassLoader to execute for java API
    *
    * @param flinkVersion flinkVersion
-   * @param func         execute function
+   * @param func execute function
    * @tparam T
    * @return
    */
@@ -95,8 +95,8 @@ object FlinkShimsProxy extends Logger {
       val libURL = getFlinkHomeLib(flinkVersion.flinkHome, "lib", filterLib)
       // 2) After version 1.15 need add flink/opt/flink-table-planner*
       val getFlinkTablePlanner: File => Boolean = _.getName.startsWith("flink-table-planner")
-      val optURL = getFlinkHomeLib(flinkVersion.flinkHome, "opt", getFlinkTablePlanner)
-      val shimsUrls = ListBuffer[URL](libURL ++ optURL: _*)
+      val tablePlannerURL = getFlinkHomeLib(flinkVersion.flinkHome, "opt", getFlinkTablePlanner)
+      val shimsUrls = ListBuffer[URL](libURL ++ tablePlannerURL: _*)
 
       // 3) shims jar
       val appHome = System.getProperty(ConfigConst.KEY_APP_HOME)


### PR DESCRIPTION
## What problem does this PR solve?
after flink 1.15 flink-table-planner migrated to opt directory, streampark classloader failed to load the CalciteParser class,  error when verify SQL script ,nedd to  add flink-table-planner to verify sql classloader classpath


Issue Number:close  #1713

Problem Summary:
after flink 1.15  error when verify SQL script

## What is changed and how it works?
Separate the verify sql from the classloader of the submitted job, compatible with multiple versions to get the check sql dependency to create a new classloader, and the submitted job is unchanged.