### PR TITLE
[Fix] add permission for /flink/conf/delete

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/ConfigController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/ConfigController.java
@@ -71,6 +71,7 @@ public class ConfigController {
   }
 
   @PostMapping("delete")
+  @RequiresPermissions("conf:delete")
   public RestResponse delete(Long id) {
     Boolean deleted = applicationConfigService.removeById(id);
     return RestResponse.success(deleted);


### PR DESCRIPTION
## What changes were proposed in this pull request

Streampark adds 'conf:delete' permission in [mysql-data.sql#L83](https://github.com/apache/incubator-streampark/blob/dev/streampark-console/streampark-console-service/src/main/assembly/script/data/mysql-data.sql#L83) , but never use it.

## Verifying this change

- *Manually verified the change by testing locally.*

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
