### PR TITLE
[Bug] Fix the bug that latest team isn't changed when team is changed

### DIFF
--- a/streampark-console/streampark-console-webapp/src/utils/request.js
+++ b/streampark-console/streampark-console-webapp/src/utils/request.js
@@ -78,7 +78,7 @@ http.interceptors.request.use(config => {
       }
     }
     const teamId = sessionStorage.getItem(TEAM_ID)
-    if (teamId) {
+    if (data['teamId'] == null && teamId) {
       data['teamId'] = teamId
     }
     if (config.method === 'get') {


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #1833 

Fix the bug that latest team isn't changed when team is changed

## Brief change log

Fix the bug that latest team isn't changed when team is changed


Root cause:

https://github.com/apache/incubator-streampark/blob/f43646ec0d65aea5d7d2847c2097aae9975f8f0d/streampark-console/streampark-console-webapp/src/components/tools/UserMenu.vue#L330

When the team is changed, `handleChangeTeam` will call the backend with the new teamId. However, `request.js` change the teamId to the old teamId.

Solution:

When the `data['teamId'] == null`, `request.js` can change the teamId.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
