### PR TITLE
[Hotfix] Fix the redundant deleteIngress calling when 'doTriggerSavepoint' for k8s.

### DIFF
--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/KubernetesNativeClientTrait.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/KubernetesNativeClientTrait.scala
@@ -116,7 +116,6 @@ trait KubernetesNativeClientTrait extends FlinkClientTrait {
   override def doTriggerSavepoint(request: TriggerSavepointRequest, flinkConfig: Configuration): SavepointResponse = {
     executeClientAction(request, flinkConfig, (jobId, clusterClient) => {
       val actionResult = super.triggerSavepoint(request, jobId, clusterClient)
-      IngressController.deleteIngress(request.clusterId, request.kubernetesNamespace)
       SavepointResponse(actionResult)
     })
   }


### PR DESCRIPTION


<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Fix the redundant deleteIngress calling when 'doTriggerSavepoint' for k8s.

## Brief change log

Fix the redundant deleteIngress calling when 'doTriggerSavepoint' for k8s.

## Verifying this change


This change added tests and can be verified as follows:

- *Manually verified the change by testing locally.* 

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
