### PR TITLE
Fix dotenv pairs

### DIFF
--- a/streampark-console/streampark-console-webapp/.env
+++ b/streampark-console/streampark-console-webapp/.env
@@ -17,7 +17,7 @@
 VITE_PORT=10001
 
 # spa-title
-VITE_GLOB_APP_TITLE=Apache StreamPark
+VITE_GLOB_APP_TITLE="Apache StreamPark"
 
 # spa shortname
-VITE_GLOB_APP_SHORT_NAME=StreamPark
+VITE_GLOB_APP_SHORT_NAME="StreamPark"

--- a/streampark-console/streampark-console-webapp/.env.development
+++ b/streampark-console/streampark-console-webapp/.env.development
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 # public path
-VITE_PUBLIC_PATH = /
+VITE_PUBLIC_PATH=/
 
 # Cross-domain proxy, you can configure multiple
 # Please note that no line breaks
-VITE_PROXY = [["/basic-api","http://localhost:10000"]]
+VITE_PROXY=[["/basic-api","http://localhost:10000"]]
 
 # Delete console
-VITE_DROP_CONSOLE = false
+VITE_DROP_CONSOLE=false
 
 # Basic interface address SPA
 VITE_GLOB_API_URL=/basic-api
@@ -32,4 +32,4 @@ VITE_GLOB_UPLOAD_URL=/upload
 # Interface prefix
 VITE_GLOB_API_URL_PREFIX=
 
-VITE_APP_BASE_API = /basic-api
+VITE_APP_BASE_API=/basic-api

--- a/streampark-console/streampark-console-webapp/.env.production
+++ b/streampark-console/streampark-console-webapp/.env.production
@@ -14,18 +14,18 @@
 # limitations under the License.
 
 # public path
-VITE_PUBLIC_PATH = /
+VITE_PUBLIC_PATH=/
 
 # Delete console
-VITE_DROP_CONSOLE = true
+VITE_DROP_CONSOLE=true
 
 # Whether to enable gzip or brotli compression
 # Optional: gzip | brotli | none
 # If you need multiple forms, you can use `,` to separate
-VITE_BUILD_COMPRESS = 'gzip'
+VITE_BUILD_COMPRESS=gzip
 
 # Whether to delete origin files when using compress, default false
-VITE_BUILD_COMPRESS_DELETE_ORIGIN_FILE = false
+VITE_BUILD_COMPRESS_DELETE_ORIGIN_FILE=false
 
 # Basic interface address SPA
 VITE_GLOB_API_URL=
@@ -38,7 +38,7 @@ VITE_GLOB_UPLOAD_URL=/upload
 VITE_GLOB_API_URL_PREFIX=
 
 # Whether to enable image compression
-VITE_USE_IMAGEMIN= true
+VITE_USE_IMAGEMIN=true
 
 # Is it compatible with older browsers
-VITE_LEGACY = false
+VITE_LEGACY=false


### PR DESCRIPTION
## What changes were proposed in this pull request

dotenv payload is effectively shell.

Without this patch, dotenv loads can provide warnings:

```
.env:20: command not found: StreamPark
```

## Brief change log

Trivially trim whitespace and quote strings.

## Verifying this change

Manually locally.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (no)
