### PR TITLE
[Fix] Exclude SNAPSHOT dependency

### DIFF
--- a/streampark-spark/streampark-spark-connector/streampark-spark-connector-kafka/pom.xml
+++ b/streampark-spark/streampark-spark-connector/streampark-spark-connector-kafka/pom.xml
@@ -64,6 +64,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
             </exclusions>
             <scope>provided</scope>
         </dependency>
@@ -73,7 +77,5 @@
             <version>${hbase.version}</version>
             <scope>provided</scope>
         </dependency>
-
     </dependencies>
-
 </project>


### PR DESCRIPTION
* See also https://issues.apache.org/jira/browse/STORM-3828
* See also https://issues.apache.org/jira/browse/JCR-4626

org.glassfish:javax.el is unused for StreamPark. Depend on a SNAPSHOT lib can cause:

> [ERROR] Failed to execute goal on project streampark-spark-connector-kafka_2.12: Could not resolve dependencies for project org.apache.streampark:streampark-spark-connector-kafka_2.12:jar:2.1.0-SNAPSHOT: Failed to collect dependencies at org.apache.hbase:hbase-server:jar:2.1.10 -> org.glassfish.web:javax.servlet.jsp:jar:2.3.2 -> org.glassfish:javax.el:jar:3.0.1-b06-SNAPSHOT: Failed to read artifact descriptor for org.glassfish:javax.el:jar:3.0.1-b06-SNAPSHOT: Could not transfer artifact org.glassfish:javax.el:pom:3.0.1-b06-SNAPSHOT from/to jvnet-nexus-snapshots (https://maven.java.net/content/repositories/snapshots): transfer failed for https://maven.java.net/content/repositories/snapshots/org/glassfish/javax.el/3.0.1-b06-SNAPSHOT/javax.el-3.0.1-b06-SNAPSHOT.pom: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target -> [Help 1]

## Verifying this change

Manually successfully build locally.

## Does this pull request potentially affect one of the following parts

 - Dependencies (does it add or upgrade a dependency): (no)
