### PR TITLE
[Feature] Simplify restartStrategy related configuration

### DIFF
--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
@@ -149,20 +149,6 @@ object ConfigConst {
 
   val KEY_FLINK_STATE_ROCKSDB = "flink.state.backend.rocksdb"
 
-  //---restart-strategy---
-
-  val KEY_FLINK_RESTART_STRATEGY = "flink.restart-strategy.value"
-
-  val KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_PER_INTERVAL = "flink.restart-strategy.failure-rate.max-failures-per-interval"
-
-  val KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_RATE_INTERVAL = "flink.restart-strategy.failure-rate.failure-rate-interval"
-
-  val KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_DELAY = "flink.restart-strategy.failure-rate.delay"
-
-  val KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS = "flink.restart-strategy.fixed-delay.attempts"
-
-  val KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_DELAY = "flink.restart-strategy.fixed-delay.delay"
-
   val KEY_EXECUTION_RUNTIME_MODE = "flink.execution.runtime-mode"
 
   // ---watermark---

--- a/streampark-console/streampark-console-service/src/main/resources/flink-application.conf
+++ b/streampark-console/streampark-console-service/src/main/resources/flink-application.conf
@@ -44,6 +44,15 @@ flink:
         managed.fraction: 0.4
       pipeline:
         auto-watermark-interval: 200ms
+      # restart strategy
+      restart-strategy: fixed-delay  # Restart strategy [(fixed-delay|failure-rate|none) a total of 3 configurable strategies]
+      restart-strategy.fixed-delay:
+        attempts: 3
+        delay: 5000
+      restart-strategy.failure-rate:
+        max-failures-per-interval:
+        failure-rate-interval:
+        delay:
   checkpoints:
     enable: true
     interval: 30000
@@ -65,16 +74,6 @@ flink:
     checkpoints.dir: file:///tmp/chkdir
     savepoints.dir: file:///tmp/chkdir
     checkpoints.num-retained: 1
-  # restart strategy
-  restart-strategy:
-    value: fixed-delay  # Restart strategy [(fixed-delay|failure-rate|none) a total of 3 configurable strategies]
-    fixed-delay:
-      attempts: 3
-      delay: 5000
-    failure-rate:
-      max-failures-per-interval:
-      failure-rate-interval:
-      delay:
   # table
   table:
     planner: blink # (blink|old|any)

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.12/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.12/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
@@ -179,8 +179,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
     val executionMode = Try(RuntimeExecutionMode.valueOf(parameter.get(KEY_EXECUTION_RUNTIME_MODE))).getOrElse(RuntimeExecutionMode.STREAMING)
     localStreamEnv.setRuntimeMode(executionMode)
 
-    restartStrategy()
-
     checkpoint()
 
     apiType match {
@@ -189,84 +187,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
       case _ =>
     }
     localStreamEnv.getConfig.setGlobalJobParameters(parameter)
-  }
-
-  private[this] def restartStrategy(): Unit = {
-    /**
-     * Priority to the current project configuration to find the configuration, if can not find,
-     * then take $FLINK_HOME/conf/flink-conf.yml as the configuration
-     */
-    val prefixLen = "flink.".length
-    val strategy = Try(RestartStrategy.byName(parameter.get(KEY_FLINK_RESTART_STRATEGY)))
-      .getOrElse(
-        Try(RestartStrategy.byName(defaultFlinkConf("restart-strategy"))).getOrElse(null)
-      )
-
-    strategy match {
-      case RestartStrategy.`failure-rate` =>
-        /**
-         * restart-strategy.failure-rate.max-failures-per-interval: maximum number of restarts before a Job is deemed to have failed
-         * restart-strategy.failure-rate.failure-rate-interval: time interval for calculating the failure rate
-         * restart-strategy.failure-rate.delay: time interval between two consecutive reboot attempts
-         * e.g:
-         * >>>
-         * max-failures-per-interval: 10
-         * failure-rate-interval: 5 min
-         * delay: 2 s
-         * <<<
-         * That is:
-         * the time interval of each abnormal restart is "2 seconds",
-         * if the total number of failures reaches "10" within "5 minutes", the task will fail.
-         */
-        val interval = Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_PER_INTERVAL).toInt)
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_PER_INTERVAL.drop(prefixLen)).toInt).getOrElse(3)
-          )
-
-        val rateInterval = DateUtils.getTimeUnit(Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_RATE_INTERVAL))
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_RATE_INTERVAL.drop(prefixLen))).getOrElse(null)
-          ), (5, TimeUnit.MINUTES))
-
-        val delay = DateUtils.getTimeUnit(Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_DELAY))
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_DELAY.drop(prefixLen))).getOrElse(null)
-          ))
-
-        streamEnvironment.getConfig.setRestartStrategy(RestartStrategies.failureRateRestart(
-          interval,
-          Time.of(rateInterval._1, rateInterval._2),
-          Time.of(delay._1, delay._2)
-        ))
-      case RestartStrategy.`fixed-delay` =>
-        /**
-         * restart-strategy.fixed-delay.attempts: the number of times Flink tries to execute a Job before it finally failure
-         * restart-strategy.fixed-delay.delay: specific how long the restart interval
-         * e.g:
-         * attempts: 5,delay: 3 s
-         * That is:
-         * The maximum number of failed retries for a task is 5, and the time interval for each task restart is 3 seconds,
-         * if the number of failed attempts reaches 5, the task will fail and exit
-         */
-        val attempts = Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS).toInt)
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS.drop(prefixLen)).toInt).getOrElse(3)
-          )
-
-        val delay = DateUtils.getTimeUnit(Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_DELAY))
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_DELAY.drop(prefixLen))).getOrElse(null)
-          ))
-
-        /**
-         * Total `restartAttempts` after task execution failure, each restart interval `delayBetweenAttempts`
-         */
-        streamEnvironment.getConfig.setRestartStrategy(RestartStrategies.fixedDelayRestart(attempts, Time.of(delay._1, delay._2)))
-
-      case RestartStrategy.none => streamEnvironment.getConfig.setRestartStrategy(RestartStrategies.noRestart())
-
-      case null => logInfo("RestartStrategy not set,use default from $flink_conf")
-    }
   }
 
   private[this] def checkpoint(): Unit = {

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.13/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.13/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
@@ -173,8 +173,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
     val executionMode = Try(RuntimeExecutionMode.valueOf(parameter.get(KEY_EXECUTION_RUNTIME_MODE))).getOrElse(RuntimeExecutionMode.STREAMING)
     localStreamEnv.setRuntimeMode(executionMode)
 
-    restartStrategy()
-
     checkpoint()
 
     apiType match {
@@ -183,85 +181,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
       case _ =>
     }
     localStreamEnv.getConfig.setGlobalJobParameters(parameter)
-  }
-
-  private[this] def restartStrategy(): Unit = {
-    /**
-     * Priority to the current project configuration to find the configuration, if can not find,
-     * then take $FLINK_HOME/conf/flink-conf.yml as the configuration
-     */
-    val prefixLen = "flink.".length
-    val strategy = Try(RestartStrategy.byName(parameter.get(KEY_FLINK_RESTART_STRATEGY)))
-      .getOrElse(
-        Try(RestartStrategy.byName(defaultFlinkConf("restart-strategy"))).getOrElse(null)
-      )
-
-    strategy match {
-      case RestartStrategy.`failure-rate` =>
-
-        /**
-         * restart-strategy.failure-rate.max-failures-per-interval: maximum number of restarts before a Job is deemed to have failed
-         * restart-strategy.failure-rate.failure-rate-interval: time interval for calculating the failure rate
-         * restart-strategy.failure-rate.delay: time interval between two consecutive reboot attempts
-         * e.g:
-         * >>>
-         * max-failures-per-interval: 10
-         * failure-rate-interval: 5 min
-         * delay: 2 s
-         * <<<
-         * That is:
-         * the time interval of each abnormal restart is "2 seconds",
-         * if the total number of failures reaches "10" within "5 minutes", the task will fail.
-         */
-        val interval = Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_PER_INTERVAL).toInt)
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_PER_INTERVAL.drop(prefixLen)).toInt).getOrElse(3)
-          )
-
-        val rateInterval = DateUtils.getTimeUnit(Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_RATE_INTERVAL))
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_RATE_INTERVAL.drop(prefixLen))).getOrElse(null)
-          ), (5, TimeUnit.MINUTES))
-
-        val delay = DateUtils.getTimeUnit(Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_DELAY))
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_DELAY.drop(prefixLen))).getOrElse(null)
-          ))
-
-        streamEnvironment.getConfig.setRestartStrategy(RestartStrategies.failureRateRestart(
-          interval,
-          Time.of(rateInterval._1, rateInterval._2),
-          Time.of(delay._1, delay._2)
-        ))
-      case RestartStrategy.`fixed-delay` =>
-        /**
-         * restart-strategy.fixed-delay.attempts: the number of times Flink tries to execute a Job before it finally failure
-         * restart-strategy.fixed-delay.delay: specific how long the restart interval
-         * e.g:
-         * attempts: 5,delay: 3 s
-         * That is:
-         * The maximum number of failed retries for a task is 5, and the time interval for each task restart is 3 seconds,
-         * if the number of failed attempts reaches 5, the task will fail and exit
-         */
-        val attempts = Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS).toInt)
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS.drop(prefixLen)).toInt).getOrElse(3)
-          )
-
-        val delay = DateUtils.getTimeUnit(Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_DELAY))
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_DELAY.drop(prefixLen))).getOrElse(null)
-          ))
-
-        /**
-         * Total `restartAttempts` after task execution failure, each restart interval `delayBetweenAttempts`
-         */
-        streamEnvironment.getConfig.setRestartStrategy(RestartStrategies.fixedDelayRestart(attempts, Time.of(delay._1, delay._2)))
-
-      case RestartStrategy.none => streamEnvironment.getConfig.setRestartStrategy(RestartStrategies.noRestart())
-
-      case null => logInfo("RestartStrategy not set,use default from $flink_conf")
-    }
   }
 
   private[this] def checkpoint(): Unit = {

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.14/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.14/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
@@ -173,8 +173,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
     val executionMode = Try(RuntimeExecutionMode.valueOf(parameter.get(KEY_EXECUTION_RUNTIME_MODE))).getOrElse(RuntimeExecutionMode.STREAMING)
     localStreamEnv.setRuntimeMode(executionMode)
 
-    restartStrategy()
-
     checkpoint()
 
     apiType match {
@@ -183,86 +181,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
       case _ =>
     }
     localStreamEnv.getConfig.setGlobalJobParameters(parameter)
-  }
-
-  private[this] def restartStrategy(): Unit = {
-    /**
-     * Priority to the current project configuration to find the configuration, if can not find,
-     * then take $FLINK_HOME/conf/flink-conf.yml as the configuration
-     */
-    val prefixLen = "flink.".length
-    val strategy = Try(RestartStrategy.byName(parameter.get(KEY_FLINK_RESTART_STRATEGY)))
-      .getOrElse(
-        Try(RestartStrategy.byName(defaultFlinkConf("restart-strategy"))).getOrElse(null)
-      )
-
-    strategy match {
-      case RestartStrategy.`failure-rate` =>
-
-        /**
-         * restart-strategy.failure-rate.max-failures-per-interval: maximum number of restarts before a Job is deemed to have failed
-         * restart-strategy.failure-rate.failure-rate-interval: time interval for calculating the failure rate
-         * restart-strategy.failure-rate.delay: time interval between two consecutive reboot attempts
-         * e.g:
-         * >>>
-         * max-failures-per-interval: 10
-         * failure-rate-interval: 5 min
-         * delay: 2 s
-         * <<<
-         * That is:
-         * the time interval of each abnormal restart is "2 seconds",
-         * if the total number of failures reaches "10" within "5 minutes", the task will fail.
-         */
-        val interval = Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_PER_INTERVAL).toInt)
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_PER_INTERVAL.drop(prefixLen)).toInt).getOrElse(3)
-          )
-
-        val rateInterval = DateUtils.getTimeUnit(Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_RATE_INTERVAL))
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_RATE_INTERVAL.drop(prefixLen))).getOrElse(null)
-          ), (5, TimeUnit.MINUTES))
-
-        val delay = DateUtils.getTimeUnit(Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_DELAY))
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FAILURE_RATE_DELAY.drop(prefixLen))).getOrElse(null)
-          ))
-
-        streamEnvironment.getConfig.setRestartStrategy(RestartStrategies.failureRateRestart(
-          interval,
-          Time.of(rateInterval._1, rateInterval._2),
-          Time.of(delay._1, delay._2)
-        ))
-      case RestartStrategy.`fixed-delay` =>
-
-        /**
-         * restart-strategy.fixed-delay.attempts: the number of times Flink tries to execute a Job before it finally failure
-         * restart-strategy.fixed-delay.delay: specific how long the restart interval
-         * e.g:
-         * attempts: 5,delay: 3 s
-         * That is:
-         * The maximum number of failed retries for a task is 5, and the time interval for each task restart is 3 seconds,
-         * if the number of failed attempts reaches 5, the task will fail and exit
-         */
-        val attempts = Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS).toInt)
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS.drop(prefixLen)).toInt).getOrElse(3)
-          )
-
-        val delay = DateUtils.getTimeUnit(Try(parameter.get(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_DELAY))
-          .getOrElse(
-            Try(defaultFlinkConf(KEY_FLINK_RESTART_STRATEGY_FIXED_DELAY_DELAY.drop(prefixLen))).getOrElse(null)
-          ))
-
-        /**
-         * Total `restartAttempts` after task execution failure, each restart interval `delayBetweenAttempts`
-         */
-        streamEnvironment.getConfig.setRestartStrategy(RestartStrategies.fixedDelayRestart(attempts, Time.of(delay._1, delay._2)))
-
-      case RestartStrategy.none => streamEnvironment.getConfig.setRestartStrategy(RestartStrategies.noRestart())
-
-      case null => logInfo("RestartStrategy not set,use default from $flink_conf")
-    }
   }
 
   private[this] def checkpoint(): Unit = {


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: close #1743 

Problem Summary:

Click  #1739 to get detailed background.

Simplify restartStrategy related configuration.

| StreamPark Configuration | Flink Configuration | Flink 1.12 doc | Flink 1.15 doc |
| --- | --- | --- | --- |
| flink.restart-strategy.value | restart-strategy | https://nightlies.apache.org/flink/flink-docs-release-1.12/deployment/config.html#restart-strategy | https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/deployment/config/#restart-strategy |
| flink.restart-strategy.failure-rate.max-failures-per-interval | restart-strategy.failure-rate.max-failures-per-interval | https://nightlies.apache.org/flink/flink-docs-release-1.12/deployment/config.html#restart-strategy-failure-rate-max-failures-per-interval | https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/deployment/config/#restart-strategy-failure-rate-max-failures-per-interval |
| flink.restart-strategy.failure-rate.failure-rate-interval | restart-strategy.failure-rate.failure-rate-interval | https://nightlies.apache.org/flink/flink-docs-release-1.12/deployment/config.html#restart-strategy-failure-rate-failure-rate-interval | https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/deployment/config/#restart-strategy-failure-rate-failure-rate-interval |
| flink.restart-strategy.failure-rate.delay | restart-strategy.failure-rate.delay | https://nightlies.apache.org/flink/flink-docs-release-1.12/deployment/config.html#restart-strategy-failure-rate-delay | https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/deployment/config/#restart-strategy-failure-rate-delay |
| flink.restart-strategy.fixed-delay.attempts | restart-strategy.fixed-delay.attempts | https://nightlies.apache.org/flink/flink-docs-release-1.12/deployment/config.html#restart-strategy-fixed-delay-attempts | https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/deployment/config/#restart-strategy-fixed-delay-attempts |
| flink.restart-strategy.fixed-delay.delay | restart-strategy.fixed-delay.delay | https://nightlies.apache.org/flink/flink-docs-release-1.12/deployment/config.html#restart-strategy-fixed-delay-delay | https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/deployment/config/#restart-strategy-fixed-delay-delay |


## What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

## Purpose of this pull request

Simplify restartStrategy related configuration.
