### PR TITLE
[issue-2510] update springboot version to 2.7.10

### DIFF
--- a/streampark-console/streampark-console-service/pom.xml
+++ b/streampark-console/streampark-console-service/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.7.3</version>
+                <version>2.7.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #2510 

## Brief change log

springboot 2.7.10 depends on springframework `5.3.26` which fixed `CVE-2023-20860.`

## Verifying this change

- *Manually verified the change by testing locally.* 

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
