### PR TITLE
[Bug] Clear the teamId when delete the member

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/UserController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/UserController.java
@@ -92,8 +92,8 @@ public class UserController {
 
     @DeleteMapping("delete")
     @RequiresPermissions("user:delete")
-    public RestResponse deleteUsers(Long userId) {
-        this.userService.removeById(userId);
+    public RestResponse deleteUser(Long userId) throws Exception {
+        this.userService.deleteUser(userId);
         return RestResponse.success();
     }
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/mapper/UserMapper.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/mapper/UserMapper.java
@@ -33,4 +33,6 @@ public interface UserMapper extends BaseMapper<User> {
     List<User> getNoTokenUser();
 
     List<User> findByAppOwner(@Param("teamId") Long teamId);
+
+    void clearTeamId(@Param("userId") Long userId);
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/mapper/UserMapper.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/mapper/UserMapper.java
@@ -34,5 +34,6 @@ public interface UserMapper extends BaseMapper<User> {
 
     List<User> findByAppOwner(@Param("teamId") Long teamId);
 
-    void clearTeamId(@Param("userId") Long userId);
+    void unbindTeam(@Param("userId") Long userId);
+
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/MemberService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/MemberService.java
@@ -30,7 +30,7 @@ public interface MemberService extends IService<Member> {
 
     void deleteByRoleIds(String[] roleIds);
 
-    void deleteByUserIds(String[] userIds);
+    void deleteByUserId(Long userId);
 
     void deleteByTeamId(Long teamId);
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
@@ -71,11 +71,11 @@ public interface UserService extends IService<User> {
     void updateUser(User user) throws Exception;
 
     /**
-     * delete user list
+     * delete user
      *
-     * @param userIds user id list
+     * @param userId user id
      */
-    void deleteUsers(String[] userIds) throws Exception;
+    void deleteUser(Long userId) throws Exception;
 
     /**
      * update user

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
@@ -120,6 +120,8 @@ public interface UserService extends IService<User> {
 
     void setLatestTeam(Long teamId, Long userId);
 
+    void clearDeletedTeamId(Long userId, Long teamId);
+
     void fillInTeam(User user);
 
     List<User> findByAppOwner(Long teamId);

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
@@ -120,7 +120,7 @@ public interface UserService extends IService<User> {
 
     void setLatestTeam(Long teamId, Long userId);
 
-    void clearDeletedTeamId(Long userId, Long teamId);
+    void unbindTeam(Long userId, Long teamId);
 
     void fillInTeam(User user);
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/MemberServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/MemberServiceImpl.java
@@ -66,8 +66,8 @@ public class MemberServiceImpl extends ServiceImpl<MemberMapper, Member>
 
     @Override
     @Transactional
-    public void deleteByUserIds(String[] userIds) {
-        Arrays.stream(userIds).forEach(id -> baseMapper.deleteByUserId(Long.valueOf(id)));
+    public void deleteByUserId(Long userId) {
+        baseMapper.deleteByUserId(userId);
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/MemberServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/MemberServiceImpl.java
@@ -19,6 +19,7 @@ package org.apache.streampark.console.system.service.impl;
 
 import org.apache.streampark.common.util.AssertUtils;
 import org.apache.streampark.console.base.domain.RestRequest;
+import org.apache.streampark.console.base.exception.ApiAlertException;
 import org.apache.streampark.console.system.entity.Member;
 import org.apache.streampark.console.system.entity.Team;
 import org.apache.streampark.console.system.entity.User;
@@ -119,11 +120,11 @@ public class MemberServiceImpl extends ServiceImpl<MemberMapper, Member>
     @Override
     public void createMember(Member member) {
         User user = Optional.ofNullable(userService.findByName(member.getUserName()))
-            .orElseThrow(() -> new IllegalArgumentException(String.format("The username [%s] not found", member.getUserName())));
+            .orElseThrow(() -> new ApiAlertException(String.format("The username [%s] not found", member.getUserName())));
         Optional.ofNullable(roleService.getById(member.getRoleId()))
-            .orElseThrow(() -> new IllegalArgumentException(String.format("The roleId [%s] not found", member.getRoleId())));
+            .orElseThrow(() -> new ApiAlertException(String.format("The roleId [%s] not found", member.getRoleId())));
         Team team = Optional.ofNullable(teamService.getById(member.getTeamId()))
-            .orElseThrow(() -> new IllegalArgumentException(String.format("The teamId [%s] not found", member.getTeamId())));
+            .orElseThrow(() -> new ApiAlertException(String.format("The teamId [%s] not found", member.getTeamId())));
         AssertUtils.isTrue(findByUserId(member.getTeamId(), user.getUserId()) == null,
             String.format("The user [%s] has been added the team [%s], please don't add it again.", member.getUserName(),
                 team.getTeamName()));
@@ -138,19 +139,19 @@ public class MemberServiceImpl extends ServiceImpl<MemberMapper, Member>
     @Override
     public void deleteMember(Member memberArg) {
         Member member = Optional.ofNullable(this.getById(memberArg.getId()))
-            .orElseThrow(() -> new IllegalArgumentException(String.format("The member [id=%s] not found", memberArg.getId())));
+            .orElseThrow(() -> new ApiAlertException(String.format("The member [id=%s] not found", memberArg.getId())));
         this.removeById(member);
-        userService.clearDeletedTeamId(member.getUserId(), member.getTeamId());
+        userService.unbindTeam(member.getUserId(), member.getTeamId());
     }
 
     @Override
     public void updateMember(Member member) {
         Member oldMember = Optional.ofNullable(this.getById(member.getId()))
-            .orElseThrow(() -> new IllegalArgumentException(String.format("The member [id=%s] not found", member.getId())));
+            .orElseThrow(() -> new ApiAlertException(String.format("The member [id=%s] not found", member.getId())));
         AssertUtils.isTrue(oldMember.getTeamId().equals(member.getTeamId()), "Team id cannot be changed.");
         AssertUtils.isTrue(oldMember.getUserId().equals(member.getUserId()), "User id cannot be changed.");
         Optional.ofNullable(roleService.getById(member.getRoleId()))
-            .orElseThrow(() -> new IllegalArgumentException(String.format("The roleId [%s] not found", member.getRoleId())));
+            .orElseThrow(() -> new ApiAlertException(String.format("The roleId [%s] not found", member.getRoleId())));
         oldMember.setRoleId(member.getRoleId());
         updateById(oldMember);
     }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/MemberServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/MemberServiceImpl.java
@@ -136,14 +136,17 @@ public class MemberServiceImpl extends ServiceImpl<MemberMapper, Member>
     }
 
     @Override
-    public void deleteMember(Member member) {
+    public void deleteMember(Member memberArg) {
+        Member member = Optional.ofNullable(this.getById(memberArg.getId()))
+            .orElseThrow(() -> new IllegalArgumentException(String.format("The member [id=%s] not found", memberArg.getId())));
         this.removeById(member);
+        userService.clearDeletedTeamId(member.getUserId(), member.getTeamId());
     }
 
     @Override
     public void updateMember(Member member) {
         Member oldMember = Optional.ofNullable(this.getById(member.getId()))
-            .orElseThrow(() -> new IllegalArgumentException(String.format("The mapping [id=%s] not found", member.getId())));
+            .orElseThrow(() -> new IllegalArgumentException(String.format("The member [id=%s] not found", member.getId())));
         AssertUtils.isTrue(oldMember.getTeamId().equals(member.getTeamId()), "Team id cannot be changed.");
         AssertUtils.isTrue(oldMember.getUserId().equals(member.getUserId()), "User id cannot be changed.");
         Optional.ofNullable(roleService.getById(member.getRoleId()))

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
@@ -42,7 +42,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Nullable;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -115,10 +114,9 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
 
     @Override
     @Transactional(rollbackFor = Exception.class)
-    public void deleteUsers(String[] userIds) {
-        List<String> list = Arrays.asList(userIds);
-        removeByIds(list);
-        this.memberService.deleteByUserIds(userIds);
+    public void deleteUser(Long userId) {
+        removeById(userId);
+        this.memberService.deleteByUserId(userId);
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
@@ -189,13 +189,13 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     }
 
     @Override
-    public void clearDeletedTeamId(Long userId, Long teamId) {
+    public void unbindTeam(Long userId, Long teamId) {
         User user = getById(userId);
         AssertUtils.checkArgument(user != null);
         if (!teamId.equals(user.getTeamId())) {
             return;
         }
-        this.baseMapper.clearTeamId(userId);
+        this.baseMapper.unbindTeam(userId);
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
@@ -175,7 +175,7 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     public List<User> getNoTokenUser() {
         List<User> users = this.baseMapper.getNoTokenUser();
         if (!users.isEmpty()) {
-            users.forEach(u -> u.dataMasking());
+            users.forEach(User::dataMasking);
         }
         return users;
     }
@@ -186,6 +186,16 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
         AssertUtils.checkArgument(user != null);
         user.setTeamId(teamId);
         this.baseMapper.updateById(user);
+    }
+
+    @Override
+    public void clearDeletedTeamId(Long userId, Long teamId) {
+        User user = getById(userId);
+        AssertUtils.checkArgument(user != null);
+        if (!teamId.equals(user.getTeamId())) {
+            return;
+        }
+        this.baseMapper.clearTeamId(userId);
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/UserMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/UserMapper.xml
@@ -75,7 +75,7 @@
         where u.user_id = t.user_id
     </select>
 
-    <update id="clearTeamId" parameterType="java.lang.Long">
+    <update id="unbindTeam" parameterType="java.lang.Long">
         update t_user
         set team_id = null
         where user_id = #{userId}

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/UserMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/UserMapper.xml
@@ -75,4 +75,10 @@
         where u.user_id = t.user_id
     </select>
 
+    <update id="clearTeamId" parameterType="java.lang.Long">
+        update t_user
+        set team_id = null
+        where user_id = #{userId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #2008 

The lastTeamId may be wrong when delete the member

## Brief change log

Clear the teamId when delete the member

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
