### PR TITLE
[Bug] Clear the lastTeamId when deleting the team

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/UserController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/controller/UserController.java
@@ -166,7 +166,7 @@ public class UserController {
         if (team == null) {
             return RestResponse.fail("teamId is invalid", ResponseCode.CODE_FAIL_ALERT);
         }
-        userService.setLatestTeam(teamId, userId);
+        userService.setLastTeam(teamId, userId);
         return RestResponse.success();
     }
 
@@ -180,7 +180,7 @@ public class UserController {
         User user = commonService.getCurrentUser();
 
         //1) set the latest team
-        userService.setLatestTeam(teamId, user.getUserId());
+        userService.setLastTeam(teamId, user.getUserId());
 
         //2) get latest userInfo
         user.dataMasking();

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/mapper/UserMapper.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/mapper/UserMapper.java
@@ -34,6 +34,8 @@ public interface UserMapper extends BaseMapper<User> {
 
     List<User> findByAppOwner(@Param("teamId") Long teamId);
 
-    void unbindTeam(@Param("userId") Long userId);
+    void clearLastTeamByUserId(@Param("userId") Long userId);
+
+    void clearLastTeamByTeamId(@Param("teamId") Long teamId);
 
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/UserService.java
@@ -118,9 +118,11 @@ public interface UserService extends IService<User> {
 
     List<User> getNoTokenUser();
 
-    void setLatestTeam(Long teamId, Long userId);
+    void setLastTeam(Long teamId, Long userId);
 
-    void unbindTeam(Long userId, Long teamId);
+    void clearLastTeam(Long userId, Long teamId);
+
+    void clearLastTeam(Long teamId);
 
     void fillInTeam(User user);
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/MemberServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/MemberServiceImpl.java
@@ -141,7 +141,7 @@ public class MemberServiceImpl extends ServiceImpl<MemberMapper, Member>
         Member member = Optional.ofNullable(this.getById(memberArg.getId()))
             .orElseThrow(() -> new ApiAlertException(String.format("The member [id=%s] not found", memberArg.getId())));
         this.removeById(member);
-        userService.unbindTeam(member.getUserId(), member.getTeamId());
+        userService.clearLastTeam(member.getUserId(), member.getTeamId());
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/TeamServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/TeamServiceImpl.java
@@ -115,6 +115,7 @@ public class TeamServiceImpl extends ServiceImpl<TeamMapper, Team> implements Te
         }
 
         memberService.deleteByTeamId(teamId);
+        userService.clearLastTeam(teamId);
         this.removeById(teamId);
     }
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
@@ -179,7 +179,7 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     }
 
     @Override
-    public void setLatestTeam(Long teamId, Long userId) {
+    public void setLastTeam(Long teamId, Long userId) {
         User user = getById(userId);
         AssertUtils.checkArgument(user != null);
         user.setLastTeamId(teamId);
@@ -187,13 +187,18 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     }
 
     @Override
-    public void unbindTeam(Long userId, Long teamId) {
+    public void clearLastTeam(Long userId, Long teamId) {
         User user = getById(userId);
         AssertUtils.checkArgument(user != null);
         if (!teamId.equals(user.getLastTeamId())) {
             return;
         }
-        this.baseMapper.unbindTeam(userId);
+        this.baseMapper.clearLastTeamByUserId(userId);
+    }
+
+    @Override
+    public void clearLastTeam(Long teamId) {
+        this.baseMapper.clearLastTeamByTeamId(teamId);
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/UserMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/UserMapper.xml
@@ -75,10 +75,16 @@
         where u.user_id = t.user_id
     </select>
 
-    <update id="unbindTeam" parameterType="java.lang.Long">
+    <update id="clearLastTeamByUserId" parameterType="java.lang.Long">
         update t_user
         set last_team_id = null
         where user_id = #{userId}
+    </update>
+
+    <update id="clearLastTeamByTeamId" parameterType="java.lang.Long">
+        update t_user
+        set last_team_id = null
+        where last_team_id = #{teamId}
     </update>
 
 </mapper>


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #2045 

The lastTeamId should be clear when the team is deleted.

If it isn't cleared, the user cannot log in.

## Brief change log

Clear the lastTeamId when deleting the team

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
