### PR TITLE
[Bug] flink job status tracking bug

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/enums/FlinkAppState.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/enums/FlinkAppState.java
@@ -128,7 +128,7 @@ public enum FlinkAppState implements Serializable {
         || FlinkAppState.KILLED == flinkAppState
         || FlinkAppState.FINISHED == flinkAppState
         || FlinkAppState.SUCCEEDED == flinkAppState
-        || FlinkAppState.LOST == flinkAppState
+        // || FlinkAppState.LOST == flinkAppState
         || FlinkAppState.TERMINATED == flinkAppState;
   }
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkRESTAPIWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkRESTAPIWatcher.java
@@ -238,7 +238,6 @@ public class FlinkRESTAPIWatcher {
                   application.setEndTime(new Date());
                   cleanSavepoint(application);
                   cleanOptioning(optionState, key);
-                  doPersistMetrics(application, false);
                   FlinkAppState appState = FlinkAppState.of(application.getState());
                   if (appState.equals(FlinkAppState.FAILED)
                       || appState.equals(FlinkAppState.LOST)) {
@@ -415,6 +414,7 @@ public class FlinkRESTAPIWatcher {
       application.setAvailableSlot(null);
       application.setJmMemory(null);
       application.setTmMemory(null);
+      unWatching(application.getId());
     } else if (stopWatch) {
       unWatching(application.getId());
     } else {

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkRESTAPIWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkRESTAPIWatcher.java
@@ -238,7 +238,7 @@ public class FlinkRESTAPIWatcher {
                   application.setEndTime(new Date());
                   cleanSavepoint(application);
                   cleanOptioning(optionState, key);
-                  doPersistMetrics(application, true);
+                  doPersistMetrics(application, false);
                   FlinkAppState appState = FlinkAppState.of(application.getState());
                   if (appState.equals(FlinkAppState.FAILED)
                       || appState.equals(FlinkAppState.LOST)) {
@@ -415,7 +415,6 @@ public class FlinkRESTAPIWatcher {
       application.setAvailableSlot(null);
       application.setJmMemory(null);
       application.setTmMemory(null);
-      unWatching(application.getId());
     } else if (stopWatch) {
       unWatching(application.getId());
     } else {

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkRESTAPIWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkRESTAPIWatcher.java
@@ -238,6 +238,7 @@ public class FlinkRESTAPIWatcher {
                   application.setEndTime(new Date());
                   cleanSavepoint(application);
                   cleanOptioning(optionState, key);
+                  doPersistMetrics(application, false);
                   FlinkAppState appState = FlinkAppState.of(application.getState());
                   if (appState.equals(FlinkAppState.FAILED)
                       || appState.equals(FlinkAppState.LOST)) {


### PR DESCRIPTION

## What changes were proposed in this pull request
When the Flink job manager restarts, the status of the job changes from "RUNNING" to "LOST". The application (Flink job) is marked as tracking=0 in the database, which means that the background task will not monitor the status of the Flink job using the REST API.

![image](https://user-images.githubusercontent.com/16623214/226507498-0428f2f3-a2ca-41c6-8176-65b3dec09f07.png)

## Brief change log

fix  job tracking bug when rest api request failed



## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): ( no)
