### PR TITLE
[improve] job submit parameter improvement

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/ApplicationController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/ApplicationController.java
@@ -142,8 +142,13 @@ public class ApplicationController {
             if (pipeStates.containsKey(e.getId())) {
                 e.setBuildStatus(pipeStates.get(e.getId()).getCode());
             }
-        }).peek(e -> e.setAppControl(new AppControl().setAllowBuild(e.getBuildStatus() == null || !PipelineStatus.running.getCode().equals(e.getBuildStatus())).setAllowStart(PipelineStatus.success.getCode().equals(e.getBuildStatus()) && !e.shouldBeTrack()).setAllowStop(e.isRunning()))).collect(Collectors.toList());
-
+        }).peek(e -> {
+            AppControl appControl = new AppControl()
+                .setAllowBuild(e.getBuildStatus() == null || !PipelineStatus.running.getCode().equals(e.getBuildStatus()))
+                .setAllowStart(!e.shouldBeTrack() && PipelineStatus.success.getCode().equals(e.getBuildStatus()))
+                .setAllowStop(e.isRunning());
+            e.setAppControl(appControl);
+        }).collect(Collectors.toList());
         applicationList.setRecords(appRecords);
         return RestResponse.success(applicationList);
     }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/FlinkCluster.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/FlinkCluster.java
@@ -21,8 +21,10 @@ import org.apache.streampark.common.conf.ConfigConst;
 import org.apache.streampark.common.enums.ClusterState;
 import org.apache.streampark.common.enums.ExecutionMode;
 import org.apache.streampark.common.enums.FlinkK8sRestExposedType;
+import org.apache.streampark.common.enums.ResolveOrder;
 import org.apache.streampark.common.util.HttpClientUtils;
 import org.apache.streampark.console.base.util.JacksonUtils;
+import org.apache.streampark.flink.submit.FlinkSubmitter;
 
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
@@ -33,6 +35,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Data;
 import lombok.SneakyThrows;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.http.client.config.RequestConfig;
 
 import java.io.Serializable;
@@ -166,6 +169,19 @@ public class FlinkCluster implements Serializable {
         Map<String, String> config = new HashMap<>(0);
         confList.forEach(k -> config.put(k.get("key"), k.get("value")));
         return config;
+    }
+
+    @JsonIgnore
+    public Map<String, Object> getProperties() {
+        Map<String, Object> map = new HashMap<>();
+        Map<String, String> dynamicProperties = FlinkSubmitter.extractDynamicPropertiesAsJava(this.getDynamicProperties());
+        map.putAll(this.getOptionMap());
+        map.putAll(dynamicProperties);
+        ResolveOrder resolveOrder = ResolveOrder.of(this.getResolveOrder());
+        if (resolveOrder != null) {
+            map.put(CoreOptions.CLASSLOADER_RESOLVE_ORDER.key(), resolveOrder.getName());
+        }
+        return map;
     }
 
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/AppBuildPipeServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/AppBuildPipeServiceImpl.java
@@ -445,16 +445,13 @@ public class AppBuildPipeServiceImpl
             return Maps.newHashMap();
         }
         LambdaQueryWrapper<AppBuildPipeline> queryWrapper = new LambdaQueryWrapper<AppBuildPipeline>()
-            .select(AppBuildPipeline::getAppId, AppBuildPipeline::getPipeStatusCode)
             .in(AppBuildPipeline::getAppId, appIds);
-        List<Map<String, Object>> rMaps = baseMapper.selectMaps(queryWrapper);
+
+        List<AppBuildPipeline> rMaps = baseMapper.selectList(queryWrapper);
         if (CollectionUtils.isEmpty(rMaps)) {
             return Maps.newHashMap();
         }
-
-        return rMaps.stream().collect(Collectors.toMap(
-            e -> (Long) e.get("app_id"),
-            e -> PipelineStatus.of((Integer) e.get("pipeStatusCode"))));
+        return rMaps.stream().collect(Collectors.toMap(e -> e.getAppId(), e -> e.getPipelineStatus()));
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/AppBuildPipeServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/AppBuildPipeServiceImpl.java
@@ -447,11 +447,11 @@ public class AppBuildPipeServiceImpl
         LambdaQueryWrapper<AppBuildPipeline> queryWrapper = new LambdaQueryWrapper<AppBuildPipeline>()
             .in(AppBuildPipeline::getAppId, appIds);
 
