### PR TITLE
[Bug]fix the "Cannot resolve org.apache.bahir:flink-connector-redis_2.12:1.0 " problem.

### DIFF
--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-redis/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-redis/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.bahir</groupId>
             <artifactId>flink-connector-redis_${scala.binary.version}</artifactId>
-            <version>1.0</version>
+            <version>1.1.0</version>
         </dependency>
 
         <!-- provided -->


### PR DESCRIPTION
[Bug]fix the "Cannot resolve org.apache.bahir:flink-connector-redis_2.12:1.0 " problem.

when choose the scala version 2.12, flink-connector-redis only support the version of 1.1.0.
https://mvnrepository.com/artifact/org.apache.bahir/flink-connector-redis
![image](https://user-images.githubusercontent.com/14801784/208346310-3fc42b05-8f0c-469b-b74a-82082da96bd5.png)

