### PR TITLE
[Improve] Remove Scala version in module name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
 
             <dependency>
                 <groupId>org.apache.streampark</groupId>
-                <artifactId>streampark-common_${scala.binary.version}</artifactId>
+                <artifactId>streampark-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/streampark-common/pom.xml
+++ b/streampark-common/pom.xml
@@ -24,7 +24,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-common_${scala.binary.version}</artifactId>
+    <artifactId>streampark-common</artifactId>
     <name>StreamPark : Common</name>
 
     <dependencies>

--- a/streampark-console/streampark-console-service/pom.xml
+++ b/streampark-console/streampark-console-service/pom.xml
@@ -335,36 +335,36 @@
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <artifactId>streampark-common</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-client-api_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-client-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-kubernetes_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-kubernetes</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-kubernetes-core_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-kubernetes-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-sqlclient_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-sqlclient</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -447,7 +447,7 @@
             <groupId>dev.zio</groupId>
             <artifactId>zio-logging_${scala.binary.version}</artifactId>
         </dependency>
-      
+
         <dependency>
             <groupId>dev.zio</groupId>
             <artifactId>zio-streams_${scala.binary.version}</artifactId>
@@ -508,49 +508,49 @@
                         <!-- flink 1.12 support-->
                         <dependency>
                             <groupId>org.apache.streampark</groupId>
-                            <artifactId>streampark-flink-shims_flink-1.12_${scala.binary.version}</artifactId>
+                            <artifactId>streampark-flink-shims_flink-1.12</artifactId>
                             <version>${project.version}</version>
                             <outputDirectory>${project.build.directory}/shims</outputDirectory>
                         </dependency>
                         <!-- flink 1.13 support-->
                         <dependency>
                             <groupId>org.apache.streampark</groupId>
-                            <artifactId>streampark-flink-shims_flink-1.13_${scala.binary.version}</artifactId>
+                            <artifactId>streampark-flink-shims_flink-1.13</artifactId>
                             <version>${project.version}</version>
                             <outputDirectory>${project.build.directory}/shims</outputDirectory>
                         </dependency>
                         <!-- flink 1.14 support-->
                         <dependency>
                             <groupId>org.apache.streampark</groupId>
-                            <artifactId>streampark-flink-shims_flink-1.14_${scala.binary.version}</artifactId>
+                            <artifactId>streampark-flink-shims_flink-1.14</artifactId>
                             <version>${project.version}</version>
                             <outputDirectory>${project.build.directory}/shims</outputDirectory>
                         </dependency>
                         <!-- flink 1.15 support-->
                         <dependency>
                             <groupId>org.apache.streampark</groupId>
-                            <artifactId>streampark-flink-shims_flink-1.15_${scala.binary.version}</artifactId>
+                            <artifactId>streampark-flink-shims_flink-1.15</artifactId>
                             <version>${project.version}</version>
                             <outputDirectory>${project.build.directory}/shims</outputDirectory>
                         </dependency>
                         <!-- flink 1.16 support-->
                         <dependency>
                             <groupId>org.apache.streampark</groupId>
-                            <artifactId>streampark-flink-shims_flink-1.16_${scala.binary.version}</artifactId>
+                            <artifactId>streampark-flink-shims_flink-1.16</artifactId>
                             <version>${project.version}</version>
                             <outputDirectory>${project.build.directory}/shims</outputDirectory>
                         </dependency>
                         <!-- flink 1.17 support-->
                         <dependency>
                             <groupId>org.apache.streampark</groupId>
-                            <artifactId>streampark-flink-shims_flink-1.17_${scala.binary.version}</artifactId>
+                            <artifactId>streampark-flink-shims_flink-1.17</artifactId>
                             <version>${project.version}</version>
                             <outputDirectory>${project.build.directory}/shims</outputDirectory>
                         </dependency>
                         <!-- flink-submit-core -->
                         <dependency>
                             <groupId>org.apache.streampark</groupId>
-                            <artifactId>streampark-flink-client-core_${scala.binary.version}</artifactId>
+                            <artifactId>streampark-flink-client-core</artifactId>
                             <version>${project.version}</version>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </dependency>

--- a/streampark-console/streampark-console-service/src/main/assembly/assembly.xml
+++ b/streampark-console/streampark-console-service/src/main/assembly/assembly.xml
@@ -29,14 +29,14 @@
             <useProjectArtifact>true</useProjectArtifact>
             <outputDirectory>lib</outputDirectory>
             <excludes>
-                <exclude>org.apache.streampark:streampark-flink-sqlclient_${scala.binary.version}</exclude>
+                <exclude>org.apache.streampark:streampark-flink-sqlclient</exclude>
                 <exclude>javax.servlet:servlet-api</exclude>
             </excludes>
         </dependencySet>
         <dependencySet>
             <outputDirectory>client</outputDirectory>
             <includes>
