### PR TITLE
[Improve] Add some config to flink-application.conf

### DIFF
--- a/streampark-console/streampark-console-service/src/main/resources/flink-application.conf
+++ b/streampark-console/streampark-console-service/src/main/resources/flink-application.conf
@@ -51,6 +51,7 @@ flink:
         timeout: 10min
         unaligned: false
         externalized-checkpoint-retention: RETAIN_ON_CANCELLATION
+        tolerable-failed-checkpoints: 99
     # state backend
     state:
       backend: hashmap # Special note: flink1.12 optional configuration ('jobmanager', 'filesystem', 'rocksdb'), flink1.12+ optional configuration ('hashmap', 'rocksdb'),
@@ -70,6 +71,7 @@ flink:
   # table
   table:
     table.local-time-zone: default # @see https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/dev/table/config/
+    mode: streaming #(batch|streaming)
 
 app: # user's parameter
   #$key: $value


### PR DESCRIPTION
## Add some config to flink-application.conf

## Brief change log

Add `table.mode` and `execution.checkpointing.tolerable-failed-checkpoints` config to flink-application.conf file.

`table.mode`, It is convenient to configure the execution mode of the task, so that users can avoid the trouble of searching the execution mode parameter key.

`execution.checkpointing.tolerable-failed-checkpoints` default value is 0, In other words, if a checkpoint fails, the mission is restarted. On production, a large value is set to checkpoint failure to prevent task restart.

## Verifying this change

It has been verified in the production environment

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
