### PR TITLE
[FIX] streampark version displayed in FE does not match the current version

### DIFF
--- a/streampark-console/streampark-console-webapp/package.json
+++ b/streampark-console/streampark-console-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streampark-webapp",
-  "version": "2.1.0",
+  "version": "2.2.0-SNAPSHOT",
   "author": {
     "name": "streampark",
     "url": "https://streampark.apache.org"


### PR DESCRIPTION
## What changes were proposed in this pull request

![0504](https://user-images.githubusercontent.com/23091870/236107511-8f4e6454-65b3-442e-8d2c-5278c618bd3d.png)

## Verifying this change

- *Manually verified the change by testing locally.*

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)