### PR TITLE
Fix the wrong method name

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/UserController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/UserController.java
@@ -205,9 +205,9 @@ public class UserController {
     }
 
     @PostMapping("appOwners")
-    public RestResponse appOnwers(Long teamId) {
+    public RestResponse appOwners(Long teamId) {
         List<User> userList = userService.findByAppOwner(teamId);
-        userList.forEach((u) -> u.dataMasking());
+        userList.forEach(User::dataMasking);
         return RestResponse.success(userList);
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #xxx

Fix the wrong method name.

## Brief change log

Fix the wrong method name. Change the method name from `appOnwers` to `appOwners`.

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
