### PR TITLE
docs: drop vanity metrics from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,6 @@ Thank you to all the people who already contributed to StreamPark!
 
 [![contrib graph](https://contrib.rocks/image?repo=apache/streampark)](https://github.com/apache/incubator-streampark/graphs/contributors)
 
-## ⏰ Contributor Over Time
-
-[![Stargazers Over Time](https://contributor-overtime-api.git-contributor.com/contributors-svg?chart=contributorOverTime&repo=apache/incubator-streampark)](https://git-contributor.com?chart=contributorOverTime&repo=apache/incubator-streampark)
-
-## 👍Stargazers Over Time
-
-![Stargazers over time](https://api.star-history.com/svg?repos=apache/incubator-streampark&type=Date)
-
 ## 💬 Social Media
 
 - [Twitter](https://twitter.com/ASFStreamPark)


### PR DESCRIPTION
These photos are unstable to render that can cause negative reading experience.

Also, the number of stars is shown right upper and contributors are shown on the above contributors big graph.

We don't need too much vanity metrics.

<img width="850" alt="image" src="https://github.com/apache/incubator-streampark/assets/18818196/5b48adc7-b681-4c6f-b73b-6d228de6141b">
