### PR TITLE
[improve]: fix header and dependency style

### DIFF
--- a/streampark-console/streampark-console-webapp/src/layouts/default/header/components/Slogan.vue
+++ b/streampark-console/streampark-console-webapp/src/layouts/default/header/components/Slogan.vue
@@ -67,7 +67,7 @@
     }
   }
 
-  @media screen and (max-width: 1585px) {
+  @media screen and (max-width: 1626px) {
     .@{prefix-cls}:not(.collapse-slogo) {
       display: none;
     }

--- a/streampark-console/streampark-console-webapp/src/layouts/default/header/index.less
+++ b/streampark-console/streampark-console-webapp/src/layouts/default/header/index.less
@@ -185,6 +185,7 @@
     background-color: @header-dark-bg-color !important;
     // border-bottom: 1px solid @border-color-base;
     border-left: 1px solid @border-color-base;
+    border-bottom: 1px solid @border-color-base;
     .@{header-prefix-cls}-logo {
       &:hover {
         background-color: @header-dark-bg-hover-color;

--- a/streampark-console/streampark-console-webapp/src/views/flink/app/components/Dependency.vue
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/components/Dependency.vue
@@ -262,10 +262,12 @@
 <template>
   <Tabs type="card" v-model:activeKey="activeTab" class="pom-card">
     <TabPane key="pom" tab="Maven pom">
-      <div ref="pomBox" class="pom-box syntax-true" style="height: 300px"></div>
-      <a-button type="primary" class="apply-pom" @click="handleApplyPom()">
-        {{ t('common.apply') }}
-      </a-button>
+      <div class="relative">
+        <div ref="pomBox" class="pom-box syntax-true" style="height: 300px"></div>
+        <a-button type="primary" class="apply-pom" @click="handleApplyPom()">
+          {{ t('common.apply') }}
+        </a-button>
+      </div>
     </TabPane>
     <TabPane key="jar" tab="Upload Jar">
       <template v-if="isK8sExecMode(formModel?.executionMode)">

--- a/streampark-console/streampark-console-webapp/src/views/system/token/Token.vue
+++ b/streampark-console/streampark-console-webapp/src/views/system/token/Token.vue
@@ -15,7 +15,7 @@
   limitations under the License.
 -->
 <template>
-  <div>
+  <PageWrapper>
     <BasicTable @register="registerTable">
       <template #toolbar>
         <a-button type="primary" @click="handleCreate" v-auth="'token:add'">
@@ -49,7 +49,7 @@
       </template>
     </BasicTable>
     <TokenDrawer @register="registerDrawer" @success="handleSuccess" />
-  </div>
+  </PageWrapper>
 </template>
 <script lang="ts">
   import { defineComponent, unref } from 'vue';
@@ -63,10 +63,10 @@
   import { useMessage } from '/@/hooks/web/useMessage';
   import { useI18n } from '/@/hooks/web/useI18n';
   import Icon from '/@/components/Icon';
-
+  import { PageWrapper } from '/@/components/Page';
   export default defineComponent({
     name: 'UserToken',
-    components: { BasicTable, TokenDrawer, TableAction, Icon },
+    components: { BasicTable, TokenDrawer, TableAction, Icon, PageWrapper },
     setup() {
       const { t } = useI18n();
       const { createMessage } = useMessage();
@@ -75,12 +75,19 @@
       const [registerTable, { reload, updateTableDataRecord }] = useTable({
         title: t('system.token.table.title'),
         api: fetTokenList,
+        // beforeFetch: (params) => {
+        //   if (params.user) {
+        //     params.username = params.user;
+        //     delete params.user;
+        //   }
+        //   return params;
+        // },
         columns,
         formConfig: {
           baseColProps: { style: { paddingRight: '30px' } },
           schemas: searchFormSchema,
         },
-        useSearchForm: true,
+        useSearchForm: false,
         showTableSetting: true,
         rowKey: 'tokenId',
         showIndexColumn: false,

--- a/streampark-console/streampark-console-webapp/src/views/system/token/token.data.ts
+++ b/streampark-console/streampark-console-webapp/src/views/system/token/token.data.ts
@@ -90,7 +90,7 @@ export const columns: BasicColumn[] = [
 
 export const searchFormSchema: FormSchema[] = [
   {
-    field: 'userName',
+    field: 'user',
     label: t('system.token.table.userName'),
     component: 'Input',
     colProps: { span: 8 },


### PR DESCRIPTION

## What changes were proposed in this pull request
1. Border is added at the bottom of the dark mode header
<img width="1418" alt="iShot_2022-11-17_10 01 08" src="https://user-images.githubusercontent.com/39726513/202335782-1f272f5d-8023-4e20-85c3-b7e8ed9f3f68.png">

2. fix slogan extrusion problem 
<img width="1416" alt="iShot_2022-11-17_10 02 42" src="https://user-images.githubusercontent.com/39726513/202336055-16b0e588-e059-487b-8d67-8bacb9cbbcc8.png">
<img width="1414" alt="iShot_2022-11-17_10 03 09" src="https://user-images.githubusercontent.com/39726513/202336061-727a025c-76f1-44e3-9ced-82284e9d18fb.png">

3. fix dependency button position
	When there are uploaded files, the apply button may move down

<img width="979" alt="iShot_2022-11-17_10 04 10" src="https://user-images.githubusercontent.com/39726513/202336190-c832b9e9-e83f-475b-8358-3b53933bedc8.png">

4. token list 
 	It is found that there is no username query field in the back-end interface (query conditions exist in the old webapp)

<img width="1391" alt="iShot_2022-11-17_10 05 23" src="https://user-images.githubusercontent.com/39726513/202336364-af872f5c-c45d-47fd-9ae9-7e45922782ea.png">

```java
    @PostMapping(value = "list")
    @RequiresPermissions("token:view")
    public RestResponse tokenList(RestRequest restRequest, AccessToken accessToken) {
        IPage<AccessToken> accessTokens = accessTokenService.findAccessTokens(accessToken, restRequest);
        return RestResponse.success(accessTokens);
    }
```
```java
public class RestRequest implements Serializable {

    private static final long serialVersionUID = -4869594085374385813L;

    private int pageSize = 10;
    private int pageNum = 1;

    private String sortField;
    private String sortOrder;
}
```
old webapp
<img width="864" alt="iShot_2022-11-17_10 08 52" src="https://user-images.githubusercontent.com/39726513/202336914-f7aba64f-336c-4201-bbc8-d126edcd1bc2.png">

