### PR TITLE
[improve] support i18n for tab name & add copy button for backup path

### DIFF
--- a/streampark-console/streampark-console-webapp/src/locales/lang/en/flink/app.ts
+++ b/streampark-console/streampark-console-webapp/src/locales/lang/en/flink/app.ts
@@ -88,6 +88,14 @@ export default {
     nullAccessToken: 'access token is null,please contact the administrator to add.',
     invalidAccessToken: 'access token is invalid,please contact the administrator.',
     detailTab: {
+      detailTabName: {
+        option: 'Option',
+        configuration: 'Configuration',
+        flinkSql: 'Flink SQL',
+        savepoint: 'Savepoint',
+        backup: 'Backup',
+        operationLog: 'Operation Log'
+      },
       configDetail: 'View Config Detail',
       sqlDetail: 'View SQL Detail',
       confDeleteTitle: 'Are you sure delete this record?',

--- a/streampark-console/streampark-console-webapp/src/locales/lang/zh-CN/flink/app.ts
+++ b/streampark-console/streampark-console-webapp/src/locales/lang/zh-CN/flink/app.ts
@@ -90,7 +90,7 @@ export default {
         option: '选项',
         configuration: '配置',
         flinkSql: 'Flink SQL',
-        savepoint: '保存点',
+        savepoint: 'Savepoint',
         backup: '备份',
         operationLog: '操作日志'
       },

--- a/streampark-console/streampark-console-webapp/src/locales/lang/zh-CN/flink/app.ts
+++ b/streampark-console/streampark-console-webapp/src/locales/lang/zh-CN/flink/app.ts
@@ -86,6 +86,14 @@ export default {
     nullAccessToken: '访问令牌为空，请联系管理员添加.',
     invalidAccessToken: '访问令牌无效，请联系管理员。',
     detailTab: {
+      detailTabName: {
+        option: '选项',
+        configuration: '配置',
+        flinkSql: 'Flink SQL',
+        savepoint: '保存点',
+        backup: '备份',
+        operationLog: '操作日志'
+      },
       configDetail: '查看配置详情',
       sqlDetail: '查看 SQL 详情',
       confDeleteTitle: '您确定要删除此记录吗?',

--- a/streampark-console/streampark-console-webapp/src/views/flink/app/components/AppDetail/DetailTab.vue
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/components/AppDetail/DetailTab.vue
@@ -282,8 +282,15 @@
   }
 
   function getBackupAction(record: Recordable): ActionItem[] {
-    return [{
-      popConfirm: {
+    return [
+      {
+        tooltip: { title: t('flink.app.detail.detailTab.copyPath') },
+        shape: 'circle',
+        icon: 'ant-design:copy-outlined',
+        onClick: handleCopy.bind(null, record),
+      },
+      {
+        popConfirm: {
         title: t('flink.app.detail.detailTab.confBackupTitle'),
           confirm: handleDeleteBackup.bind(null, record),
       },
@@ -333,7 +340,7 @@
       </TabPane>
       <TabPane
         key="2"
-        tab="Configuration"
+        :tab="t('flink.app.detail.detailTab.detailTabName.configuration')"
         v-if="app && app.appType == AppTypeEnum.STREAMPARK_FLINK && tabConf.showConf"
       >
         <BasicTable @register="registerConfigTable">
@@ -361,7 +368,7 @@
           </template>
         </BasicTable>
       </TabPane>
-      <TabPane key="3" tab="Flink SQL" v-if="app.jobType === JobTypeEnum.SQL">
+      <TabPane key="3" :tab="t('flink.app.detail.detailTab.detailTabName.flinkSql')" v-if="app.jobType === JobTypeEnum.SQL">
         <BasicTable @register="registerFlinkSqlTable">
           <template #bodyCell="{ column, record }">
             <template v-if="column.dataIndex == 'candidate'">
@@ -387,7 +394,7 @@
           </template>
         </BasicTable>
       </TabPane>
-      <TabPane key="4" tab="Savepoints" v-if="tabConf.showSaveOption">
+      <TabPane key="4" :tab="t('flink.app.detail.detailTab.detailTabName.savepoint')" v-if="tabConf.showSaveOption">
         <BasicTable @register="registerSavePointTable">
           <template #bodyCell="{ column, record }">
             <template v-if="column.dataIndex == 'triggerTime'">
@@ -413,7 +420,7 @@
           </template>
         </BasicTable>
       </TabPane>
-      <TabPane key="5" tab="Backups" v-if="tabConf.showBackup">
+      <TabPane key="5" :tab="t('flink.app.detail.detailTab.detailTabName.backup')" v-if="tabConf.showBackup">
         <BasicTable @register="registerBackupTable">
           <template #bodyCell="{ column, record }">
             <template v-if="column.dataIndex == 'version'">
@@ -427,7 +434,7 @@
           </template>
         </BasicTable>
       </TabPane>
-      <TabPane key="6" tab="Option Logs" v-if="tabConf.showOptionLog">
+      <TabPane key="6" :tab="t('flink.app.detail.detailTab.detailTabName.operationLog')" v-if="tabConf.showOptionLog">
         <BasicTable @register="registerLogsTable">
           <template #bodyCell="{ column, record }">
             <template v-if="column.dataIndex == 'yarnAppId'">


### PR DESCRIPTION
## What changes were proposed in this pull request

1. add i18n support for tab name

![1](https://user-images.githubusercontent.com/23091870/227080295-5d0a2a7b-ea1b-482e-9f6d-1196baa6a778.png)

2. add copy button for backup path

![3](https://user-images.githubusercontent.com/23091870/227080497-140d8dc7-dc85-4067-9479-ef6fa54ec971.png)

3. change `Option Log` to `Operation Log`

## Verifying this change

- *Manually verified the change by testing locally.* 

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
