### PR TITLE
[bug] there is no log output in kubernetes session cluster

### DIFF
--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesNativeSessionClient.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesNativeSessionClient.scala
@@ -149,6 +149,7 @@ object KubernetesNativeSessionClient extends KubernetesNativeClientTrait with Lo
         .safeSet(KubernetesConfigOptions.CLUSTER_ID, deployRequest.clusterId)
         .safeSet(KubernetesConfigOptions.CONTAINER_IMAGE, deployRequest.k8sDeployParam.flinkImage)
         .safeSet(KubernetesConfigOptions.KUBE_CONFIG_FILE, getDefaultKubernetesConf(deployRequest.k8sDeployParam.kubeConf))
+        .safeSet(DeploymentOptionsInternal.CONF_DIR, s"${deployRequest.flinkVersion.flinkHome}/conf")
 
       val kubernetesClusterDescriptor = getK8sClusterDescriptorAndSpecification(flinkConfig)
       clusterDescriptor = kubernetesClusterDescriptor._1


### PR DESCRIPTION
## What changes were proposed in this pull request

when deploying a kubernetes session cluster with streampark, there is no log output neither in `webui/job manager/logs` nor in `kubectl logs` output.

![no-log-jm](https://user-images.githubusercontent.com/23091870/231329410-ea665301-755e-442d-80ff-a121dc570b84.png)

output of `kubectl logs`:
```
sed: couldn't open temporary file /opt/flink/conf/sedgqXrHO: Read-only file system
sed: couldn't open temporary file /opt/flink/conf/sedPEE0Kh: Read-only file system
/docker-entrypoint.sh: line 73: /opt/flink/conf/flink-conf.yaml: Read-only file system
/docker-entrypoint.sh: line 89: /opt/flink/conf/flink-conf.yaml.tmp: Read-only file system
Starting kubernetes-session as a console application on host sasasasaasa-7c6f8886bb-fhht8.
ERROR StatusLogger Reconfiguration failed: No configuration found for '6d21714c' at 'null' in 'null'
ERROR StatusLogger Reconfiguration failed: No configuration found for '327af41b' at 'null' in 'null'
```

## Brief change log

when deploying a kubernetes session cluster, flink kubernetes client needs conf dir to mount log config, so we should set flink conf dir in flink configuration.

## Verifying this change

- *Manually verified the change by testing locally.*

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)