### PR TITLE
[bug] [fix] [streampark-flink-shims-base] Repair multiple dialect set statement have no effect error.

### DIFF
--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/src/main/scala/org/apache/streampark/flink/core/SqlCommandParser.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/src/main/scala/org/apache/streampark/flink/core/SqlCommandParser.scala
@@ -84,7 +84,7 @@ object SqlCommandParser extends Logger {
             } else {
               throw new UnsupportedOperationException("flink sql syntax error, no executable sql")
             }
-          case r => r.sortWith((a, b) => a.lineStart < b.lineStart)
+          case r => r
         }
     }
   }

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims-test/src/test/scala/org/apache/streampark/flink/core/test/FlinkSqlExecuteFunSuite.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims-test/src/test/scala/org/apache/streampark/flink/core/test/FlinkSqlExecuteFunSuite.scala
@@ -42,6 +42,8 @@ class FlinkSqlExecuteFunSuite extends AnyFunSuite {
         |reset 'table.local-time-zone';
         |reset;
         |
+        |set 'table.sql-dialect' = 'default';
+        |
         |CREATE temporary TABLE source_kafka1(
         |    `id` int COMMENT '',
         |    `name` string COMMENT '',
@@ -59,6 +61,8 @@ class FlinkSqlExecuteFunSuite extends AnyFunSuite {
         |    'csv.allow-comments' = 'true'
         |);
         |
+        |set 'table.sql-dialect' = 'hive';
+        |
         |create table sink_kafka1(
         |    `id` int COMMENT '',
         |    `name` string COMMENT '',
@@ -69,6 +73,8 @@ class FlinkSqlExecuteFunSuite extends AnyFunSuite {
         |    'properties.bootstrap.servers' = 'node01:9092,node02:9092,node03:9092',
         |    'format' = 'csv'
         |);
+        |
+        |set 'table.sql-dialect' = 'default';
         |
         |insert into sink_kafka1
         |select id, name, age


### PR DESCRIPTION
#1702 
 Repair multiple dialect set statement have no effect error.

Cause：The sql statement sorts the results at the end of the parseSQL function, disrupting the original order of statements filled by the user, so that all set statements are moved to the beginning and the middle set statement is not executed in its original position.