### PR TITLE
[Improve]Streampark support remote docker daemon.

### DIFF
--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/CommonConfig.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/CommonConfig.scala
@@ -47,6 +47,12 @@ object CommonConfig {
     classType = classOf[String],
     description = "yarn http auth type. ex: sample, kerberos")
 
+  val DOCKER_HOST: InternalOption = InternalOption(
+    key = "streampark.docker.http-client.docker-host",
+    defaultValue = "",
+    classType = classOf[String],
+    description = "docker host for DockerHttpClient")
+
   val DOCKER_MAX_CONNECTIONS: InternalOption = InternalOption(
     key = "streampark.docker.http-client.max-connections",
     defaultValue = 100,

--- a/streampark-console/streampark-console-service/src/main/resources/application.yml
+++ b/streampark-console/streampark-console-service/src/main/resources/application.yml
@@ -93,6 +93,7 @@ streampark:
       max-connections: 10000
       connection-timeout-sec: 10000
       response-timeout-sec: 12000
+      docker-host: ""
 
   # flink-k8s tracking configuration
   flink-k8s:

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-redis/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-redis/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.bahir</groupId>
             <artifactId>flink-connector-redis_${scala.binary.version}</artifactId>
-            <version>1.1.0</version>
+            <version>1.0</version>
         </dependency>
 
         <!-- provided -->

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-redis/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-redis/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.bahir</groupId>
             <artifactId>flink-connector-redis_${scala.binary.version}</artifactId>
-            <version>1.0</version>
+            <version>1.1.0</version>
         </dependency>
 
         <!-- provided -->

--- a/streampark-flink/streampark-flink-packer/src/main/scala/org/apache/streampark/flink/packer/docker/DockerRetriever.scala
+++ b/streampark-flink/streampark-flink-packer/src/main/scala/org/apache/streampark/flink/packer/docker/DockerRetriever.scala
@@ -21,9 +21,10 @@ import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.core.{DefaultDockerClientConfig, DockerClientConfig, HackDockerClient}
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
 import org.apache.streampark.common.conf.{CommonConfig, InternalConfigHolder}
+import org.apache.streampark.common.util.Utils
 
+import java.net.URI
 import java.time.Duration
-
 
 object DockerRetriever {
 
@@ -51,8 +52,19 @@ object DockerRetriever {
    * get new DockerClient instance
    */
   def newDockerClient(): DockerClient = {
+    setDockerHost()
     HackDockerClient.getInstance(dockerClientConf, dockerHttpClientBuilder.build())
   }
 
+  /**
+   * set docker-host for kata
+   */
+  def setDockerHost(): Unit = {
+    val dockerhost: String = InternalConfigHolder.get(CommonConfig.DOCKER_HOST)
+    if (Utils.notEmpty(dockerhost)) {
+      val dockerHostUri: URI = new URI(dockerhost)
+      dockerHttpClientBuilder.dockerHost(dockerHostUri)
+    }
+  }
 
 }


### PR DESCRIPTION
**background**
refer the issue [#2186](https://github.com/apache/incubator-streampark/issues/2186)
This pr mainly resolve the mentioned problem.

Additional，
![image](https://user-images.githubusercontent.com/14801784/208808772-ee1ad836-664f-4846-98ea-c6c67a46257a.png)
in our test env, we had tested tcp , for example 'tcp://192.168.10.100:2375', pod could be created successfully in kata container.