-        List<AppBuildPipeline> rMaps = baseMapper.selectList(queryWrapper);
-        if (CollectionUtils.isEmpty(rMaps)) {
+        List<AppBuildPipeline> appBuildPipelines = baseMapper.selectList(queryWrapper);
+        if (CollectionUtils.isEmpty(appBuildPipelines)) {
             return Maps.newHashMap();
         }
-        return rMaps.stream().collect(Collectors.toMap(e -> e.getAppId(), e -> e.getPipelineStatus()));
+        return appBuildPipelines.stream().collect(Collectors.toMap(e -> e.getAppId(), e -> e.getPipelineStatus()));
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
@@ -38,6 +38,7 @@ import org.apache.streampark.common.util.ThreadUtils;
 import org.apache.streampark.common.util.Utils;
 import org.apache.streampark.common.util.YarnUtils;
 import org.apache.streampark.console.base.domain.RestRequest;
+import org.apache.streampark.console.base.exception.ApiAlertException;
 import org.apache.streampark.console.base.exception.ApplicationException;
 import org.apache.streampark.console.base.mybatis.pager.MybatisPager;
 import org.apache.streampark.console.base.util.CommonUtils;
@@ -107,6 +108,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
@@ -1061,7 +1063,7 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             }
         }
 
-        Map<String, Object> optionMap = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
 
         if (ExecutionMode.isRemoteMode(application.getExecutionModeEnum())) {
             FlinkCluster cluster = flinkClusterService.getById(application.getFlinkClusterId());
@@ -1070,15 +1072,15 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
                         "the cluster has been deleted. Please contact the Admin.",
                     application.getFlinkClusterId()));
             URI activeAddress = cluster.getActiveAddress();
-            optionMap.put(RestOptions.ADDRESS.key(), activeAddress.getHost());
-            optionMap.put(RestOptions.PORT.key(), activeAddress.getPort());
+            properties.put(RestOptions.ADDRESS.key(), activeAddress.getHost());
+            properties.put(RestOptions.PORT.key(), activeAddress.getPort());
         } else if (ExecutionMode.isYarnMode(application.getExecutionModeEnum())) {
             if (ExecutionMode.YARN_SESSION.equals(application.getExecutionModeEnum())) {
                 FlinkCluster cluster = flinkClusterService.getById(application.getFlinkClusterId());
                 AssertUtils.state(cluster != null,
                     String.format("The yarn session clusterId=%s cannot be find, maybe the clusterId is wrong or " +
                         "the cluster has been deleted. Please contact the Admin.", application.getFlinkClusterId()));
-                optionMap.put(ConfigConst.KEY_YARN_APP_ID(), cluster.getClusterId());
+                properties.put(ConfigConst.KEY_YARN_APP_ID(), cluster.getClusterId());
             }
         }
 
@@ -1096,7 +1098,7 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             appParam.getDrain(),
             customSavepoint,
             application.getK8sNamespace(),
-            optionMap
+            properties
         );
 
         CompletableFuture<CancelResponse> cancelFuture =
@@ -1217,6 +1219,11 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
 
         AssertUtils.state(application != null);
 
+        FlinkEnv flinkEnv = flinkEnvService.getByIdOrDefault(application.getVersionId());
+        if (flinkEnv == null) {
+            throw new ApiAlertException("[StreamPark] can no found flink version");
+        }
+
         // if manually started, clear the restart flag
         if (!auto) {
             application.setRestartCount(0);
@@ -1277,7 +1284,6 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             FlinkSql flinkSql = flinkSqlService.getEffective(application.getId(), false);
             AssertUtils.state(flinkSql != null);
             // 1) dist_userJar
-            FlinkEnv flinkEnv = flinkEnvService.getByIdOrDefault(application.getVersionId());
             String sqlDistJar = commonService.getSqlClientJar(flinkEnv);
             // 2) appConfig
             appConf = applicationConfig == null ? null : String.format("yaml://%s", applicationConfig.getContent());
@@ -1290,38 +1296,6 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             throw new UnsupportedOperationException("Unsupported...");
         }
 
