### PR TITLE
[Fix] remove candidate column in conf tab

### DIFF
--- a/streampark-console/streampark-console-webapp/src/views/flink/app/components/AppDetail/CompareModal.vue
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/components/AppDetail/CompareModal.vue
@@ -140,14 +140,6 @@
               <Tag color="green" style="margin-left: 10px" size="small" v-if="ver.effective">
                 Effective
               </Tag>
-              <Tag
-                color="cyan"
-                class="ml-5px"
-                size="small"
-                v-if="[CandidateTypeEnum.NEW, CandidateTypeEnum.HISTORY].includes(ver.candidate)"
-              >
-                {{ t('flink.app.detail.candidate') }}
-              </Tag>
             </div>
           </SelectOption>
         </Select>

--- a/streampark-console/streampark-console-webapp/src/views/flink/app/data/detail.data.ts
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/data/detail.data.ts
@@ -107,7 +107,6 @@ export const getConfColumns = (): BasicColumn[] => [
   { title: 'Version', dataIndex: 'version' },
   { title: 'Conf Format', dataIndex: 'format' },
   { title: 'Effective', dataIndex: 'effective' },
-  { title: 'Candidate', dataIndex: 'candidate' },
   { title: 'Modify Time', dataIndex: 'createTime' },
 ];
 


### PR DESCRIPTION
## What changes were proposed in this pull request

we use effective column to show effective or latest config, see [DetailTab.vue#L350-L353](https://github.com/apache/incubator-streampark/blob/dev/streampark-console/streampark-console-webapp/src/views/flink/app/components/AppDetail/DetailTab.vue#L350-L353), and candidate is not a property of [ApplicationConfig.java](https://github.com/apache/incubator-streampark/blob/dev/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/ApplicationConfig.java), so we can remove candidate column in config tab.

before:
![before](https://user-images.githubusercontent.com/23091870/225279979-26dd00a2-d3e1-43f5-8a47-6933c984e046.png)

after:
![after](https://user-images.githubusercontent.com/23091870/225280023-8261c1b8-a4e9-429a-ab23-8c5c0fd6c6b2.png)

## Verifying this change

- *Manually verified the change by testing locally.* 

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
