### PR TITLE
[Improve] after change team the routers need to be regenerated

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/MenuController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/MenuController.java
@@ -53,8 +53,8 @@ public class MenuController {
     private CommonService commonService;
 
     @PostMapping("router")
-    public RestResponse getUserRouters() {
-        ArrayList<VueRouter<Menu>> routers = this.menuService.getUserRouters(commonService.getCurrentUser());
+    public RestResponse getUserRouters(Long teamId) {
+        ArrayList<VueRouter<Menu>> routers = this.menuService.getUserRouters(commonService.getUserId(), teamId);
         return RestResponse.success(routers);
     }
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/PassportController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/PassportController.java
@@ -42,9 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.constraints.NotBlank;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 @Validated
 @RestController
@@ -91,29 +89,6 @@ public class PassportController {
         return new RestResponse();
     }
 
-    /**
-     * generate user info, contains: 1.token, 2.vue router, 3.role, 4.permission, 5.personalized config info of frontend
-     *
-     * @param token token
-     * @param user  user
-     * @return UserInfo
-     */
-    private Map<String, Object> generateUserInfo(JWTToken token, User user) {
-        String username = user.getUsername();
-        Map<String, Object> userInfo = new HashMap<>(8);
-        userInfo.put("token", token.getToken());
-        userInfo.put("expire", token.getExpireAt());
-
-        Set<String> roles = this.roleService.getUserRoleName(username);
-        userInfo.put("roles", roles);
-
-        Set<String> permissions = this.userService.getPermissions(username);
-        userInfo.put("permissions", permissions);
-        user.dataMasking();
-        userInfo.put("user", user);
-        return userInfo;
-    }
-
     private RestResponse login(String username, String password, User user) throws Exception {
         if (user == null) {
             return RestResponse.success().put("code", 0);
@@ -139,6 +114,7 @@ public class PassportController {
         JWTToken jwtToken = new JWTToken(token, expireTimeStr);
         String userId = RandomStringUtils.randomAlphanumeric(20);
         user.setId(userId);
-        return new RestResponse().data(this.generateUserInfo(jwtToken, user));
+        Map<String, Object> userInfo = userService.generateFrontendUserInfo(user, jwtToken);
+        return new RestResponse().data(userInfo);
     }
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/UserController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/UserController.java
@@ -47,10 +47,8 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Slf4j
 @Validated
@@ -185,22 +183,13 @@ public class UserController {
 
         User user = commonService.getCurrentUser();
 
-        //1) set latest team
+        //1) set the latest team
         userService.setLatestTeam(teamId, user.getUserId());
 
         //2) get latest userInfo
         user.dataMasking();
 
-        Map<String, Object> infoMap = new HashMap<>(8);
-        infoMap.put("user", user);
-
-        String username = user.getUsername();
-        Set<String> roles = this.roleService.getUserRoleName(username);
-        infoMap.put("roles", roles);
-
-        Set<String> permissions = this.userService.getPermissions(username);
-        infoMap.put("permissions", permissions);
-
+        Map<String, Object> infoMap = userService.generateFrontendUserInfo(user, null);
         return new RestResponse().data(infoMap);
     }
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/mapper/MenuMapper.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/mapper/MenuMapper.java
@@ -29,7 +29,7 @@ public interface MenuMapper extends BaseMapper<Menu> {
 
     List<Menu> findUserPermissions(String userName);
 
-    List<Menu> findUserMenus(String userName);
+    List<Menu> findUserMenus(@Param("userId")Long userId, @Param("teamId") Long teamId);
 
     /**
      * Find the user ID associated with the current menu or button

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/MenuService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/MenuService.java
@@ -19,7 +19,6 @@ package org.apache.streampark.console.system.service;
 
 import org.apache.streampark.console.base.domain.router.VueRouter;
 import org.apache.streampark.console.system.entity.Menu;
-import org.apache.streampark.console.system.entity.User;
 
 import com.baomidou.mybatisplus.extension.service.IService;
 
@@ -31,7 +30,7 @@ public interface MenuService extends IService<Menu> {
 
     List<Menu> findUserPermissions(String username);
 
-    List<Menu> findUserMenus(String username);
+    List<Menu> findUserMenus(Long userId, Long teamId);
 
     Map<String, Object> findMenus(Menu menu);
 
@@ -48,5 +47,5 @@ public interface MenuService extends IService<Menu> {
      */
     void deleteMenus(String[] menuIds) throws Exception;
 
-    ArrayList<VueRouter<Menu>> getUserRouters(User user);
+    ArrayList<VueRouter<Menu>> getUserRouters(Long userId, Long teamId);
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
@@ -18,12 +18,14 @@
 package org.apache.streampark.console.system.service;
 
 import org.apache.streampark.console.base.domain.RestRequest;
+import org.apache.streampark.console.system.authentication.JWTToken;
 import org.apache.streampark.console.system.entity.User;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.service.IService;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public interface UserService extends IService<User> {
@@ -112,4 +114,6 @@ public interface UserService extends IService<User> {
     void fillInTeam(User user);
 
     List<User> findByAppOwner(Long teamId);
+
+    Map<String, Object> generateFrontendUserInfo(User user, JWTToken token);
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/MenuServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/MenuServiceImpl.java
@@ -65,14 +65,14 @@ public class MenuServiceImpl extends ServiceImpl<MenuMapper, Menu> implements Me
     }
 
     @Override
-    public List<Menu> findUserMenus(String username) {
-        User user = Optional.ofNullable(userService.findByName(username))
-            .orElseThrow(() -> new IllegalArgumentException(String.format("The username [%s] not found", username)));
+    public List<Menu> findUserMenus(Long userId, Long teamId) {
+        User user = Optional.ofNullable(userService.getById(userId))
+            .orElseThrow(() -> new IllegalArgumentException(String.format("The user, id:[%s] not found", userId)));
         // Admin has the permission for all menus.
         if (UserType.ADMIN.equals(user.getUserType())) {
             return this.list(new LambdaQueryWrapper<Menu>().eq(Menu::getType, "0").orderByAsc(Menu::getOrderNum));
         }
-        return this.baseMapper.findUserMenus(username);
+        return this.baseMapper.findUserMenus(userId, teamId);
     }
 
     @Override
@@ -139,10 +139,10 @@ public class MenuServiceImpl extends ServiceImpl<MenuMapper, Menu> implements Me
     }
 
     @Override
-    public ArrayList<VueRouter<Menu>> getUserRouters(User user) {
+    public ArrayList<VueRouter<Menu>> getUserRouters(Long userId, Long teamId) {
         List<VueRouter<Menu>> routes = new ArrayList<>();
         // The query type is the menu type
-        List<Menu> menus = this.findUserMenus(user.getUsername());
+        List<Menu> menus = this.findUserMenus(userId, teamId);
         menus.forEach(menu -> {
             VueRouter<Menu> route = new VueRouter<>();
             route.setId(menu.getMenuId().toString());

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
@@ -21,6 +21,7 @@ import org.apache.streampark.common.util.AssertUtils;
 import org.apache.streampark.console.base.domain.RestRequest;
 import org.apache.streampark.console.base.exception.ApiAlertException;
 import org.apache.streampark.console.base.util.ShaHashUtils;
+import org.apache.streampark.console.system.authentication.JWTToken;
 import org.apache.streampark.console.system.entity.Member;
 import org.apache.streampark.console.system.entity.Menu;
 import org.apache.streampark.console.system.entity.Team;
@@ -28,6 +29,7 @@ import org.apache.streampark.console.system.entity.User;
 import org.apache.streampark.console.system.mapper.UserMapper;
 import org.apache.streampark.console.system.service.MemberService;
 import org.apache.streampark.console.system.service.MenuService;
+import org.apache.streampark.console.system.service.RoleService;
 import org.apache.streampark.console.system.service.UserService;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
@@ -44,7 +46,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -58,6 +62,9 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
 
     @Autowired
     private MenuService menuService;
+
+    @Autowired
+    private RoleService roleService;
 
     @Override
     public User findByName(String username) {
@@ -201,6 +208,39 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     @Override
     public List<User> findByAppOwner(Long teamId) {
         return baseMapper.findByAppOwner(teamId);
+    }
+
+    /**
+     * generate user info, contains: 1.token, 2.vue router, 3.role, 4.permission, 5.personalized config info of frontend
+     *
+     * @param user  user
+     * @return UserInfo
+     */
+    @Override
+    public Map<String, Object> generateFrontendUserInfo(User user, JWTToken token) {
+        AssertUtils.checkNotNull(user);
+        String username = user.getUsername();
+        Map<String, Object> userInfo = new HashMap<>(8);
+
+        // 1) token & expire
+        if (token != null) {
+            userInfo.put("token", token.getToken());
+            userInfo.put("expire", token.getExpireAt());
+        }
+
+        // 2) user
+        user.dataMasking();
+        userInfo.put("user", user);
+
+        // 3) roles
+        Set<String> roles = this.roleService.getUserRoleName(username);
+        userInfo.put("roles", roles);
+
+        // 4) permissions
+        Set<String> permissions = this.getPermissions(username);
+        userInfo.put("permissions", permissions);
+
+        return userInfo;
     }
 
     private void setUserRoles(User user, String[] roles) {

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/MenuMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/MenuMapper.xml
@@ -49,15 +49,13 @@
 
     <select id="findUserMenus" resultMap="menu">
         select m.*
-        from t_menu m
+        from t_menu m inner join t_role_menu rm
+        on m.menu_id = rm.menu_id
+        inner join t_member mr
+        on rm.role_id = mr.role_id
         where m.type &lt;&gt; 1
-          and m.menu_id in
-              (select distinct rm.menu_id
-               from t_role_menu rm
-                        left join t_role r on (rm.role_id = r.role_id)
-                        left join t_member ur on (ur.role_id = r.role_id)
-                        left join t_user u on (u.user_id = ur.user_id)
-               where u.username = #{userName})
+        and mr.user_id = #{userId}
+        and mr.team_id = #{teamId}
         order by m.order_num
     </select>
 

--- a/streampark-console/streampark-console-webapp/src/components/tools/UserMenu.vue
+++ b/streampark-console/streampark-console-webapp/src/components/tools/UserMenu.vue
@@ -317,10 +317,10 @@ export default {
     },
 
     handlePrepareTeam() {
-      let id = sessionStorage.getItem(TEAM_ID)
+      let id = storage.getSession(TEAM_ID)
       if (id == null) {
         id = storage.get(TEAM_ID)
-        sessionStorage.setItem(TEAM_ID, id)
+        storage.setSession(TEAM_ID, id)
       }
       this.teamId = id.toString()
     },
@@ -344,29 +344,29 @@ export default {
         '/system/member',
         '/system/variable',
         '/flink/project',
-        '/flink/app'
-      ]
-      const skipPages = [
-        '/flink/notebook/view',
+        '/flink/app',
         '/flink/setting'
       ]
+      const whiteList = [
+        '/flink/notebook/view',
+      ]
       const currPath = location.href.replace(/(.*)#/,'')
-      if (!skipPages.includes(currPath)) {
-        if (pages.includes(currPath)) {
-          this.GetRouter({}).then(resp => {
-            const routers = resp || []
-            if (routers != null) {
-              const hasAuth = this.handleFilterRouter(routers[0], currPath)
-              if (hasAuth) {
-                window.location.reload()
-              } else {
-                window.location.href = '/'
-              }
+      if (pages.includes(currPath)) {
+        this.GetRouter({}).then(resp => {
+          const routers = resp || []
+          if (routers != null) {
+            const hasAuth = this.handleFilterRouter(routers[0], currPath)
+            if (hasAuth) {
+              window.location.reload()
+            } else {
+              window.location.href = '/'
             }
-          })
-        } else {
-          window.location.href = '/'
-        }
+          }
+        })
+      } else if (whiteList.includes(currPath)) {
+        window.location.reload()
+      } else {
+        window.location.href = '/'
       }
     },
 

--- a/streampark-console/streampark-console-webapp/src/store/modules/user.js
+++ b/streampark-console/streampark-console-webapp/src/store/modules/user.js
@@ -26,10 +26,10 @@ const user = {
     expire: storage.get(EXPIRE),
     token: storage.get(TOKEN),
     info: storage.get(USER_INFO),
-    roles: storage.get(ROLES),
-    permissions: storage.get(PERMISSIONS),
-    routers: storage.get(USER_ROUTER),
-    teamId: storage.get(TEAM_ID),
+    roles: storage.getSession(ROLES) || storage.get(ROLES),
+    permissions: storage.getSession(PERMISSIONS) || storage.get(PERMISSIONS),
+    routers: storage.getSession(USER_ROUTER) || storage.get(USER_ROUTER),
+    teamId: storage.getSession(TEAM_ID) || storage.get(TEAM_ID),
     name: '',
     welcome: '',
     avatar: ''
@@ -44,27 +44,6 @@ const user = {
       storage.set(TOKEN, token)
       state.token = token
     },
-    SET_TEAM: (state, teamId) => {
-      sessionStorage.setItem(TEAM_ID, teamId)
-      storage.set(TEAM_ID, teamId)
-      state.teamId = teamId
-    },
-    SET_ROLES: (state, roles) => {
-      storage.set(ROLES, roles)
-      state.roles = roles
-    },
-    SET_PERMISSIONS: (state, permissions) => {
-      storage.set(PERMISSIONS, permissions)
-      state.permissions = permissions
-    },
-    SET_ROUTERS: (state, routers) => {
-      storage.set(USER_ROUTER, routers)
-      state.routers = routers
-    },
-    CLEAR_ROUTERS: (state, empty) => {
-      state.roles = null
-      storage.rm(USER_ROUTER)
-    },
     SET_INFO: (state, info) => {
       storage.set(USER_INFO, info)
       storage.set(USER_NAME, info.username)
@@ -72,6 +51,32 @@ const user = {
       state.name = info.username
       state.avatar = info.avatar
     },
+    SET_TEAM: (state, teamId) => {
+      storage.setSession(TEAM_ID, teamId)
+      storage.set(TEAM_ID, teamId)
+      state.teamId = teamId
+    },
+    SET_ROLES: (state, roles) => {
+      storage.set(ROLES, roles)
+      storage.setSession(ROLES, roles)
+      state.roles = roles
+    },
+    SET_PERMISSIONS: (state, permissions) => {
+      storage.set(PERMISSIONS, permissions)
+      storage.setSession(PERMISSIONS, permissions)
+      state.permissions = permissions
+    },
+    SET_ROUTERS: (state, routers) => {
+      storage.set(USER_ROUTER, routers)
+      storage.setSession(USER_ROUTER, routers)
+      state.routers = routers
+    },
+    CLEAR_ROUTERS: (state, empty) => {
+      state.roles = null
+      storage.rm(USER_ROUTER)
+      storage.rmSession(USER_ROUTER)
+    },
+
     SET_EMPTY: (state, empty) => {
       state.token = null
       state.info = null
@@ -82,12 +87,18 @@ const user = {
       state.avatar = null
       storage.rm(USER_INFO)
       storage.rm(USER_NAME)
-      storage.rm(USER_ROUTER)
       storage.rm(TOKEN)
+      storage.rm(EXPIRE)
+
+      storage.rm(USER_ROUTER)
       storage.rm(TEAM_ID)
       storage.rm(ROLES)
       storage.rm(PERMISSIONS)
-      storage.rm(EXPIRE)
+
+      storage.rmSession(USER_ROUTER)
+      storage.rmSession(TEAM_ID)
+      storage.rmSession(ROLES)
+      storage.rmSession(PERMISSIONS)
     }
   },
 

--- a/streampark-console/streampark-console-webapp/src/store/modules/user.js
+++ b/streampark-console/streampark-console-webapp/src/store/modules/user.js
@@ -61,6 +61,10 @@ const user = {
       storage.set(USER_ROUTER, routers)
       state.routers = routers
     },
+    CLEAR_ROUTERS: (state, empty) => {
+      state.roles = null
+      storage.rm(USER_ROUTER)
+    },
     SET_INFO: (state, info) => {
       storage.set(USER_INFO, info)
       storage.set(USER_NAME, info.username)
@@ -149,6 +153,7 @@ const user = {
             commit('SET_ROLES', respData.roles)
             commit('SET_PERMISSIONS', respData.permissions)
             commit('SET_INFO', respData.user)
+            commit('CLEAR_ROUTERS', null)
             resolve()
           }).catch(error => {
             reject(error)

--- a/streampark-console/streampark-console-webapp/src/utils/request.js
+++ b/streampark-console/streampark-console-webapp/src/utils/request.js
@@ -77,10 +77,11 @@ http.interceptors.request.use(config => {
         delete data.sortOrder
       }
     }
-    const teamId = sessionStorage.getItem(TEAM_ID)
+    const teamId = storage.getSession(TEAM_ID)
     if (data['teamId'] == null && teamId) {
       data['teamId'] = teamId
     }
+
     if (config.method === 'get') {
       // filter undefined params
       data = Object.fromEntries(Object.entries(data).filter(([_,value]) => value !== undefined))

--- a/streampark-console/streampark-console-webapp/src/utils/storage.js
+++ b/streampark-console/streampark-console-webapp/src/utils/storage.js
@@ -83,12 +83,51 @@ const storage = {
     window.localStorage.removeItem(name)
     window.localStorage.removeItem(`${name}_EXPIRE`)
   },
+
   clear: () => {
     if (!global.window || !name) {
       return
     }
     window.localStorage.clear()
-  }
+  },
+
+  setSession: (name, content) => {
+    name = config.storageOptions.namespace + name
+    if (!global.window || !name) {
+      return
+    }
+    if (typeof content !== 'string') {
+      content = JSON.stringify(content)
+    }
+    const storage = global.window.sessionStorage
+    storage.setItem(name, content)
+  },
+
+  getSession: (name, defValue) => {
+    name = config.storageOptions.namespace + name
+    defValue = defValue === undefined ? null : defValue
+    if (!global.window || !name) {
+      return defValue
+    }
+    const storage = global.window.sessionStorage
+    const content = storage.getItem(name)
+    if (!content) return defValue
+    try {
+      return JSON.parse(content)
+    } catch (e) {
+      return content
+    }
+  },
+
+  rmSession: (name) => {
+    name = config.storageOptions.namespace + name
+    if (!global.window || !name) {
+      return
+    }
+    window.sessionStorage.removeItem(name)
+  },
+
+
 }
 
 export default storage


### PR DESCRIPTION
When switching teams, the backend to re-return the user's latest role, permissions, and router, the front-end needs to re-render the router

Currently, the backend does not return the latest router, The front-end also did not rebuild the generated router



## What changes were proposed in this pull request

Issue Number: close #1867 

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
