### PR TITLE
[Bug] Fix the job cannot be start due to wrong type

### DIFF
--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/src/main/scala/org/apache/streampark/flink/core/FlinkTableInitializer.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/src/main/scala/org/apache/streampark/flink/core/FlinkTableInitializer.scala
@@ -138,7 +138,10 @@ private[flink] class FlinkTableInitializer(args: Array[String], apiType: ApiType
         case null | "" =>
           logWarn("Usage:can't fond config,you can set \"--conf $path \" in main arguments")
           ParameterTool.fromSystemProperties().mergeWith(argsMap) -> new Configuration()
-        case file => super.parseConfig(file)
+        case file =>
+          val (userConf, flinkConf) = super.parseConfig(file)
+          // config priority: explicitly specified priority > project profiles > system profiles
+          ParameterTool.fromSystemProperties().mergeWith(ParameterTool.fromMap(userConf)).mergeWith(argsMap) -> Configuration.fromMap(flinkConf)
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #1823 

It is caused by #1820

## Brief change log

Fix the job cannot be start due to wrong type

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