-        Map<String, String> properties = FlinkSubmitter.extractDynamicPropertiesAsJava(application.getDynamicProperties());
-
-        Map<String, Object> optionMap = application.getOptionMap();
-
-        if (appParam.getAllowNonRestored()) {
-            optionMap.put(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key(), true);
-        }
-
-        if (ExecutionMode.isRemoteMode(application.getExecutionModeEnum())) {
-            FlinkCluster cluster = flinkClusterService.getById(application.getFlinkClusterId());
-            AssertUtils.state(cluster != null,
-                String.format("The clusterId=%s cannot be find, maybe the clusterId is wrong or " +
-                    "the cluster has been deleted. Please contact the Admin.", application.getFlinkClusterId()));
-            URI activeAddress = cluster.getActiveAddress();
-            optionMap.put(RestOptions.ADDRESS.key(), activeAddress.getHost());
-            optionMap.put(RestOptions.PORT.key(), activeAddress.getPort());
-        } else if (ExecutionMode.isYarnMode(application.getExecutionModeEnum())) {
-            String yarnQueue = (String) application.getHotParamsMap().get(ConfigConst.KEY_YARN_APP_QUEUE());
-            if (yarnQueue != null) {
-                properties.put(ConfigConst.KEY_YARN_APP_QUEUE(), yarnQueue);
-            }
-            if (ExecutionMode.YARN_SESSION.equals(application.getExecutionModeEnum())) {
-                FlinkCluster cluster = flinkClusterService.getById(application.getFlinkClusterId());
-                AssertUtils.state(cluster != null,
-                    String.format("The yarn session clusterId=%s cannot be find, maybe the clusterId is wrong or " +
-                        "the cluster has been deleted. Please contact the Admin.", application.getFlinkClusterId()));
-                optionMap.put(ConfigConst.KEY_YARN_APP_ID(), cluster.getClusterId());
-            }
-        } else if (ExecutionMode.isKubernetesMode(application.getExecutionModeEnum())) {
-            optionMap.put(ConfigConst.KEY_K8S_IMAGE_PULL_POLICY(), "Always");
-        }
-
         Map<String, Object> extraParameter = new HashMap<>(0);
         if (application.isFlinkSqlJob()) {
             FlinkSql flinkSql = flinkSqlService.getEffective(application.getId(), true);
@@ -1331,17 +1305,11 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             extraParameter.put(ConfigConst.KEY_FLINK_SQL(null), flinkSql.getSql());
         }
 
-        ResolveOrder resolveOrder = ResolveOrder.of(application.getResolveOrder());
-
         KubernetesSubmitParam kubernetesSubmitParam = new KubernetesSubmitParam(
             application.getClusterId(),
             application.getK8sNamespace(),
-            application.getK8sRestExposedTypeEnum());
-
-        FlinkEnv flinkEnv = flinkEnvService.getByIdOrDefault(application.getVersionId());
-        if (flinkEnv == null) {
-            throw new IllegalArgumentException("[StreamPark] can no found flink version");
-        }
+            application.getK8sRestExposedTypeEnum()
+        );
 
         AppBuildPipeline buildPipeline = appBuildPipeService.getById(application.getId());
 
@@ -1353,7 +1321,6 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
         } else {
             if (ExecutionMode.isKubernetesApplicationMode(application.getExecutionMode())) {
                 AssertUtils.state(buildResult != null);
-                properties.put(JobManagerOptions.ARCHIVE_DIR.key(), Workspace.ARCHIVES_FILE_PATH());
                 DockerImageBuildResponse result = buildResult.as(DockerImageBuildResponse.class);
                 String ingressTemplates = application.getIngressTemplate();
                 String domainName = application.getDefaultModeIngress();
@@ -1386,7 +1353,6 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             flinkEnv.getFlinkConf(),
             DevelopmentMode.of(application.getJobType()),
             ExecutionMode.of(application.getExecutionMode()),
-            resolveOrder,
             application.getId(),
             jobId,
             application.getJobName(),
@@ -1394,8 +1360,7 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             application.getApplicationType(),
             getSavePointed(appParam),
             appParam.getFlameGraph() ? getFlameGraph(application) : null,
-            optionMap,
-            properties,
+            getProperties(application),
             applicationArgs,
             buildResult,
             kubernetesSubmitParam,
@@ -1476,6 +1441,50 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
             startFutureMap.remove(application.getId());
         });
 
