### PR TITLE
[Improve] Skip Docker build for forks

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -22,9 +22,11 @@ on:
     - cron: '0 10 * * *'
   push:
     branches:
-      - '**'
+      - dev
+      - release-*
     tags:
-      - 'v*.*.*'
+      - v*
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -32,16 +34,17 @@ concurrency:
 jobs:
   build_image:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'apache/incubator-streampark' }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Java and Scala
         uses: olafurpg/setup-scala@v13
         with:
-            java-version: adopt@1.8
+          java-version: adopt@1.8
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
 


### PR DESCRIPTION
## Brief change log

This workflow always fails on forks since no DOCKER_USER and DOCKER_TOKEN configured. Actually, it should not run in forks.

BTW, perhaps we should not use GHA to release formal Docker images since it's part of a formal release. See https://github.com/apache/incubator-kvrocks/pull/1247#pullrequestreview-1284549026. But I'd regard it as a differnt topic than what this patch do.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (no)
