### PR TITLE
[Bugfix]Upgrade commons cli version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <typesafe-conf.version>1.4.2</typesafe-conf.version>
         <json4s-jackson.version>4.0.6</json4s-jackson.version>
-        <commons-cli.version>1.3.1</commons-cli.version>
+        <commons-cli.version>1.5</commons-cli.version>
         <commons-net.version>3.9.0</commons-net.version>
         <commons-lang3.version>3.8.1</commons-lang3.version>
         <enumeratum.version>1.6.1</enumeratum.version>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <typesafe-conf.version>1.4.2</typesafe-conf.version>
         <json4s-jackson.version>4.0.6</json4s-jackson.version>
-        <commons-cli.version>1.5</commons-cli.version>
+        <commons-cli.version>1.5.0</commons-cli.version>
         <commons-net.version>3.9.0</commons-net.version>
         <commons-lang3.version>3.8.1</commons-lang3.version>
         <enumeratum.version>1.6.1</enumeratum.version>


### PR DESCRIPTION
Since flink 1.15, the commons cli version used by flink clients package is 1.5.0.
Streampark currently uses commons cli 1.3.1, which is not compatible with flink 1.17.0.
See #2723
Upgrade the commons cli version will fix this problem.
I have tested this modification in prod environment under flink 1.16.0 & 1.17.0 and streampark 2.1.0-rc1.