+    }
+
+    private Map<String, Object> getProperties(Application application) {
+        Map<String, Object> properties = application.getOptionMap();
+        if (ExecutionMode.isRemoteMode(application.getExecutionModeEnum())) {
+            FlinkCluster cluster = flinkClusterService.getById(application.getFlinkClusterId());
+            AssertUtils.state(cluster != null,
+                String.format("The clusterId=%s cannot be find, maybe the clusterId is wrong or " +
+                    "the cluster has been deleted. Please contact the Admin.", application.getFlinkClusterId()));
+            URI activeAddress = cluster.getActiveAddress();
+            properties.put(RestOptions.ADDRESS.key(), activeAddress.getHost());
+            properties.put(RestOptions.PORT.key(), activeAddress.getPort());
+        } else if (ExecutionMode.isYarnMode(application.getExecutionModeEnum())) {
+            String yarnQueue = (String) application.getHotParamsMap().get(ConfigConst.KEY_YARN_APP_QUEUE());
+            if (yarnQueue != null) {
+                properties.put(ConfigConst.KEY_YARN_APP_QUEUE(), yarnQueue);
+            }
+            if (ExecutionMode.YARN_SESSION.equals(application.getExecutionModeEnum())) {
+                FlinkCluster cluster = flinkClusterService.getById(application.getFlinkClusterId());
+                AssertUtils.state(cluster != null,
+                    String.format("The yarn session clusterId=%s cannot be find, maybe the clusterId is wrong or " +
+                        "the cluster has been deleted. Please contact the Admin.", application.getFlinkClusterId()));
+                properties.put(ConfigConst.KEY_YARN_APP_ID(), cluster.getClusterId());
+            }
+        } else if (ExecutionMode.isKubernetesMode(application.getExecutionModeEnum())) {
+            properties.put(ConfigConst.KEY_K8S_IMAGE_PULL_POLICY(), "Always");
+        }
+
+        if (ExecutionMode.isKubernetesApplicationMode(application.getExecutionMode())) {
+            properties.put(JobManagerOptions.ARCHIVE_DIR.key(), Workspace.ARCHIVES_FILE_PATH());
+        }
+
+        if (application.getAllowNonRestored()) {
+            properties.put(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key(), true);
+        }
+
+        Map<String, String> dynamicProperties = FlinkSubmitter.extractDynamicPropertiesAsJava(application.getDynamicProperties());
+        properties.putAll(dynamicProperties);
+        ResolveOrder resolveOrder = ResolveOrder.of(application.getResolveOrder());
+        if (resolveOrder != null) {
+            properties.put(CoreOptions.CLASSLOADER_RESOLVE_ORDER.key(), resolveOrder.getName());
+        }
+
+        return properties;
     }
 
     private void updateToStopped(Application app) {

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/CancelRequest.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/CancelRequest.scala
@@ -32,7 +32,4 @@ case class CancelRequest(flinkVersion: FlinkVersion,
                          withDrain: Boolean,
                          customSavePointPath: String,
                          kubernetesNamespace: String = K8sFlinkConfig.DEFAULT_KUBERNETES_NAMESPACE,
-                         @Nullable option: JavaMap[String, Any]
-                      ) {
-
-}
+                         @Nullable properties: JavaMap[String, Any])

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/CancelResponse.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/CancelResponse.scala
@@ -17,6 +17,4 @@
 
 package org.apache.streampark.flink.submit.bean
 
-case class CancelResponse(savePointDir: String) {
-
-}
+case class CancelResponse(savePointDir: String)

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/DeployRequest.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/DeployRequest.scala
@@ -23,7 +23,7 @@ import java.util.{Map => JavaMap}
 import org.apache.streampark.common.conf.Workspace
 import javax.annotation.Nullable
 import org.apache.streampark.common.domain.FlinkVersion
