### PR TITLE
[Bug] fix after flink 1.15 K8S session start&stop error

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkClusterServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkClusterServiceImpl.java
@@ -263,9 +263,7 @@ public class FlinkClusterServiceImpl extends ServiceImpl<FlinkClusterMapper, Fli
         || ExecutionMode.REMOTE.equals(executionModeEnum)) {
       if (ClusterState.STARTED.equals(ClusterState.of(flinkCluster.getClusterState()))) {
         if (!flinkCluster.verifyClusterConnection()) {
-          updateWrapper.set(FlinkCluster::getAddress, null);
-          updateWrapper.set(FlinkCluster::getClusterState, ClusterState.LOST.getValue());
-          update(updateWrapper);
+          updateClusterIsLost(updateWrapper);
           throw new ApiAlertException("current cluster is not active, please check");
         }
       } else {
@@ -299,6 +297,7 @@ public class FlinkClusterServiceImpl extends ServiceImpl<FlinkClusterMapper, Fli
         updateWrapper.set(FlinkCluster::getClusterState, ClusterState.STOPED.getValue());
         update(updateWrapper);
       } else {
+        updateClusterIsLost(updateWrapper);
         throw new ApiAlertException("get shutdown response failed");
       }
     } catch (Exception e) {
@@ -308,6 +307,12 @@ public class FlinkClusterServiceImpl extends ServiceImpl<FlinkClusterMapper, Fli
       throw new ApiDetailException(
           "shutdown cluster failed, Caused By: " + ExceptionUtils.getStackTrace(e));
     }
+  }
+
+  private void updateClusterIsLost(LambdaUpdateWrapper<FlinkCluster> updateWrapper) {
+    updateWrapper.set(FlinkCluster::getAddress, null);
+    updateWrapper.set(FlinkCluster::getClusterState, ClusterState.LOST.getValue());
+    update(updateWrapper);
   }
 
   @Override


### PR DESCRIPTION

## What changes were proposed in this pull request

Issue Number:  #2188

1. because after flink 1.15 FlinkKubeClient removed the getRestService method, Therefore, the logic to verify the existence of the getRestService method is added

2.When the streampark shutdown the k8s session network exception, the response returned is null, the actual k8s session is closed, but the streampark is still in the started state, this scenario should be lost state



## Brief change log

fix after flink 1.15 K8S session start&Stop error

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

This change added tests and can be verified as follows:

- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
