### PR TITLE
[bug]Resolve the problem that the flink jobid stored in the trackid i…

### DIFF
--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
@@ -45,11 +45,7 @@ object ConfigConst {
   val KEY_PASSWORD = "password"
 
   val KEY_TIMEOUT = "timeout"
-
-  val KEY_JOB_ID = "jobId"
-
-  val KEY_FLINK_JOB_ID = "flinkJobId"
-
+  
   val KEY_SEMANTIC = "semantic"
 
   /**

--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
@@ -45,7 +45,7 @@ object ConfigConst {
   val KEY_PASSWORD = "password"
 
   val KEY_TIMEOUT = "timeout"
-  
+
   val KEY_SEMANTIC = "semantic"
 
   /**

--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/ConfigConst.scala
@@ -48,6 +48,8 @@ object ConfigConst {
 
   val KEY_JOB_ID = "jobId"
 
+  val KEY_FLINK_JOB_ID = "flinkJobId"
+
   val KEY_SEMANTIC = "semantic"
 
   /**

--- a/streampark-common/src/main/scala/org/apache/streampark/common/enums/ApplicationType.java
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/enums/ApplicationType.java
@@ -19,7 +19,6 @@ package org.apache.streampark.common.enums;
 
 import java.io.Serializable;
 
-
 public enum ApplicationType implements Serializable {
     /**
      * StreamPark Flink

--- a/streampark-common/src/main/scala/org/apache/streampark/common/enums/DevelopmentMode.java
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/enums/DevelopmentMode.java
@@ -19,7 +19,6 @@ package org.apache.streampark.common.enums;
 
 import java.io.Serializable;
 
-
 public enum DevelopmentMode implements Serializable {
 
     /**

--- a/streampark-common/src/main/scala/org/apache/streampark/common/enums/ExecutionMode.java
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/enums/ExecutionMode.java
@@ -22,8 +22,6 @@ import com.google.common.collect.Lists;
 import java.io.Serializable;
 import java.util.List;
 
-
-
 public enum ExecutionMode implements Serializable {
 
     /**

--- a/streampark-common/src/main/scala/org/apache/streampark/common/enums/Semantic.java
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/enums/Semantic.java
@@ -19,8 +19,6 @@ package org.apache.streampark.common.enums;
 
 import java.io.Serializable;
 
-
-
 public enum Semantic implements Serializable {
 
     /**

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
@@ -105,6 +105,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
@@ -1340,6 +1341,7 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             buildResult = new ShadedBuildResponse(null, flinkUserJar, true);
         } else {
             if (ExecutionMode.isKubernetesApplicationMode(application.getExecutionMode())) {
+                extraParameter.put(ConfigConst.KEY_FLINK_JOB_ID(), new JobID().toHexString());
                 AssertUtils.state(buildResult != null);
                 DockerImageBuildResponse result = buildResult.as(DockerImageBuildResponse.class);
                 String ingressTemplates = application.getIngressTemplate();

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
@@ -1285,7 +1285,6 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
         Map<String, String> dynamicOption = FlinkSubmitter.extractDynamicOptionAsJava(application.getDynamicOptions());
 
         Map<String, Object> extraParameter = new HashMap<>(0);
-        extraParameter.put(ConfigConst.KEY_JOB_ID(), application.getId());
 
         if (appParam.getAllowNonRestored()) {
             extraParameter.put(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key(), true);
@@ -1341,7 +1340,6 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             buildResult = new ShadedBuildResponse(null, flinkUserJar, true);
         } else {
             if (ExecutionMode.isKubernetesApplicationMode(application.getExecutionMode())) {
-                extraParameter.put(ConfigConst.KEY_FLINK_JOB_ID(), new JobID().toHexString());
                 AssertUtils.state(buildResult != null);
                 DockerImageBuildResponse result = buildResult.as(DockerImageBuildResponse.class);
                 String ingressTemplates = application.getIngressTemplate();
@@ -1372,6 +1370,8 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             DevelopmentMode.of(application.getJobType()),
             ExecutionMode.of(application.getExecutionMode()),
             resolveOrder,
+            application.getId(),
+            new JobID().toHexString(),
             application.getJobName(),
             appConf,
             application.getApplicationType(),

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/K8sFlinkTrackMonitorWrapper.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/K8sFlinkTrackMonitorWrapper.java
@@ -131,7 +131,7 @@ public class K8sFlinkTrackMonitorWrapper {
         public static TrackId toTrackId(@Nonnull Application app) {
             Enumeration.Value mode = FlinkK8sExecuteMode.of(app.getExecutionModeEnum());
             if (FlinkK8sExecuteMode.APPLICATION().equals(mode)) {
-                return TrackId.onApplication(app.getK8sNamespace(), app.getClusterId(), app.getId(), null);
+                return TrackId.onApplication(app.getK8sNamespace(), app.getClusterId(), app.getId(), app.getJobId());
             } else if (FlinkK8sExecuteMode.SESSION().equals(mode)) {
                 return TrackId.onSession(app.getK8sNamespace(), app.getClusterId(), app.getId(), app.getJobId());
             } else {

--- a/streampark-console/streampark-console-service/src/main/resources/application-mysql.yml
+++ b/streampark-console/streampark-console-service/src/main/resources/application-mysql.yml
@@ -18,6 +18,6 @@
 spring:
   datasource:
     username: root
-    password: streampark
+    password: 123456
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/streampark?useSSL=false&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=false&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=GMT%2B8
+    url: jdbc:mysql://10.30.238.21:3306/streampark?useSSL=false&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=false&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=GMT%2B8

--- a/streampark-console/streampark-console-service/src/main/resources/application-mysql.yml
+++ b/streampark-console/streampark-console-service/src/main/resources/application-mysql.yml
@@ -18,6 +18,6 @@
 spring:
   datasource:
     username: root
-    password: 123456
+    password: streampark
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://10.30.238.21:3306/streampark?useSSL=false&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=false&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=GMT%2B8
+    url: jdbc:mysql://localhost:3306/streampark?useSSL=false&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=false&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=GMT%2B8

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
@@ -86,8 +86,8 @@ class FlinkJobStatusWatcher(conf: JobStatusWatcherConfig = JobStatusWatcherConfi
    * single flink job status tracking task
    */
   override def doWatch(): Unit = {
-    this.synchronized{
-      logInfo("[FlinkJobStatusWatcher]: Status monitoring process begins - "+Thread.currentThread().getName)
+    this.synchronized {
+      logInfo("[FlinkJobStatusWatcher]: Status monitoring process begins - " + Thread.currentThread().getName)
       // get all legal tracking ids
       val trackIds = Try(trackController.collectAllTrackIds()).filter(_.nonEmpty).getOrElse(return)
       // retrieve flink job status in thread pool
@@ -130,7 +130,7 @@ class FlinkJobStatusWatcher(conf: JobStatusWatcherConfig = JobStatusWatcherConfi
           s" limitSeconds=${conf.requestTimeoutSec}," +
           s" trackIds=${trackIds.mkString(",")}")
       }
-      logInfo("[FlinkJobStatusWatcher]: End of status monitoring process - "+Thread.currentThread().getName)
+      logInfo("[FlinkJobStatusWatcher]: End of status monitoring process - " + Thread.currentThread().getName)
     }
   }
 

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
@@ -86,51 +86,48 @@ class FlinkJobStatusWatcher(conf: JobStatusWatcherConfig = JobStatusWatcherConfi
    * single flink job status tracking task
    */
   override def doWatch(): Unit = {
-    this.synchronized {
-      logInfo("[FlinkJobStatusWatcher]: Status monitoring process begins - " + Thread.currentThread().getName)
-      // get all legal tracking ids
-      val trackIds = Try(trackController.collectAllTrackIds()).filter(_.nonEmpty).getOrElse(return)
-      // retrieve flink job status in thread pool
-      val tracksFuture: Set[Future[Option[JobStatusCV]]] = trackIds.map { id =>
+    // get all legal tracking ids
+    val trackIds = Try(trackController.collectAllTrackIds()).filter(_.nonEmpty).getOrElse(return)
 
-        val future = Future {
-          id.executeMode match {
-            case SESSION => touchSessionJob(id)
-            case APPLICATION => touchApplicationJob(id)
-          }
+    // retrieve flink job status in thread pool
+    val tracksFuture: Set[Future[Option[JobStatusCV]]] = trackIds.map { id =>
+
+      val future = Future {
+        id.executeMode match {
+          case SESSION => touchSessionJob(id)
+          case APPLICATION => touchApplicationJob(id)
         }
-
-        future onComplete (_.getOrElse(None) match {
-          case Some(jobState) =>
-            val trackId = id.copy(jobId = jobState.jobId)
-            val latest: JobStatusCV = trackController.jobStatuses.get(trackId)
-            if (latest == null || latest.jobState != jobState.jobState || latest.jobId != jobState.jobId) {
-              // put job status to cache
-              trackController.jobStatuses.put(trackId, jobState)
-              // set jobId to trackIds
-              trackController.trackIds.update(trackId)
-              eventBus.postSync(FlinkJobStatusChangeEvent(trackId, jobState))
-            }
-            if (FlinkJobState.isEndState(jobState.jobState)) {
-              // remove trackId from cache of job that needs to be untracked
-              trackController.unTracking(trackId)
-              if (trackId.executeMode == APPLICATION) {
-                trackController.endpoints.invalidate(trackId.toClusterKey)
-              }
-            }
-          case _ =>
-        })
-        future
       }
 
-      // blocking until all future are completed or timeout is reached
-      Try(Await.ready(Future.sequence(tracksFuture), conf.requestTimeoutSec seconds))
-        .failed.map { _ =>
-        logInfo(s"[FlinkJobStatusWatcher] tracking flink job status on kubernetes mode timeout," +
-          s" limitSeconds=${conf.requestTimeoutSec}," +
-          s" trackIds=${trackIds.mkString(",")}")
-      }
-      logInfo("[FlinkJobStatusWatcher]: End of status monitoring process - " + Thread.currentThread().getName)
+      future onComplete (_.getOrElse(None) match {
+        case Some(jobState) =>
+          val trackId = id.copy(jobId = jobState.jobId)
+          val latest: JobStatusCV = trackController.jobStatuses.get(trackId)
+          if (latest == null || latest.jobState != jobState.jobState || latest.jobId != jobState.jobId) {
+            // put job status to cache
+            trackController.jobStatuses.put(trackId, jobState)
+            // set jobId to trackIds
+            trackController.trackIds.update(trackId)
+            eventBus.postSync(FlinkJobStatusChangeEvent(trackId, jobState))
+          }
+          if (FlinkJobState.isEndState(jobState.jobState)) {
+            // remove trackId from cache of job that needs to be untracked
+            trackController.unTracking(trackId)
+            if (trackId.executeMode == APPLICATION) {
+              trackController.endpoints.invalidate(trackId.toClusterKey)
+            }
+          }
+        case _ =>
+      })
+      future
+    }
+
+    // blocking until all future are completed or timeout is reached
+    Try(Await.ready(Future.sequence(tracksFuture), conf.requestTimeoutSec seconds))
+      .failed.map { _ =>
+      logInfo(s"[FlinkJobStatusWatcher] tracking flink job status on kubernetes mode timeout," +
+        s" limitSeconds=${conf.requestTimeoutSec}," +
+        s" trackIds=${trackIds.mkString(",")}")
     }
   }
 

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/SubmitRequest.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/SubmitRequest.scala
@@ -74,6 +74,8 @@ case class SubmitRequest(flinkVersion: FlinkVersion,
 
   lazy val jobID: String = extraParameter.get(KEY_JOB_ID).toString
 
+  lazy val flinkJobID: String = extraParameter.get(KEY_FLINK_JOB_ID).toString
+
   lazy val savepointRestoreSettings: SavepointRestoreSettings = {
     lazy val allowNonRestoredState = Try(extraParameter.get(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key).toString.toBoolean).getOrElse(false)
     savePoint match {

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/SubmitRequest.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/SubmitRequest.scala
@@ -47,6 +47,8 @@ case class SubmitRequest(flinkVersion: FlinkVersion,
                          developmentMode: DevelopmentMode,
                          executionMode: ExecutionMode,
                          resolveOrder: ResolveOrder,
+                         id: Long,
+                         jobId: String,
                          appName: String,
                          appConf: String,
                          applicationType: ApplicationType,
@@ -71,10 +73,6 @@ case class SubmitRequest(flinkVersion: FlinkVersion,
   lazy val effectiveAppName: String = if (this.appName == null) appProperties(KEY_FLINK_APP_NAME) else this.appName
 
   lazy val flinkSQL: String = extraParameter.get(KEY_FLINK_SQL()).toString
-
-  lazy val jobID: String = extraParameter.get(KEY_JOB_ID).toString
-
-  lazy val flinkJobID: String = extraParameter.get(KEY_FLINK_JOB_ID).toString
 
   lazy val savepointRestoreSettings: SavepointRestoreSettings = {
     lazy val allowNonRestoredState = Try(extraParameter.get(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key).toString.toBoolean).getOrElse(false)

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/KubernetesNativeApplicationSubmit.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/KubernetesNativeApplicationSubmit.scala
@@ -71,7 +71,7 @@ object KubernetesNativeApplicationSubmit extends KubernetesNativeSubmitTrait {
         .getClusterClient
 
       val clusterId = clusterClient.getClusterId
-      val result = SubmitResponse(clusterId, flinkConfig.toMap)
+      val result = SubmitResponse(clusterId, flinkConfig.toMap, submitRequest.flinkJobID)
       logInfo(s"[flink-submit] flink job has been submitted. ${flinkConfIdentifierInfo(flinkConfig)}")
       result
     } catch {

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/KubernetesNativeApplicationSubmit.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/KubernetesNativeApplicationSubmit.scala
@@ -71,7 +71,7 @@ object KubernetesNativeApplicationSubmit extends KubernetesNativeSubmitTrait {
         .getClusterClient
 
       val clusterId = clusterClient.getClusterId
-      val result = SubmitResponse(clusterId, flinkConfig.toMap, submitRequest.flinkJobID)
+      val result = SubmitResponse(clusterId, flinkConfig.toMap, submitRequest.jobId)
       logInfo(s"[flink-submit] flink job has been submitted. ${flinkConfIdentifierInfo(flinkConfig)}")
       result
     } catch {

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/YarnApplicationSubmit.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/YarnApplicationSubmit.scala
@@ -73,7 +73,7 @@ object YarnApplicationSubmit extends YarnSubmitTrait {
             case Array(1, 15, _) => array += s"${workspace.APP_SHIMS}/flink-1.15"
             case _ => throw new UnsupportedOperationException(s"Unsupported flink version: ${submitRequest.flinkVersion}")
           }
-          val jobLib = s"${workspace.APP_WORKSPACE}/${submitRequest.jobID}/lib"
+          val jobLib = s"${workspace.APP_WORKSPACE}/${submitRequest.id}/lib"
           if (HdfsUtils.exists(jobLib)) {
             array += jobLib
           }

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/trait/FlinkSubmitTrait.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/trait/FlinkSubmitTrait.scala
@@ -98,7 +98,7 @@ trait FlinkSubmitTrait extends Logger {
       .safeSet(CoreOptions.CLASSLOADER_RESOLVE_ORDER, submitRequest.resolveOrder.getName)
       .safeSet(ApplicationConfiguration.APPLICATION_MAIN_CLASS, submitRequest.appMain)
       .safeSet(ApplicationConfiguration.APPLICATION_ARGS, extractProgramArgs(submitRequest))
-      .safeSet(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID, new JobID().toHexString)
+      .safeSet(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID, submitRequest.jobId)
 
     val flinkDefaultConfiguration = getFlinkDefaultConfiguration(submitRequest.flinkVersion.flinkHome)
     //state.checkpoints.num-retained


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: Involving #1423 

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

For the precise determination of the state logic, we are using the archive log of jobmanage, but the query of the archive log has become a problem, because the previous logic, trackid the object, the value of jobid is null, resulting in you can not go to the corresponding query, so propose the current pr


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
