### PR TITLE
[Bug] update mysql.version from '8.0.16' to '8.0.27' as CVE-2021-2471.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <jackson.version>2.13.4</jackson.version>
         <guava.version>30.0-jre</guava.version>
         <caffeine.version>2.8.6</caffeine.version>
-        <mysql.version>8.0.16</mysql.version>
+        <mysql.version>8.0.27</mysql.version>
         <hikariCP.version>3.4.5</hikariCP.version>
         <snakeyaml.version>1.32</snakeyaml.version>
         <typesafe-conf.version>1.4.2</typesafe-conf.version>


### PR DESCRIPTION
update mysql.version from '8.0.16' to '8.0.27' as CVE-2021-2471.