### PR TITLE
[Improve] query data using primary key #1871

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/CommonServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/CommonServiceImpl.java
@@ -46,8 +46,8 @@ public class CommonServiceImpl implements CommonService {
     @Override
     public User getCurrentUser() {
         String token = (String) SecurityUtils.getSubject().getPrincipal();
-        String username = JWTUtil.getUsername(token);
-        return userService.findByName(username);
+        Long userId = JWTUtil.getUserId(token);
+        return userService.getById(userId);
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/authentication/JWTUtil.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/authentication/JWTUtil.java
@@ -27,7 +27,6 @@ import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.authc.AuthenticationException;
 
 import java.util.Date;
@@ -48,7 +47,7 @@ public class JWTUtil {
     public static boolean verify(String token, String username, String secret) {
         try {
             Algorithm algorithm = Algorithm.HMAC256(secret);
-            JWTVerifier verifier = JWT.require(algorithm).withClaim("username", username).build();
+            JWTVerifier verifier = JWT.require(algorithm).withClaim("userName", username).build();
             verifier.verify(token);
             return true;
         } catch (TokenExpiredException e) {
@@ -62,10 +61,20 @@ public class JWTUtil {
     /**
      * get username from token
      */
-    public static String getUsername(String token) {
+    public static String getUserName(String token) {
         try {
             DecodedJWT jwt = JWT.decode(token);
-            return jwt.getClaim("username").asString();
+            return jwt.getClaim("userName").asString();
+        } catch (JWTDecodeException e) {
+            log.info("error：{}", e.getMessage());
+            return null;
+        }
+    }
+
+    public static Long getUserId(String token) {
+        try {
+            DecodedJWT jwt = JWT.decode(token);
+            return jwt.getClaim("userId").asLong();
         } catch (JWTDecodeException e) {
             log.info("error：{}", e.getMessage());
             return null;
@@ -74,29 +83,32 @@ public class JWTUtil {
 
     /**
      * generate token
-     *
-     * @param username username
-     * @param secret   secret
-     * @return token
+     * @param userId
+     * @param userName
+     * @param secret
+     * @return
      */
-    public static String sign(String username, String secret) {
-        return sign(username, secret, getExpireTime());
+    public static String sign(Long userId, String userName, String secret) {
+        return sign(userId, userName, secret, getExpireTime());
     }
 
     /**
      * generate token
-     *
-     * @param username     username
-     * @param secret       secret
-     * @param expireTime   token expire time
-     * @return token
+     * @param userId
+     * @param userName
+     * @param secret
+     * @param expireTime
+     * @return
      */
-    public static String sign(String username, String secret, Long expireTime) {
+    public static String sign(Long userId, String userName, String secret, Long expireTime) {
         try {
-            username = StringUtils.lowerCase(username);
             Date date = new Date(expireTime);
             Algorithm algorithm = Algorithm.HMAC256(secret);
-            return JWT.create().withClaim("username", username).withExpiresAt(date).sign(algorithm);
+            return JWT.create()
+                .withClaim("userId", userId)
+                .withClaim("userName", userName)
+                .withExpiresAt(date)
+                .sign(algorithm);
         } catch (Exception e) {
             log.info("error：{}", e);
             return null;

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/authentication/ShiroRealm.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/authentication/ShiroRealm.java
@@ -65,16 +65,16 @@ public class ShiroRealm extends AuthorizingRealm {
      */
     @Override
     protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection token) {
-        String username = JWTUtil.getUsername(token.toString());
+        Long userId = JWTUtil.getUserId(token.toString());
 
         SimpleAuthorizationInfo simpleAuthorizationInfo = new SimpleAuthorizationInfo();
 
         // Get user role set
-        Set<String> roleSet = roleService.getUserRoleName(username);
+        Set<String> roleSet = roleService.getUserRoleName(userId);
         simpleAuthorizationInfo.setRoles(roleSet);
 
         // Get user permission set
-        Set<String> permissionSet = userService.getAllTeamPermissions(username);
+        Set<String> permissionSet = userService.getPermissions(userId, null);
         simpleAuthorizationInfo.setStringPermissions(permissionSet);
         return simpleAuthorizationInfo;
     }
@@ -90,11 +90,11 @@ public class ShiroRealm extends AuthorizingRealm {
     protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken authenticationToken) throws AuthenticationException {
         // The token here is passed from the executeLogin method of JWTFilter and has been decrypted
         String token = (String) authenticationToken.getCredentials();
-        String username = JWTUtil.getUsername(token);
+        String username = JWTUtil.getUserName(token);
         if (StringUtils.isBlank(username)) {
             throw new AuthenticationException("Token verification failed");
         }
-        // Query user information by user name
+        // Query user information by username
         User user = userService.findByName(username);
 
         if (user == null) {

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/PassportController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/PassportController.java
@@ -108,7 +108,7 @@ public class PassportController {
         password = ShaHashUtils.encrypt(user.getSalt(), password);
 
         this.userService.updateLoginTime(username);
-        String token = WebUtils.encryptToken(JWTUtil.sign(username, password));
+        String token = WebUtils.encryptToken(JWTUtil.sign(user.getUserId(), username, password));
         LocalDateTime expireTime = LocalDateTime.now().plusSeconds(properties.getJwtTimeOut());
         String expireTimeStr = DateUtils.formatFullTime(expireTime);
         JWTToken jwtToken = new JWTToken(token, expireTimeStr);

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/mapper/RoleMapper.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/mapper/RoleMapper.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 public interface RoleMapper extends BaseMapper<Role> {
 
-    List<Role> findUserRole(String userName);
+    List<Role> findUserRole(Long userId);
 
     IPage<Role> findRole(Page<Role> page, @Param("role") Role role);
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/RoleService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/RoleService.java
@@ -28,11 +28,11 @@ import java.util.Set;
 
 public interface RoleService extends IService<Role> {
 
-    Set<String> getUserRoleName(String username);
+    Set<String> getUserRoleName(Long userId);
 
     IPage<Role> findRoles(Role role, RestRequest request);
 
-    List<Role> findUserRole(String userName);
+    List<Role> findUserRole(Long userId);
 
     Role findByName(String roleName);
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
@@ -107,8 +107,6 @@ public interface UserService extends IService<User> {
      */
     void resetPassword(String[] usernames) throws Exception;
 
-    Set<String> getAllTeamPermissions(String username);
-
     /**
      * Get the permissions of current userId.
      *

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/AccessTokenServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/AccessTokenServiceImpl.java
@@ -67,7 +67,7 @@ public class AccessTokenServiceImpl extends ServiceImpl<AccessTokenMapper, Acces
         }
 
         Long ttl = DateUtils.getTime(expireTime, DateUtils.fullFormat(), TimeZone.getDefault());
-        String token = WebUtils.encryptToken(JWTUtil.sign(user.getUsername(), UUID.randomUUID().toString(), ttl));
+        String token = WebUtils.encryptToken(JWTUtil.sign(user.getUserId(), user.getUsername(), UUID.randomUUID().toString(), ttl));
         JWTToken jwtToken = new JWTToken(token, expireTime);
 
         AccessToken accessToken = new AccessToken();

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/RoleServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/RoleServiceImpl.java
@@ -62,8 +62,8 @@ public class RoleServiceImpl extends ServiceImpl<RoleMapper, Role> implements Ro
     private RoleMenuServie roleMenuService;
 
     @Override
-    public Set<String> getUserRoleName(String username) {
-        List<Role> roleList = this.findUserRole(username);
+    public Set<String> getUserRoleName(Long userId) {
+        List<Role> roleList = this.findUserRole(userId);
         return roleList.stream().map(Role::getRoleName).collect(Collectors.toSet());
     }
 
@@ -76,8 +76,8 @@ public class RoleServiceImpl extends ServiceImpl<RoleMapper, Role> implements Ro
     }
 
     @Override
-    public List<Role> findUserRole(String userName) {
-        return baseMapper.findUserRole(userName);
+    public List<Role> findUserRole(Long userId) {
+        return baseMapper.findUserRole(userId);
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
@@ -160,17 +160,6 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
         }
     }
 
-    /**
-     * get user permissions by name
-     *
-     * @param username name
-     * @return permissions
-     */
-    @Override
-    public Set<String> getAllTeamPermissions(String username) {
-        return getPermissions(this.findByName(username).getUserId(), null);
-    }
-
     @Override
     public Set<String> getPermissions(Long userId, @Nullable Long teamId) {
         List<String> userPermissions = this.menuService.findUserPermissions(userId, teamId);
@@ -239,7 +228,7 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
         userInfo.put("user", user);
 
         // 3) roles
-        Set<String> roles = this.roleService.getUserRoleName(username);
+        Set<String> roles = this.roleService.getUserRoleName(user.getUserId());
         userInfo.put("roles", roles);
 
         // 4) permissions

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/MenuMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/MenuMapper.xml
@@ -42,7 +42,7 @@
         left join t_role_menu rm on (rm.role_id = r.role_id)
         left join t_menu m on (m.menu_id = rm.menu_id)
         where ur.user_id = #{userId}
-          and (#{teamId} is null or ur.team_id = #{teamId})
+        and (#{teamId} is null or ur.team_id = #{teamId})
         and m.perms is not null
         and m.perms &lt;&gt; ''
     </select>

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/RoleMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/RoleMapper.xml
@@ -33,7 +33,7 @@
         from t_role r
         left join t_member m on r.role_id = m.role_id
         left join t_user u on u.user_id = m.user_id
-        where u.username = #{userName}
+        where u.user_id = #{userId}
     </select>
 
     <select id="findRole" resultType="role" parameterType="role">

--- a/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/system/authentication/JWTTest.java
+++ b/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/system/authentication/JWTTest.java
@@ -35,7 +35,7 @@ public class JWTTest {
         String userName = "black";
         String secret = UUID.randomUUID().toString();
         String expireTime = AccessToken.DEFAULT_EXPIRE_TIME;
-        String token = JWTUtil.sign(userName, secret, DateUtils.getTime(expireTime, DateUtils.fullFormat(), TimeZone.getDefault()));
+        String token = JWTUtil.sign(10000L, userName, secret, DateUtils.getTime(expireTime, DateUtils.fullFormat(), TimeZone.getDefault()));
 
         assert token != null;
         Date expiresAt = JWT.decode(token).getExpiresAt();


### PR DESCRIPTION
Currently, on the streampark platform side, many queries, such as `getUserRoleName`, `findUserRole`, etc. are based on the current login user name, which can be further improved and use userId to query uniformly.

## What changes were proposed in this pull request

Issue Number: close #1871 

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