-                <include>org.apache.streampark:streampark-flink-sqlclient_${scala.binary.version}</include>
+                <include>org.apache.streampark:streampark-flink-sqlclient</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-api/pom.xml
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-api/pom.xml
@@ -23,39 +23,39 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-client-api_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-client-api</artifactId>
     <name>StreamPark : Flink Client Api</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <artifactId>streampark-common</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-proxy_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-proxy</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-packer_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-packer</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-kubernetes_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-kubernetes</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/pom.xml
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/pom.xml
@@ -23,14 +23,14 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-client-core_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-client-core</artifactId>
     <name>StreamPark : Flink Client Core</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-client-api_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-client-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -39,14 +39,14 @@
           so a full build dependencies is required. -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-kubernetes_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-kubernetes</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-base/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-base/pom.xml
@@ -24,7 +24,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-connector-base_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-connector-base</artifactId>
     <name>StreamPark : Flink Connector Base</name>
 
     <dependencies>
@@ -38,19 +38,19 @@
         <!-- streampark -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <artifactId>streampark-common</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-core_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -58,7 +58,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-clickhouse/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-clickhouse/pom.xml
@@ -52,7 +52,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-doris/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-doris/pom.xml
@@ -42,7 +42,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch5/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch5/pom.xml
@@ -46,7 +46,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch6/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch6/pom.xml
@@ -44,7 +44,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch7/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch7/pom.xml
@@ -43,7 +43,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-hbase/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-hbase/pom.xml
@@ -23,21 +23,21 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-connector-hbase_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-connector-hbase</artifactId>
     <name>StreamPark : Flink Connector Hbase</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-connector-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-connector-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-http/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-http/pom.xml
@@ -23,14 +23,14 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-connector-http_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-connector-http</artifactId>
     <name>StreamPark : Flink Connector Http</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-connector-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-connector-base</artifactId>
             <version>${version}</version>
         </dependency>
 
@@ -48,7 +48,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-influx/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-influx/pom.xml
@@ -43,7 +43,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-jdbc/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-jdbc/pom.xml
@@ -23,21 +23,21 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-connector-jdbc_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-connector-jdbc</artifactId>
     <name>StreamPark : Flink Connector JDBC</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-connector-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-connector-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-kafka/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-kafka/pom.xml
@@ -43,7 +43,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-mongo/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-mongo/pom.xml
@@ -43,7 +43,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-redis/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-redis/pom.xml
@@ -50,7 +50,7 @@
         <!-- provided -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-core/pom.xml
+++ b/streampark-flink/streampark-flink-core/pom.xml
@@ -23,26 +23,26 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-core_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-core</artifactId>
     <name>StreamPark : Flink Core</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <artifactId>streampark-common</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-kubernetes-v2/streampark-flink-kubernetes-core/pom.xml
+++ b/streampark-flink/streampark-flink-kubernetes-v2/streampark-flink-kubernetes-core/pom.xml
@@ -25,7 +25,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-kubernetes-core_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-kubernetes-core</artifactId>
     <name>StreamPark : Flink Kubernetes Integration Core</name>
 
     <properties>
@@ -41,7 +41,7 @@
         <!-- Streampark modules -->
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <artifactId>streampark-common</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/streampark-flink/streampark-flink-kubernetes/pom.xml
+++ b/streampark-flink/streampark-flink-kubernetes/pom.xml
@@ -24,7 +24,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-kubernetes_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-kubernetes</artifactId>
     <name>StreamPark : Flink Kubernetes Integration(Deprecated)</name>
 
     <properties>
@@ -89,13 +89,13 @@
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <artifactId>streampark-common</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-packer/pom.xml
+++ b/streampark-flink/streampark-flink-packer/pom.xml
@@ -23,7 +23,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-packer_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-packer</artifactId>
     <name>StreamPark : Flink Packer</name>
 
     <properties>
@@ -38,13 +38,13 @@
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <artifactId>streampark-common</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-kubernetes_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-kubernetes</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/streampark-flink/streampark-flink-proxy/pom.xml
+++ b/streampark-flink/streampark-flink-proxy/pom.xml
@@ -23,14 +23,14 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-proxy_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-proxy</artifactId>
     <name>StreamPark : Flink Proxy</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <artifactId>streampark-common</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/pom.xml
@@ -25,14 +25,14 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-shims-base</artifactId>
     <name>StreamPark : Flink Shims Base</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <artifactId>streampark-common</artifactId>
         </dependency>
 
         <!--flink base-->

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims-test/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims-test/pom.xml
@@ -26,7 +26,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-shims-test_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-shims-test</artifactId>
     <name>StreamPark : Flink Shims Test</name>
 
     <properties>
