### PR TITLE
[Feature] Simplify the configuration of watermark interval

### DIFF
--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
@@ -165,8 +165,6 @@ object ConfigConst {
 
   val KEY_EXECUTION_RUNTIME_MODE = "flink.execution.runtime-mode"
 
-  val KEY_FLINK_WATERMARK_INTERVAL = "flink.watermark.interval"
-
   // ---watermark---
   val KEY_FLINK_WATERMARK_TIME_CHARACTERISTIC = "flink.watermark.time.characteristic"
 

--- a/streampark-console/streampark-console-service/src/main/resources/flink-application.conf
+++ b/streampark-console/streampark-console-service/src/main/resources/flink-application.conf
@@ -42,14 +42,14 @@ flink:
         jvm-overhead.max:
         jvm-overhead.min:
         managed.fraction: 0.4
+      pipeline:
+        auto-watermark-interval: 200ms
   checkpoints:
     enable: true
     interval: 30000
     mode: EXACTLY_ONCE
     timeout: 300000
     unaligned: true
-  watermark:
-    interval: 10000
   # state backend
   state:
     # Note that the configurations of flink1.12 and later are different, and the combined configuration should be selected reasonably

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.12/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.12/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
@@ -169,10 +169,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
       case p if p > 0 => localStreamEnv.setParallelism(p)
       case _ => throw new IllegalArgumentException("[StreamPark] parallelism must be > 0. ")
     }
-    val interval = Try(parameter.get(KEY_FLINK_WATERMARK_INTERVAL).toInt).getOrElse(0)
-    if (interval > 0) {
-      localStreamEnv.getConfig.setAutoWatermarkInterval(interval)
-    }
 
     // Compatible with 1.12 and previous versions (TimeCharacteristic deprecated in version 1.12)
     if (classOf[TimeCharacteristic].getDeclaredAnnotation(classOf[Deprecated]) == null) {

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.13/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.13/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
@@ -169,10 +169,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
       case p if p > 0 => localStreamEnv.setParallelism(p)
       case _ => throw new IllegalArgumentException("[StreamPark] parallelism must be > 0. ")
     }
-    val interval = Try(parameter.get(KEY_FLINK_WATERMARK_INTERVAL).toInt).getOrElse(0)
-    if (interval > 0) {
-      localStreamEnv.getConfig.setAutoWatermarkInterval(interval)
-    }
 
     val executionMode = Try(RuntimeExecutionMode.valueOf(parameter.get(KEY_EXECUTION_RUNTIME_MODE))).getOrElse(RuntimeExecutionMode.STREAMING)
     localStreamEnv.setRuntimeMode(executionMode)

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.14/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.14/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
@@ -169,10 +169,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
       case p if p > 0 => localStreamEnv.setParallelism(p)
       case _ => throw new IllegalArgumentException("[StreamPark] parallelism must be > 0. ")
     }
-    val interval = Try(parameter.get(KEY_FLINK_WATERMARK_INTERVAL).toInt).getOrElse(0)
-    if (interval > 0) {
-      localStreamEnv.getConfig.setAutoWatermarkInterval(interval)
-    }
 
     val executionMode = Try(RuntimeExecutionMode.valueOf(parameter.get(KEY_EXECUTION_RUNTIME_MODE))).getOrElse(RuntimeExecutionMode.STREAMING)
     localStreamEnv.setRuntimeMode(executionMode)

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.15/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.15/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
@@ -168,10 +168,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
       case p if p > 0 => localStreamEnv.setParallelism(p)
       case _ => throw new IllegalArgumentException("[StreamPark] parallelism must be > 0. ")
     }
-    val interval = Try(parameter.get(KEY_FLINK_WATERMARK_INTERVAL).toInt).getOrElse(0)
-    if (interval > 0) {
-      localStreamEnv.getConfig.setAutoWatermarkInterval(interval)
-    }
 
     val executionMode = Try(RuntimeExecutionMode.valueOf(parameter.get(KEY_EXECUTION_RUNTIME_MODE))).getOrElse(RuntimeExecutionMode.STREAMING)
     localStreamEnv.setRuntimeMode(executionMode)

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.15/src/main/scala/org/apache/streampark/flink/core/FlinkTableInitializer.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.15/src/main/scala/org/apache/streampark/flink/core/FlinkTableInitializer.scala
@@ -17,7 +17,7 @@
 
 package org.apache.streampark.flink.core
 
-import org.apache.streampark.common.conf.ConfigConst.{KEY_APP_CONF, KEY_APP_NAME, KEY_EXECUTION_RUNTIME_MODE, KEY_FLINK_APP_NAME, KEY_FLINK_PARALLELISM, KEY_FLINK_SQL, KEY_FLINK_TABLE_CATALOG, KEY_FLINK_TABLE_DATABASE, KEY_FLINK_TABLE_MODE, KEY_FLINK_WATERMARK_INTERVAL}
+import org.apache.streampark.common.conf.ConfigConst.{KEY_APP_CONF, KEY_APP_NAME, KEY_EXECUTION_RUNTIME_MODE, KEY_FLINK_APP_NAME, KEY_FLINK_PARALLELISM, KEY_FLINK_SQL, KEY_FLINK_TABLE_CATALOG, KEY_FLINK_TABLE_DATABASE, KEY_FLINK_TABLE_MODE}
 import org.apache.streampark.common.enums.{ApiType, TableMode}
 import org.apache.streampark.common.enums.ApiType.ApiType
 import org.apache.streampark.common.enums.TableMode.TableMode


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: close #1742 

Problem Summary:

Click  #1739  to get detailed background.

Simplify the configuration of watermark interval. 

## What is changed and how it works?

Replace `flink.watermark.interval` with `pipeline.auto-watermark-interval`.

[Flink 1.12 configuration doc](https://nightlies.apache.org/flink/flink-docs-release-1.12/deployment/config.html#pipeline-auto-watermark-interval)

[Flink 1.15 configuration doc](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/deployment/config/#pipeline-auto-watermark-interval)


Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

## Purpose of this pull request

Click  #1739  to get detailed background.

Simplify the configuration of watermark interval. 