### PR TITLE
[Improve] remove profile flink-1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -752,16 +752,6 @@
 
     <profiles>
         <profile>
-            <id>flink-1.15</id>
-            <properties>
-                <streampark.flink.shims.version>1.15</streampark.flink.shims.version>
-                <flink.version>1.15.0</flink.version>
-                <scala.binary.flink.version />
-                <flink.table.uber.artifact.id>flink-table-api-java-uber</flink.table.uber.artifact.id>
-            </properties>
-        </profile>
-
-        <profile>
             <id>scala-2.11</id>
             <properties>
                 <scala.version>2.11.12</scala.version>


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #2360 

## Brief change log

the build progress would fail if profile `flink-1.15` is activated, this may make developers confused. besides, profile flink-1.15 seems not very useful, maybe we should remove this profile.

## Verifying this change

- *Manually verified the change by testing locally.*

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