@@ -44,21 +44,21 @@
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-1.14_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-1.14</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-core_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-core</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.12/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.12/pom.xml
@@ -25,7 +25,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-shims_flink-1.12_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-shims_flink-1.12</artifactId>
     <name>StreamPark : Flink Shims 1.12</name>
 
     <properties>
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.13/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.13/pom.xml
@@ -24,7 +24,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-shims_flink-1.13_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-shims_flink-1.13</artifactId>
     <name>StreamPark : Flink Shims 1.13</name>
 
     <properties>
@@ -34,7 +34,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.14/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.14/pom.xml
@@ -24,7 +24,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-shims_flink-1.14_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-shims_flink-1.14</artifactId>
     <name>StreamPark : Flink Shims 1.14</name>
 
     <properties>
@@ -34,7 +34,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.15/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.15/pom.xml
@@ -26,7 +26,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-shims_flink-1.15_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-shims_flink-1.15</artifactId>
     <name>StreamPark : Flink Shims 1.15</name>
 
     <properties>
@@ -36,7 +36,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.16/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.16/pom.xml
@@ -25,7 +25,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-shims_flink-1.16_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-shims_flink-1.16</artifactId>
     <name>StreamPark : Flink Shims 1.16</name>
 
     <properties>
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.17/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.17/pom.xml
@@ -25,7 +25,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-shims_flink-1.17_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-shims_flink-1.17</artifactId>
     <name>StreamPark : Flink Shims 1.17</name>
 
     <properties>
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/streampark-flink/streampark-flink-sqlclient/pom.xml
+++ b/streampark-flink/streampark-flink-sqlclient/pom.xml
@@ -23,7 +23,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-sqlclient_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-sqlclient</artifactId>
     <name>StreamPark : Flink SQL Client</name>
 
     <dependencies>
@@ -35,19 +35,19 @@
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-core_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}_${scala.binary.version}</artifactId>
+            <artifactId>streampark-flink-shims_flink-${streampark.flink.shims.version}</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/streampark-flink/streampark-flink-udf/pom.xml
+++ b/streampark-flink/streampark-flink-udf/pom.xml
@@ -23,13 +23,13 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-flink-udf_${scala.binary.version}</artifactId>
+    <artifactId>streampark-flink-udf</artifactId>
     <name>StreamPark : Flink Udf</name>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <artifactId>streampark-common</artifactId>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/streampark-spark/streampark-spark-connector/pom.xml
+++ b/streampark-spark/streampark-spark-connector/pom.xml
@@ -24,7 +24,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-spark-connector_2.12</artifactId>
+    <artifactId>streampark-spark-connector</artifactId>
     <name>StreamPark : Spark Connector</name>
     <packaging>pom</packaging>
 

--- a/streampark-spark/streampark-spark-connector/streampark-spark-connector-base/pom.xml
+++ b/streampark-spark/streampark-spark-connector/streampark-spark-connector-base/pom.xml
@@ -21,18 +21,18 @@
 
     <parent>
         <groupId>org.apache.streampark</groupId>
-        <artifactId>streampark-spark-connector_2.12</artifactId>
+        <artifactId>streampark-spark-connector</artifactId>
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-spark-connector-base_2.12</artifactId>
+    <artifactId>streampark-spark-connector-base</artifactId>
     <name>StreamPark : Spark Connector Base</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-spark-core_2.12</artifactId>
+            <artifactId>streampark-spark-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/streampark-spark/streampark-spark-connector/streampark-spark-connector-kafka/pom.xml
+++ b/streampark-spark/streampark-spark-connector/streampark-spark-connector-kafka/pom.xml
@@ -20,18 +20,18 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.streampark</groupId>
-        <artifactId>streampark-spark-connector_2.12</artifactId>
+        <artifactId>streampark-spark-connector</artifactId>
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-spark-connector-kafka_2.12</artifactId>
+    <artifactId>streampark-spark-connector-kafka</artifactId>
     <name>StreamPark : Spark Connector Kafka</name>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.streampark</groupId>
-            <artifactId>streampark-spark-connector-base_2.12</artifactId>
+            <artifactId>streampark-spark-connector-base</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/streampark-spark/streampark-spark-core/pom.xml
+++ b/streampark-spark/streampark-spark-core/pom.xml
@@ -23,7 +23,7 @@
         <version>2.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>streampark-spark-core_2.12</artifactId>
+    <artifactId>streampark-spark-core</artifactId>
     <name>StreamPark : Spark Core</name>
 
     <!--项目基本依赖-->


### PR DESCRIPTION

[Improve] Remove Scala version in module name.

After email list discussions[1] within the community, starting from version StreamPark 2.2, support for Scala 2.11 will no longer be available. This PR simplifies module names and removes the Scala version from all modules . The default Scala version is now Scala 2.12.

[1] https://lists.apache.org/thread/mx8vgq4jp8dk2wgm8m5g1mmq806wzjzg