### PR TITLE
[Feature] Simplify the configuration of runtime-mode and parallelism-default

### DIFF
--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
@@ -114,8 +114,6 @@ object ConfigConst {
 
   val KEY_YARN_APP_QUEUE = "yarn.application.queue"
 
-  val KEY_EXECUTION_RUNTIME_MODE = "flink.execution.runtime-mode"
-
   // ---table---
   val KEY_FLINK_TABLE_PLANNER = "flink.table.planner"
 

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializer.scala
@@ -21,16 +21,13 @@ import org.apache.streampark.common.enums.ApiType
 import org.apache.streampark.common.enums.ApiType.ApiType
 import org.apache.streampark.common.util._
 
-import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.java.utils.ParameterTool
-import org.apache.flink.configuration.CoreOptions
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.TableConfig
 
 import java.io.File
 import collection.JavaConversions._
 import collection.Map
-import util.Try
 
 private[flink] object FlinkStreamingInitializer {
 
@@ -154,15 +151,6 @@ private[flink] class FlinkStreamingInitializer(args: Array[String], apiType: Api
 
   def initEnvironment(): Unit = {
     localStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment
-    Try(parameter.get(KEY_FLINK_PARALLELISM()).toInt).getOrElse {
-      Try(parameter.get(CoreOptions.DEFAULT_PARALLELISM.key()).toInt).getOrElse(CoreOptions.DEFAULT_PARALLELISM.defaultValue().toInt)
-    } match {
-      case p if p > 0 => localStreamEnv.setParallelism(p)
-      case _ => throw new IllegalArgumentException("[StreamPark] parallelism must be > 0. ")
-    }
-
-    val executionMode = Try(RuntimeExecutionMode.valueOf(parameter.get(KEY_EXECUTION_RUNTIME_MODE))).getOrElse(RuntimeExecutionMode.STREAMING)
-    localStreamEnv.setRuntimeMode(executionMode)
 
     apiType match {
       case ApiType.java if javaStreamEnvConfFunc != null => javaStreamEnvConfFunc.configuration(localStreamEnv.getJavaEnv, parameter)


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: close #1761 

Problem Summary:

Click  #1739 to get detailed background.

Simplify runtime-mode and parallelism-default configuration.

| StreamPark Configuration | Flink Configuration | Flink 1.12 doc | Flink 1.15 doc |
| --- | --- | --- | --- |
| flink.execution.runtime-mode | execution.runtime-mode | https://nightlies.apache.org/flink/flink-docs-release-1.12/deployment/config.html#execution-runtime-mode | https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/deployment/config/#execution-runtime-mode |
| parallelism.default | parallelism.default | They are same, just remove some code |  |

## What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

## Purpose of this pull request

Simplify runtime-mode and parallelism-default configuration.
