### PR TITLE
[Bug] Rename the teamId of user table to lastTeamId

### DIFF
--- a/streampark-console/streampark-console-service/src/assembly/script/schema/mysql-schema.sql
+++ b/streampark-console/streampark-console-service/src/assembly/script/schema/mysql-schema.sql
@@ -392,7 +392,7 @@ create table `t_user` (
   `password` varchar(128) collate utf8mb4_general_ci not null comment 'password',
   `email` varchar(128) collate utf8mb4_general_ci default null comment 'email',
   `user_type` int  not null comment 'user type 1:admin 2:user',
-  `team_id` bigint default null comment 'latest team id',
+  `last_team_id` bigint default null comment 'last team id',
   `status` char(1) collate utf8mb4_general_ci not null comment 'status 0:locked 1:active',
   `create_time` datetime not null default current_timestamp comment 'create time',
   `modify_time` datetime not null default current_timestamp on update current_timestamp comment 'modify time',

--- a/streampark-console/streampark-console-service/src/assembly/script/schema/pgsql-schema.sql
+++ b/streampark-console/streampark-console-service/src/assembly/script/schema/pgsql-schema.sql
@@ -711,7 +711,7 @@ create table "public"."t_user" (
   "password" varchar(128) collate "pg_catalog"."default" not null,
   "email" varchar(128) collate "pg_catalog"."default",
   "user_type" int4,
-  "team_id" int8,
+  "last_team_id" int8,
   "status" int2,
   "create_time" timestamp(6) not null default timezone('UTC-8'::text, (now())::timestamp(0) without time zone),
   "modify_time" timestamp(6) not null default timezone('UTC-8'::text, (now())::timestamp(0) without time zone),
@@ -728,7 +728,7 @@ comment on column "public"."t_user"."salt" is 'salt';
 comment on column "public"."t_user"."password" is 'password';
 comment on column "public"."t_user"."email" is 'email';
 comment on column "public"."t_user"."user_type" is 'user type 1:admin 2:user';
-comment on column "public"."t_user"."team_id" is 'latest team id';
+comment on column "public"."t_user"."last_team_id" is 'last team id';
 comment on column "public"."t_user"."status" is 'status 0:locked 1:active';
 comment on column "public"."t_user"."create_time" is 'creation time';
 comment on column "public"."t_user"."modify_time" is 'change time';

--- a/streampark-console/streampark-console-service/src/assembly/script/upgrade/mysql/2.0.0.sql
+++ b/streampark-console/streampark-console-service/src/assembly/script/upgrade/mysql/2.0.0.sql
@@ -211,7 +211,7 @@ add index `inx_team` (`team_id`) using btree;
 -- Update user
 alter table `t_user`
 add column `user_type` int  not null default 2 comment 'user type 1:admin 2:user' after `email`,
-add column `team_id` bigint default null comment 'latest team id' after `user_type`;
+add column `last_team_id` bigint default null comment 'last team id' after `user_type`;
 
 -- after adding team module, admin has all permissions by default, so admin does not need to add permissions separately, so delete admin related roles and associations
 update `t_user` set `user_type` = 1

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/PassportController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/PassportController.java
@@ -97,7 +97,7 @@ public class PassportController {
         userService.fillInTeam(user);
 
         //no team.
-        if (user.getTeamId() == null) {
+        if (user.getLastTeamId() == null) {
             return RestResponse.success().data(user.getUserId()).put("code", ResponseCode.CODE_FORBIDDEN);
         }
 
@@ -110,7 +110,7 @@ public class PassportController {
         JWTToken jwtToken = new JWTToken(token, expireTimeStr);
         String userId = RandomStringUtils.randomAlphanumeric(20);
         user.setId(userId);
-        Map<String, Object> userInfo = userService.generateFrontendUserInfo(user, user.getTeamId(), jwtToken);
+        Map<String, Object> userInfo = userService.generateFrontendUserInfo(user, user.getLastTeamId(), jwtToken);
         return new RestResponse().data(userInfo);
     }
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/entity/User.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/entity/User.java
@@ -101,7 +101,7 @@ public class User implements Serializable {
     /**
      * The last set teamId
      */
-    private Long teamId;
+    private Long lastTeamId;
 
     public void dataMasking() {
         String dataMask = ConfigConst.DEFAULT_DATAMASK_STRING();

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
@@ -182,7 +182,7 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     public void setLatestTeam(Long teamId, Long userId) {
         User user = getById(userId);
         AssertUtils.checkArgument(user != null);
-        user.setTeamId(teamId);
+        user.setLastTeamId(teamId);
         this.baseMapper.updateById(user);
     }
 
@@ -190,7 +190,7 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     public void unbindTeam(Long userId, Long teamId) {
         User user = getById(userId);
         AssertUtils.checkArgument(user != null);
-        if (!teamId.equals(user.getTeamId())) {
+        if (!teamId.equals(user.getLastTeamId())) {
             return;
         }
         this.baseMapper.unbindTeam(userId);
@@ -198,13 +198,13 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
 
     @Override
     public void fillInTeam(User user) {
-        if (user.getTeamId() == null) {
+        if (user.getLastTeamId() == null) {
             List<Team> teams = memberService.findUserTeams(user.getUserId());
             if (CollectionUtils.isEmpty(teams)) {
                 throw new ApiAlertException("The current user not belong to any team, please contact the administrator!");
             } else if (teams.size() == 1) {
                 Team team = teams.get(0);
-                user.setTeamId(team.getId());
+                user.setLastTeamId(team.getId());
                 this.baseMapper.updateById(user);
             }
         }

--- a/streampark-console/streampark-console-service/src/main/resources/db/schema-h2.sql
+++ b/streampark-console/streampark-console-service/src/main/resources/db/schema-h2.sql
@@ -346,7 +346,7 @@ create table if not exists `t_user` (
   `password` varchar(128)  not null comment 'password',
   `email` varchar(128)  default null comment 'email',
   `user_type` int  not null comment 'user type 1:admin 2:user',
-  `team_id` bigint default null comment 'latest team id',
+  `last_team_id` bigint default null comment 'last team id',
   `status` char(1)  not null comment 'status 0:locked 1:active',
   `create_time` datetime not null default current_timestamp comment 'create time',
   `modify_time` datetime not null default current_timestamp on update current_timestamp comment 'modify time',

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/UserMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/UserMapper.xml
@@ -33,7 +33,7 @@
         <result column="sex" jdbcType="CHAR" property="sex"/>
         <result column="avatar" jdbcType="VARCHAR" property="avatar"/>
         <result column="description" jdbcType="VARCHAR" property="description"/>
-        <result column="team_id" jdbcType="BIGINT" property="teamId"/>
+        <result column="last_team_id" jdbcType="BIGINT" property="lastTeamId"/>
     </resultMap>
 
     <select id="findUserDetail" resultType="org.apache.streampark.console.system.entity.User" parameterType="org.apache.streampark.console.system.entity.User">
@@ -77,7 +77,7 @@
 
     <update id="unbindTeam" parameterType="java.lang.Long">
         update t_user
-        set team_id = null
+        set last_team_id = null
         where user_id = #{userId}
     </update>
 

--- a/streampark-console/streampark-console-webapp/src/api/system/model/userModel.ts
+++ b/streampark-console/streampark-console-webapp/src/api/system/model/userModel.ts
@@ -48,7 +48,7 @@ export interface GetUserInfoModel {
   nickName: string;
   avatar: string;
   desc?: string;
-  teamId?: string;
+  lastTeamId?: string;
 }
 export interface TeamSetResponse {
   permissions: string[];

--- a/streampark-console/streampark-console-webapp/src/views/base/login/LoginForm.vue
+++ b/streampark-console/streampark-console-webapp/src/views/base/login/LoginForm.vue
@@ -181,10 +181,11 @@
         userStore.setData(data);
         let successText = t('sys.login.loginSuccessDesc');
         if (data?.user) {
-          const { teamId, nickName } = data.user;
-          userStore.teamId = teamId || '';
-          sessionStorage.setItem(APP_TEAMID_KEY_, teamId || '');
-          localStorage.setItem(APP_TEAMID_KEY_, teamId || '');
+          const { lastTeamId, nickName } = data.user;
+          // The lastTeamId of user as the current teamId.
+          userStore.teamId = lastTeamId || '';
+          sessionStorage.setItem(APP_TEAMID_KEY_, userStore.teamId);
+          localStorage.setItem(APP_TEAMID_KEY_, userStore.teamId);
           successText += `: ${nickName}`;
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #2030 

Avoid the bug that the lastTeamId of new user isn't null

## Brief change log

Rename the teamId of user table to lastTeamId

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
