### PR TITLE
[hotfix] Add default local workspace directory

### DIFF
--- a/streampark-console/streampark-console-service/src/main/assembly/assembly.xml
+++ b/streampark-console/streampark-console-service/src/main/assembly/assembly.xml
@@ -90,6 +90,11 @@
             <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>
+            <directory>${project.build.directory}/../src/main/assembly/workspace</directory>
+            <outputDirectory>workspace</outputDirectory>
+            <fileMode>0777</fileMode>
+        </fileSet>
+        <fileSet>
             <directory>${project.build.directory}/../src/main/resources</directory>
             <outputDirectory>conf</outputDirectory>
             <lineEnding>unix</lineEnding>

--- a/streampark-console/streampark-console-service/src/main/resources/application.yml
+++ b/streampark-console/streampark-console-service/src/main/resources/application.yml
@@ -96,7 +96,7 @@ streampark:
   hadoop-user-name: hdfs
   # local workspace, used to store source code and build dir etc.
   workspace:
-    local:
+    local: /streampark/workspace
     remote: hdfs://hdfscluster/streampark   # support hdfs:///streampark/ 、 /streampark 、hdfs://host:ip/streampark/
 
   # remote docker register namespace for streampark


### PR DESCRIPTION
Add default `workspace` directory,because `streampark.sh`  will validate this directory's permission and whether exists.