### PR TITLE
[Fix]: monaco editor foldingStrategy parameters

### DIFF
--- a/streampark-console/streampark-console-webapp/src/hooks/web/useMonaco.ts
+++ b/streampark-console/streampark-console-webapp/src/hooks/web/useMonaco.ts
@@ -182,7 +182,8 @@ export function useMonaco(
           insertSpaces: true,
           autoClosingQuotes: 'always',
           detectIndentation: false,
-          folding: false,
+          folding: true,
+          foldingStrategy: 'indentation', // code fragmentation
           automaticLayout: true,
           theme: 'vs',
           minimap: {

--- a/streampark-console/streampark-console-webapp/src/views/flink/app/data/index.ts
+++ b/streampark-console/streampark-console-webapp/src/views/flink/app/data/index.ts
@@ -69,7 +69,6 @@ export const getAppColumns = (): BasicColumn[] => [
 export const getMonacoOptions = (readOnly: boolean) => {
   return {
     selectOnLineNumbers: false,
-    foldingStrategy: 'indentation', // code fragmentation
     overviewRulerBorder: false, // Don't scroll bar borders
     autoClosingBrackets: 'always',
     autoClosingDelete: 'always',

--- a/streampark-console/streampark-console-webapp/src/views/setting/FlinkHome/components/Drawer.vue
+++ b/streampark-console/streampark-console-webapp/src/views/setting/FlinkHome/components/Drawer.vue
@@ -47,6 +47,7 @@
     language: 'yaml',
     options: {
       selectOnLineNumbers: false,
+      folding: true,
       foldingStrategy: 'indentation', // code fragmentation
       overviewRulerBorder: false, // Don't scroll bar borders
       tabSize: 2, // tab indent length
@@ -57,7 +58,7 @@
       automaticLayout: true,
       cursorStyle: 'line',
       cursorWidth: 3,
-      renderFinalNewline: true,
+      renderFinalNewline: 'on',
       renderLineHighlight: 'all',
       quickSuggestionsDelay: 100, // Code prompt delay
       minimap: { enabled: true },


### PR DESCRIPTION

## Fix the problem of invalid foldingStrategy in SQL editor parameter


<img width="1180" alt="iShot_2023-07-12_11 55 52" src="https://github.com/apache/incubator-streampark/assets/39726513/b86d8113-6a2a-40eb-9bda-43b818f5da86">

Editor adds code folding