### PR TITLE
[Fix] parse key with fraction suffix to float

### DIFF
--- a/streampark-console/streampark-console-webapp/src/views/flink/app/hooks/useEdit.ts
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/hooks/useEdit.ts
@@ -75,11 +75,22 @@ export const useEdit = () => {
         } else {
           if (k.startsWith('jobmanager.memory.')) {
             memoryItems.jmMemoryItems.push(key);
-            fieldValueOptions.jmOptionsItem[key] = parseFloat(v);
+            if (k === 'jobmanager.memory.jvm-overhead.fraction') {
+              fieldValueOptions.jmOptionsItem[key] = parseFloat(v);
+            } else {
+              fieldValueOptions.jmOptionsItem[key] = parseInt(v);
+            }
           }
           if (k.startsWith('taskmanager.memory.')) {
             memoryItems.tmMemoryItems.push(key);
-            fieldValueOptions.tmOptionsItem[key] = parseFloat(v);
+            if (
+              k === 'taskmanager.memory.managed.fraction' ||
+              k === 'taskmanager.memory.jvm-overhead.fraction'
+            ) {
+              fieldValueOptions.tmOptionsItem[key] = parseFloat(v);
+            } else {
+              fieldValueOptions.tmOptionsItem[key] = parseInt(v);
+            }
           }
         }
       } else {


### PR DESCRIPTION
## What changes were proposed in this pull request

the following options should be parsed as float：
- `jobmanager.memory.jvm-overhead.fraction`
- `taskmanager.memory.managed.fraction`
- `taskmanager.memory.jvm-overhead.fraction`

## Verifying this change

- *Manually verified the change by testing locally.* 

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
