### PR TITLE
[FIx] correct the path of shims jar

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvInitializer.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvInitializer.java
@@ -69,7 +69,7 @@ public class EnvInitializer implements ApplicationRunner {
 
   private static final Pattern PATTERN_FLINK_SHIMS_JAR =
       Pattern.compile(
-          "^streampark-flink-shims_flink-1.1[2-7]_(2.11|2.12)-(.*).jar$",
+          "^streampark-flink-shims_flink-(1.1[2-7])_(2.11|2.12)-(.*).jar$",
           Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request

the path of shims jar is incorrect, when release app, we cannot pack shims jar into flink-job jar. 

## Verifying this change

- *Manually verified the change by testing locally.* 

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)