### PR TITLE
[Bug] Kubernetes session cluster can be deleted even if it's still in use

### DIFF
--- a/streampark-console/streampark-console-webapp/src/views/flink/app/Add.vue
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/Add.vue
@@ -169,6 +169,9 @@
       })[0] || null;
     if (cluster) {
       Object.assign(values, { flinkClusterId: cluster.id });
+      if (values.executionMode == ExecModeEnum.KUBERNETES_SESSION) {
+        Object.assign(values, { clusterId: cluster.clusterId });
+      }
     }
   }
 

--- a/streampark-console/streampark-console-webapp/src/views/flink/app/EditStreamPark.vue
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/EditStreamPark.vue
@@ -52,7 +52,7 @@
   import { useGo } from '/@/hooks/web/usePage';
   import ProgramArgs from './components/ProgramArgs.vue';
   import VariableReview from './components/VariableReview.vue';
-  import { ExecModeEnum, JobTypeEnum, UseStrategyEnum } from '/@/enums/flinkEnum';
+  import { ClusterStateEnum, ExecModeEnum, JobTypeEnum, UseStrategyEnum } from '/@/enums/flinkEnum';
 
   const route = useRoute();
   const go = useGo();
@@ -80,6 +80,7 @@
   const {
     alerts,
     flinkEnvs,
+    flinkClusters,
     flinkSql,
     getEditStreamParkFormSchema,
     registerDifferentDrawer,
@@ -254,6 +255,16 @@
 
   /* Send submission interface */
   async function handleUpdateApp(params: Recordable) {
+    if (params.executionMode == ExecModeEnum.KUBERNETES_SESSION) {
+      const cluster =
+        unref(flinkClusters).filter((c) => {
+          return c.id == params.flinkClusterId && c.clusterState === ClusterStateEnum.STARTED;
+        })[0] || null;
+      if (cluster) {
+        Object.assign(params, { clusterId: cluster.clusterId });
+      }
+    }
+
     try {
       const updated = await fetchUpdate(params);
       if (updated) {

--- a/streampark-console/streampark-console-webapp/src/views/flink/app/hooks/useCreateAndEditSchema.ts
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/hooks/useCreateAndEditSchema.ts
@@ -285,13 +285,13 @@ export const useCreateAndEditSchema = (
         ],
       },
       {
-        field: 'clusterId',
+        field: 'flinkClusterId',
         label: t('flink.app.kubernetesClusterId'),
         component: 'Select',
         ifShow: ({ values }) => values.executionMode == ExecModeEnum.KUBERNETES_SESSION,
         componentProps: {
           placeholder: t('flink.app.addAppTips.kubernetesClusterIdPlaceholder'),
-          options: getExecutionCluster(ExecModeEnum.KUBERNETES_SESSION, 'clusterId'),
+          options: getExecutionCluster(ExecModeEnum.KUBERNETES_SESSION, 'id'),
         },
         rules: [
           {


### PR DESCRIPTION
## What changes were proposed in this pull request

Kubernetes session cluster can be deleted even if it's still in use, that because application which ran in kubernetes session mode does not set flinkClusterId field in database.

## Verifying this change

- *Manually verified the change by testing locally.* 

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / **no**)
