### PR TITLE
[fix] Remove latest tag on docker image triggered by branch dev

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -78,7 +78,6 @@ jobs:
         with:
           images: apache/streampark
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=tag
             type=ref,event=branch
 


### PR DESCRIPTION
[fix] Remove latest tag on docker image triggered by branch dev.

Test scene:
Step1: Login to docker hub and remove `latest` tag and add new tag `v2.1.1`. Here is result:
<img width="723" alt="b8a0663e27588a48ef88538bb1a2e7f" src="https://github.com/apache/incubator-streampark/assets/13617900/008e1e38-dc08-49e0-950a-339be7db60cf">
Step2: Append commit to `dev` branch and result is:
<img width="645" alt="be0648718c9d86cbf0e385c8fbdc982" src="https://github.com/apache/incubator-streampark/assets/13617900/ce14400a-39cd-4c2f-8092-9feb646619de">
Step3: Append commit to `release-2.1.0` branch and result is:
<img width="1017" alt="a5c0577f0624c1c5058e4cb01fdd4c4" src="https://github.com/apache/incubator-streampark/assets/13617900/645d0371-f090-47a3-bce2-98d122845163">
Step4: Append commit to `dev` branch and result is:
<img width="984" alt="企业微信截图_1686129504296" src="https://github.com/apache/incubator-streampark/assets/13617900/5f6cd440-bf5a-4d7d-91c3-f837a7d0c019">

