### PR TITLE
[Fix] fix access token invalid bug

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/AccessTokenServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/AccessTokenServiceImpl.java
@@ -46,7 +46,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.TimeZone;
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -66,11 +65,10 @@ public class AccessTokenServiceImpl extends ServiceImpl<AccessTokenMapper, Acces
     if (StringUtils.isEmpty(expireTime)) {
       expireTime = AccessToken.DEFAULT_EXPIRE_TIME;
     }
-
     Long ttl = DateUtils.getTime(expireTime, DateUtils.fullFormat(), TimeZone.getDefault());
     String token =
         WebUtils.encryptToken(
-            JWTUtil.sign(user.getUserId(), user.getUsername(), UUID.randomUUID().toString(), ttl));
+            JWTUtil.sign(user.getUserId(), user.getUsername(), user.getPassword(), ttl));
     JWTToken jwtToken = new JWTToken(token, expireTime);
 
     AccessToken accessToken = new AccessToken();

--- a/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/AccessTokenServiceTest.java
+++ b/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/AccessTokenServiceTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.streampark.console.core.service;
+
+import org.apache.streampark.console.SpringTestBase;
+import org.apache.streampark.console.base.domain.RestResponse;
+import org.apache.streampark.console.base.util.WebUtils;
+import org.apache.streampark.console.system.authentication.JWTToken;
+import org.apache.streampark.console.system.authentication.JWTUtil;
+import org.apache.streampark.console.system.entity.AccessToken;
+import org.apache.streampark.console.system.entity.User;
+import org.apache.streampark.console.system.service.AccessTokenService;
+import org.apache.streampark.console.system.service.UserService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class AccessTokenServiceTest extends SpringTestBase {
+
+  @Autowired private AccessTokenService accessTokenService;
+
+  @Autowired private UserService userService;
+
+  @Test
+  void testGenerateToken() throws Exception {
+    Long mockUserId = 100000L;
+    String expireTime = "9999-01-01 00:00:00";
+    RestResponse restResponse = accessTokenService.generateToken(mockUserId, expireTime, "");
+    Assertions.assertNotNull(restResponse);
+    Assertions.assertInstanceOf(AccessToken.class, restResponse.get("data"));
+    AccessToken accessToken = (AccessToken) restResponse.get("data");
+    LOG.info(accessToken.getToken());
+    JWTToken jwtToken = new JWTToken(WebUtils.decryptToken(accessToken.getToken()));
+    LOG.info(jwtToken.getToken());
+    String username = JWTUtil.getUserName(jwtToken.getToken());
+    Assertions.assertNotNull(username);
+    Assertions.assertEquals("admin", username);
+    User user = userService.findByName(username);
+    Assertions.assertNotNull(user);
+    Assertions.assertTrue(JWTUtil.verify(jwtToken.getToken(), username, user.getPassword()));
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #2457  <!-- REMOVE this line if no issue to close -->

<!--(For example: This pull request proposed to add checkstyle plugin).-->

Fix access token invalid bug, because of token sign with uuid, but verify token use password

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->
- Added AccessTokenServiceTest to verify the change

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no) no
