### PR TITLE
[bug] fix the wrong duration value in webui

### DIFF
--- a/streampark-console/streampark-console-webapp/src/utils/dateUtil.ts
+++ b/streampark-console/streampark-console-webapp/src/utils/dateUtil.ts
@@ -44,10 +44,10 @@ export function dateToDuration(ms: number) {
   const hh = mi * 60;
   const dd = hh * 24;
 
-  const day = parseInt(ms / dd);
-  const hour = parseInt((ms - day * dd) / hh);
-  const minute = parseInt((ms - day * dd - hour * hh) / mi);
-  const seconds = parseInt((ms - day * dd - hour * hh - minute * mi) / ss);
+  const day = Math.floor(ms / dd);
+  const hour = Math.floor((ms - day * dd) / hh);
+  const minute = Math.floor((ms - day * dd - hour * hh) / mi);
+  const seconds = Math.floor((ms - day * dd - hour * hh - minute * mi) / ss);
   if (day > 0) {
     return day + 'd ' + hour + 'h ' + minute + 'm ' + seconds + 's';
   } else if (hour > 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request

when duration time is less than 87ms, function [dateToDuration](https://github.com/apache/incubator-streampark/blob/dev/streampark-console/streampark-console-webapp/src/utils/dateUtil.ts#L38) will return a bad result. This is because `parseInt` cannot handle scientific notation well.

![duration_error](https://user-images.githubusercontent.com/23091870/228519986-7c1e14ae-ab22-4f2a-a1f1-82e5c96ec41d.png)

**FYI:** same reason as [PR-1585](https://github.com/apache/incubator-streampark/pull/1585)

## Verifying this change

- *Manually verified the change by testing locally.* 

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
