### PR TITLE
[bug] change flinksql to a history version does not take effect

### DIFF
--- a/streampark-console/streampark-console-webapp/src/views/flink/app/EditStreamPark.vue
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/EditStreamPark.vue
@@ -202,7 +202,7 @@
       }
       const params = {
         id: app.id,
-        sqlId: values.sqlId || app.sqlId || null,
+        sqlId: values.flinkSqlHistory || app.sqlId || null,
         flinkSql: values.flinkSql,
         config,
         format: values.isSetConfig ? 1 : null,


### PR DESCRIPTION
## What changes were proposed in this pull request

when editing an application in web-ui, we can change flinksql to a history version, but the selected history version won't take effect. That because the selected `sqlId` passed from frontend is incorrect and would make streampark create a new flinksql in backend whenever the flinksql version is changed.

## Verifying this change

- *Manually verified the change by testing locally.* 

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
