### PR TITLE
[Improve] Upgrade Scala patch versions to build on JDK 17

### DIFF
--- a/dist-material/release-docs/LICENSE
+++ b/dist-material/release-docs/LICENSE
@@ -491,9 +491,9 @@ The text of each license is the standard Apache 2.0 license. https://www.apache.
     https://mvnrepository.com/artifact/org.objenesis/objenesis/2.1 Apache-2.0
     https://mvnrepository.com/artifact/org.objenesis/objenesis/3.2 Apache-2.0
     https://mvnrepository.com/artifact/org.quartz-scheduler/quartz/2.3.2 Apache-2.0
-    https://mvnrepository.com/artifact/org.scala-lang/scala-compiler/2.12.8 Apache-2.0
-    https://mvnrepository.com/artifact/org.scala-lang/scala-library/2.12.8 Apache-2.0
-    https://mvnrepository.com/artifact/org.scala-lang/scala-reflect/2.12.8 Apache-2.0
+    https://mvnrepository.com/artifact/org.scala-lang/scala-compiler/2.12.17 Apache-2.0
+    https://mvnrepository.com/artifact/org.scala-lang/scala-library/2.12.17 Apache-2.0
+    https://mvnrepository.com/artifact/org.scala-lang/scala-reflect/2.12.17 Apache-2.0
     https://mvnrepository.com/artifact/org.scalaj/scalaj-http_2.12/2.4.2 Apache-2.0
     https://mvnrepository.com/artifact/org.slf4j/jcl-over-slf4j/1.7.36 Apache-2.0
     https://mvnrepository.com/artifact/org.slf4j/log4j-over-slf4j/1.7.30 Apache-2.0

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <scala.version>2.12.8</scala.version>
+        <scala.version>2.12.17</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.xml.version>1.3.0</scala.xml.version>
         <scalatest.version>3.2.9</scalatest.version>


### PR DESCRIPTION
## What changes were proposed in this pull request

See https://github.com/sbt/sbt/issues/5509 and https://github.com/sbt/sbt/issues/5093.

Otherwise, build with JDK 17 will fail with:

```
/packages cannot be represented as URI
```

I suppose upgrading patch versions of Scala should not affect end-user's experience.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes)
