### PR TITLE
[FIX] add flink-shaded-guava back

### DIFF
--- a/streampark-console/streampark-console-service/pom.xml
+++ b/streampark-console/streampark-console-service/pom.xml
@@ -54,7 +54,6 @@
         <xml-apis.version>1.4.01</xml-apis.version>
         <ivy.version>2.5.0</ivy.version>
         <eclipse.jgit.version>5.13.1.202206130422-r</eclipse.jgit.version>
-        <flink.shaded.guava.version>30.1.1-jre-14.0</flink.shaded.guava.version>
     </properties>
 
     <dependencyManagement>
@@ -398,13 +397,6 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>force-shading</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-shaded-guava</artifactId>
-            <version>${flink.shaded.guava.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request

Add flink-shaded-guava back which is used in kubernetes mode.

## Verifying this change

- *Manually verified the change by testing locally.*

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (**yes** / no)