### PR TITLE
[type:fix] Refactor AlertType class for fix cannot trigger alert

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/enums/AlertType.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/enums/AlertType.java
@@ -18,39 +18,63 @@
 package org.apache.streampark.console.core.enums;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.collect.Lists;
 import org.springframework.util.CollectionUtils;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/** The AlertType enum represents different types of alerts that can be used for notifications. */
 public enum AlertType {
+  /** Email */
   EMAIL(1),
+
+  /** Ding talk */
   DING_TALK(2),
+
+  /** WeChat work */
   WE_COM(4),
+
+  /** Http callback */
   HTTP_CALLBACK(8),
+
+  /** Lark */
   LARK(16);
 
+  /** The empty level */
+  private static final Integer EMPTY_LEVEL = 0;
+
+  /** Get the alert type by the code */
   private final Integer code;
 
-  private static Map<Integer, AlertType> cacheMap;
+  /** A cache map used to quickly get the alert type from an integer code */
+  private static final Map<Integer, AlertType> CACHE_MAP = createCacheMap();
+
+  private static Map<Integer, AlertType> createCacheMap() {
+    Map<Integer, AlertType> map = new HashMap<>();
+    for (AlertType notifyType : AlertType.values()) {
+      map.put(notifyType.code, notifyType);
+    }
+    return Collections.unmodifiableMap(map);
+  }
 
   AlertType(Integer code) {
     this.code = code;
   }
 
-  /**
-   * Alarm way, binary bits indicate Where bit 1 means: email alarm, bit 2 means: ding alarm, bit 3
-   * means: weCom alarm, bit 4 means: http callback, and bit 5 means: lark. Example: level= 3, its
-   * binary bit is: 0000 0011, then the corresponding alarm mode bit: ding, email level= 10, its
-   * binary bit is: 0000 1010, then the corresponding alarm mode bit: ding, callback
-   */
+  @JsonValue
+  public int getCode() {
+    return this.code;
+  }
+
   public static List<AlertType> decode(Integer level) {
     if (level == null) {
-      level = 0;
+      level = EMPTY_LEVEL;
     }
-    List<AlertType> result = Lists.newArrayList();
+
+    List<AlertType> result = new ArrayList<>(AlertType.values().length);
     while (level != 0) {
       int code = level & -level;
       result.add(getByCode(code));
@@ -60,27 +84,18 @@ public enum AlertType {
   }
 
   public static int encode(List<AlertType> alertTypes) {
+    if (CollectionUtils.isEmpty(alertTypes)) {
+      return EMPTY_LEVEL;
+    }
+
     int result = 0;
-    if (!CollectionUtils.isEmpty(alertTypes)) {
-      for (AlertType alertType : alertTypes) {
-        result |= alertType.code;
-      }
+    for (AlertType alertType : alertTypes) {
+      result |= alertType.code;
     }
     return result;
   }
 
   private static AlertType getByCode(Integer code) {
-    if (cacheMap == null) {
-      cacheMap = new HashMap<>();
-      for (AlertType notifyType : AlertType.values()) {
-        cacheMap.put(notifyType.code, notifyType);
-      }
-    }
-    return cacheMap.get(code);
-  }
-
-  @JsonValue
-  public int getCode() {
-    return this.code;
+    return CACHE_MAP.get(code);
   }
 }


### PR DESCRIPTION
Fix bug: AlertType's `cachemap` is lack of threading safety. Which can case would not trigger alert action.
@wolfboys @MonsterChenzhuo PTAL.