### PR TITLE
[bug] [fix] [streampark-flink-shims-base] Repair multiple dialect set statement have no effect error.

### DIFF
--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/src/main/scala/org/apache/streampark/flink/core/SqlCommandParser.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/src/main/scala/org/apache/streampark/flink/core/SqlCommandParser.scala
@@ -84,7 +84,7 @@ object SqlCommandParser extends Logger {
             } else {
               throw new UnsupportedOperationException("flink sql syntax error, no executable sql")
             }
-          case r => r.sortWith((a, b) => a.lineStart < b.lineStart)
+          case r => r
         }
     }
   }

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/YarnPerJobSubmit.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/YarnPerJobSubmit.scala
@@ -96,7 +96,7 @@ object YarnPerJobSubmit extends YarnSubmitTrait {
           submitRequest.effectiveAppName,
           classOf[YarnJobClusterEntrypoint].getName,
           jobGraph,
-          false
+          true
         ).getClusterClient
 
       }


### PR DESCRIPTION
Repair multiple dialect set statement have no effect error.

Cause：The sql statement sorts the results at the end of the parseSQL function, disrupting the original order of statements filled by the user, so that all set statements are moved to the beginning and the middle set statement is not executed in its original position.