-import org.apache.streampark.common.enums.{ExecutionMode, FlinkK8sRestExposedType, ResolveOrder}
+import org.apache.streampark.common.enums.{ExecutionMode, FlinkK8sRestExposedType}
 import org.apache.streampark.common.util.FlinkUtils
 import org.apache.commons.io.FileUtils
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions
@@ -31,12 +31,10 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions
 case class DeployRequest(flinkVersion: FlinkVersion,
                          clusterId: String,
                          executionMode: ExecutionMode,
-                         resolveOrder: ResolveOrder,
                          flameGraph: JavaMap[String, java.io.Serializable],
-                         properties: JavaMap[String, String],
-                         @Nullable k8sDeployParam: KubernetesDeployParam,
-                         @Nullable extraParameter: JavaMap[String, Any]
-                         ) {
+                         properties: JavaMap[String, Any],
+                         @Nullable k8sDeployParam: KubernetesDeployParam) {
+
   private[submit] lazy val hdfsWorkspace = {
     /**
       * You must keep the flink version and configuration in the native flink and hdfs exactly the same.

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/DeployResponse.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/DeployResponse.scala
@@ -19,5 +19,4 @@ package org.apache.streampark.flink.submit.bean
 
 case class DeployResponse(address: String,
                           clusterId: String,
-                          message: String = null
-                         )
+                          message: String = null)

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/ShutDownRequest.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/ShutDownRequest.scala
@@ -26,5 +26,4 @@ case class ShutDownRequest(flinkVersion: FlinkVersion,
                             executionMode: ExecutionMode,
                             clusterId: String,
                             @Nullable kubernetesDeployParam: KubernetesDeployParam,
-                            @Nullable extraParameter: JavaMap[String, Any]
-                          )
+                            @Nullable properties: JavaMap[String, Any])

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/SubmitRequest.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/SubmitRequest.scala
@@ -46,7 +46,6 @@ case class SubmitRequest(flinkVersion: FlinkVersion,
                          flinkYaml: String,
                          developmentMode: DevelopmentMode,
                          executionMode: ExecutionMode,
-                         resolveOrder: ResolveOrder,
                          id: Long,
                          jobId: String,
                          appName: String,
@@ -54,8 +53,7 @@ case class SubmitRequest(flinkVersion: FlinkVersion,
                          applicationType: ApplicationType,
                          savePoint: String,
                          flameGraph: JavaMap[String, java.io.Serializable],
-                         option: JavaMap[String, Any],
-                         properties: JavaMap[String, String],
+                         properties: JavaMap[String, Any],
                          args: String,
                          @Nullable buildResult: BuildResult,
                          @Nullable k8sSubmitParam: KubernetesSubmitParam,
@@ -74,7 +72,7 @@ case class SubmitRequest(flinkVersion: FlinkVersion,
 
   lazy val flinkSQL: String = extraParameter.get(KEY_FLINK_SQL()).toString
 
-  lazy val allowNonRestoredState = Try(option.get(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key).toString.toBoolean).getOrElse(false)
+  lazy val allowNonRestoredState = Try(properties.get(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key).toString.toBoolean).getOrElse(false)
 
   lazy val savepointRestoreSettings: SavepointRestoreSettings = {
     savePoint match {

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/SubmitResponse.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-api/src/main/scala/org/apache/streampark/flink/submit/bean/SubmitResponse.scala
@@ -23,6 +23,4 @@ import javax.annotation.Nullable
 case class SubmitResponse(clusterId: String,
                           flinkConfig: JavaMap[String, String],
                           @Nullable jobId: String = "",
-                          @Nullable jobManagerUrl: String = "") {
-
-}
+                          @Nullable jobManagerUrl: String = "")

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/KubernetesNativeSessionSubmit.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/KubernetesNativeSessionSubmit.scala
@@ -130,7 +130,6 @@ object KubernetesNativeSessionSubmit extends KubernetesNativeSubmitTrait with Lo
          |    exposedType      : ${deployRequest.k8sDeployParam.flinkRestExposedType}
          |    serviceAccount   : ${deployRequest.k8sDeployParam.serviceAccount}
          |    flinkImage       : ${deployRequest.k8sDeployParam.flinkImage}
-         |    resolveOrder     : ${deployRequest.resolveOrder.getName}
          |    flameGraph       : ${deployRequest.flameGraph != null}
          |    properties       : ${deployRequest.properties.mkString(" ")}
          |-------------------------------------------------------------------------------------------
@@ -139,12 +138,7 @@ object KubernetesNativeSessionSubmit extends KubernetesNativeSubmitTrait with Lo
     var client: ClusterClient[String] = null
     var kubeClient: FlinkKubeClient = null
     try {
-      val flinkConfig = extractConfiguration(
-        deployRequest.flinkVersion.flinkHome,
-        deployRequest.properties,
-        deployRequest.extraParameter,
-        deployRequest.resolveOrder)
-
+      val flinkConfig = extractConfiguration(deployRequest.flinkVersion.flinkHome, deployRequest.properties)
       flinkConfig
         .safeSet(DeploymentOptions.TARGET, KubernetesDeploymentTarget.SESSION.getName)
         .safeSet(KubernetesConfigOptions.NAMESPACE, deployRequest.k8sDeployParam.kubernetesNamespace)
@@ -181,7 +175,7 @@ object KubernetesNativeSessionSubmit extends KubernetesNativeSubmitTrait with Lo
     var kubeClient: FlinkKubeClient = null
     try {
       val flinkConfig = getFlinkDefaultConfiguration(shutDownRequest.flinkVersion.flinkHome)
-      shutDownRequest.extraParameter.foreach(m => m._2 match {
+      shutDownRequest.properties.foreach(m => m._2 match {
         case v if v != null => flinkConfig.setString(m._1, m._2.toString)
         case _ =>
       })

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/RemoteSubmit.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/RemoteSubmit.scala
@@ -52,8 +52,8 @@ object RemoteSubmit extends FlinkSubmitTrait {
   override def doCancel(cancelRequest: CancelRequest, flinkConfig: Configuration): CancelResponse = {
     flinkConfig
       .safeSet(DeploymentOptions.TARGET, cancelRequest.executionMode.getName)
-      .safeSet(RestOptions.ADDRESS, cancelRequest.option.get(RestOptions.ADDRESS.key()).toString)
-      .safeSet[JavaInt](RestOptions.PORT, cancelRequest.option.get(RestOptions.PORT.key()).toString.toInt)
+      .safeSet(RestOptions.ADDRESS, cancelRequest.properties.get(RestOptions.ADDRESS.key()).toString)
+      .safeSet[JavaInt](RestOptions.PORT, cancelRequest.properties.get(RestOptions.PORT.key()).toString.toInt)
     logInfo(
       s"""
          |------------------------------------------------------------------

--- a/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/YarnSessionSubmit.scala
+++ b/streampark-flink/streampark-flink-submit/streampark-flink-submit-core/src/main/scala/org/apache/streampark/flink/submit/impl/YarnSessionSubmit.scala
@@ -137,7 +137,7 @@ object YarnSessionSubmit extends YarnSubmitTrait {
   }
 
   override def doCancel(cancelRequest: CancelRequest, flinkConfig: Configuration): CancelResponse = {
-    flinkConfig.safeSet(YarnConfigOptions.APPLICATION_ID, cancelRequest.option.get(KEY_YARN_APP_ID).toString)
+    flinkConfig.safeSet(YarnConfigOptions.APPLICATION_ID, cancelRequest.properties.get(KEY_YARN_APP_ID).toString)
     flinkConfig.safeSet(DeploymentOptions.TARGET, YarnDeploymentTarget.SESSION.getName)
     logInfo(
       s"""
@@ -172,7 +172,6 @@ object YarnSessionSubmit extends YarnSubmitTrait {
          |    flinkVersion     : ${deployRequest.flinkVersion.version}
          |    execMode         : ${deployRequest.executionMode.name()}
          |    clusterId        : ${deployRequest.clusterId}
-         |    resolveOrder     : ${deployRequest.resolveOrder.getName}
          |    flameGraph       : ${deployRequest.flameGraph != null}
          |    properties       : ${deployRequest.properties.mkString(" ")}
          |-------------------------------------------------------------------------------------------
@@ -180,10 +179,9 @@ object YarnSessionSubmit extends YarnSubmitTrait {
     var clusterDescriptor: YarnClusterDescriptor = null
     var client: ClusterClient[ApplicationId] = null
     try {
-      val flinkConfig = extractConfiguration(deployRequest.flinkVersion.flinkHome,
-        deployRequest.properties,
-        deployRequest.extraParameter,
-        deployRequest.resolveOrder)
+      val flinkConfig = extractConfiguration(
+        deployRequest.flinkVersion.flinkHome,
+        deployRequest.properties)
       setConfig(deployRequest, flinkConfig)
       val yarnClusterDescriptor = getSessionClusterDeployDescriptor(flinkConfig)
       clusterDescriptor = yarnClusterDescriptor._2
@@ -222,7 +220,7 @@ object YarnSessionSubmit extends YarnSubmitTrait {
     var client: ClusterClient[ApplicationId] = null
     try {
       val flinkConfig = getFlinkDefaultConfiguration(shutDownRequest.flinkVersion.flinkHome)
-      shutDownRequest.extraParameter.foreach(m => m._2 match {
+      shutDownRequest.properties.foreach(m => m._2 match {
         case v if v != null => flinkConfig.setString(m._1, m._2.toString)
         case _ =>
       })


### PR DESCRIPTION
[improve] job submit parameter improvement

Currently, when submitting a flink job in streampark, there are three properties, namely `option`, `properties`, and `extraParameter`, which can cause confusion and unclear usage during method invocation, so we have simplified this part by removing the option property and putting all flink The standard configuration of flink is put in `properties`, and the extra parameters are put in `extraParameter`

## What changes were proposed in this pull request

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
