### PR TITLE
[Imporve] fix that savepointing state lasts for a long time

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/CheckpointProcessor.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/CheckpointProcessor.java
@@ -69,6 +69,8 @@ public class CheckpointProcessor {
 
   @Autowired private SavePointService savePointService;
 
+  @Autowired private FlinkRESTAPIWatcher flinkRESTAPIWatcher;
+
   public void process(Application application, @Nonnull CheckPoints checkPoints) {
     checkPoints.getLatestCheckpoint().forEach(checkPoint -> process(application, checkPoint));
   }
@@ -83,6 +85,7 @@ public class CheckpointProcessor {
       if (shouldStoreAsSavepoint(checkPointKey, checkPoint)) {
         savepointedCache.put(checkPointKey.getSavePointId(), DEFAULT_FLAG_BYTE);
         saveSavepoint(checkPoint, application.getId());
+        flinkRESTAPIWatcher.cleanSavepoint(application);
         return;
       }
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkRESTAPIWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkRESTAPIWatcher.java
@@ -568,7 +568,7 @@ public class FlinkRESTAPIWatcher {
     }
   }
 
-  private void cleanSavepoint(Application application) {
+  public void cleanSavepoint(Application application) {
     SAVEPOINT_CACHE.invalidate(application.getId());
     application.setOptionState(OptionState.NONE.getValue());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request

when we trigger savepoint in streampark web, the app status will change to `SAVEPOINTING`, and `SAVEPOINTING` state lasts for a long time, even if the savepoint operation has already finished.

## Verifying this change

- *Manually verified the change by testing locally.*

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
