### PR TITLE
[Improvement] add support for SinkRequest that has multiple statements

### DIFF
--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-base/src/test/scala/org/apache/streampark/flink/connector/failover/SinkRequestTest.scala
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-base/src/test/scala/org/apache/streampark/flink/connector/failover/SinkRequestTest.scala
@@ -1,0 +1,28 @@
+package org.apache.streampark.flink.connector.failover
+
+import org.junit.jupiter.api.{Assertions, Test}
+
+import scala.collection.JavaConverters._
+
+class SinkRequestTest {
+  @Test
+  def sqlStatement(): Unit = {
+    val statementsList = List(
+      "insert into table_1(col1, col2) values(1, 2)",
+      "insert into table_1(col1, col2) values(11, 22)",
+      "insert into table_1(col1, col2, col3) values(11, 22, 33)",
+      "insert into table_2(col1, col2, col3) values(11, 22, 33)",
+    )
+
+    val sinkRequest = SinkRequest(statementsList.asJava)
+
+    val expectedSqlStatement = List(
+      "insert into table_2(col1, col2, col3) VALUES (11, 22, 33)",
+      "insert into table_1(col1, col2) VALUES (1, 2),(11, 22)",
+      "insert into table_1(col1, col2, col3) VALUES (11, 22, 33)",
+    )
+
+    Assertions.assertTrue(sinkRequest.sqlStatement.toSet == expectedSqlStatement.toSet)
+
+  }
+}

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-base/src/test/scala/org/apache/streampark/flink/connector/failover/SinkRequestTest.scala
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-base/src/test/scala/org/apache/streampark/flink/connector/failover/SinkRequestTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.streampark.flink.connector.failover
 
 import org.junit.jupiter.api.{Assertions, Test}

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-base/src/test/scala/org/apache/streampark/flink/connector/failover/SinkRequestTest.scala
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-base/src/test/scala/org/apache/streampark/flink/connector/failover/SinkRequestTest.scala
@@ -7,6 +7,7 @@ import scala.collection.JavaConverters._
 class SinkRequestTest {
   @Test
   def sqlStatement(): Unit = {
+    // input statements
     val statementsList = List(
       "insert into table_1(col1, col2) values(1, 2)",
       "insert into table_1(col1, col2) values(11, 22)",
@@ -16,12 +17,14 @@ class SinkRequestTest {
 
     val sinkRequest = SinkRequest(statementsList.asJava)
 
+    // expected result
     val expectedSqlStatement = List(
       "insert into table_2(col1, col2, col3) VALUES (11, 22, 33)",
       "insert into table_1(col1, col2) VALUES (1, 2),(11, 22)",
       "insert into table_1(col1, col2, col3) VALUES (11, 22, 33)",
     )
 
+    // comparison of result should be based on Set, that is, there is no need to care about the order of elements
     Assertions.assertTrue(sinkRequest.sqlStatement.toSet == expectedSqlStatement.toSet)
 
   }

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-clickhouse/src/main/scala/org/apache/streampark/flink/connector/clickhouse/internal/ClickHouseWriterTask.scala
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-clickhouse/src/main/scala/org/apache/streampark/flink/connector/clickhouse/internal/ClickHouseWriterTask.scala
@@ -26,7 +26,7 @@ import org.asynchttpclient.{AsyncHttpClient, ListenableFuture, Request, Response
 
 import java.util.concurrent.{BlockingQueue, ExecutorService, TimeUnit}
 
-import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+import scala.collection.convert.ImplicitConversions._
 import scala.util.Try
 
 case class ClickHouseWriterTask(

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-clickhouse/src/main/scala/org/apache/streampark/flink/connector/clickhouse/internal/ClickHouseWriterTask.scala
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-clickhouse/src/main/scala/org/apache/streampark/flink/connector/clickhouse/internal/ClickHouseWriterTask.scala
@@ -21,12 +21,12 @@ import org.apache.streampark.common.util.Logger
 import org.apache.streampark.flink.connector.clickhouse.conf.ClickHouseHttpConfig
 import org.apache.streampark.flink.connector.failover.{FailoverWriter, SinkRequest}
 
-import io.netty.handler.codec.http.{HttpHeaderNames, HttpHeaders}
+import io.netty.handler.codec.http.HttpHeaderNames
 import org.asynchttpclient.{AsyncHttpClient, ListenableFuture, Request, Response}
 
 import java.util.concurrent.{BlockingQueue, ExecutorService, TimeUnit}
 
-import scala.collection.JavaConversions._
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import scala.util.Try
 
 case class ClickHouseWriterTask(

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-clickhouse/src/main/scala/org/apache/streampark/flink/connector/clickhouse/internal/ClickHouseWriterTask.scala
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-clickhouse/src/main/scala/org/apache/streampark/flink/connector/clickhouse/internal/ClickHouseWriterTask.scala
@@ -26,7 +26,7 @@ import org.asynchttpclient.{AsyncHttpClient, ListenableFuture, Request, Response
 
 import java.util.concurrent.{BlockingQueue, ExecutorService, TimeUnit}
 
-import scala.collection.convert.ImplicitConversions._
+import scala.collection.JavaConversions._
 import scala.util.Try
 
 case class ClickHouseWriterTask(
@@ -63,24 +63,36 @@ case class ClickHouseWriterTask(
     }
 
   def send(sinkRequest: SinkRequest): Unit = {
-    val request = buildRequest(sinkRequest)
-    logDebug(s"Ready to load data to ${sinkRequest.table}, size: ${sinkRequest.size}")
-    val whenResponse = asyncHttpClient.executeRequest(request)
-    val callback = respCallback(whenResponse, sinkRequest)
-    whenResponse.addListener(callback, callbackService)
+    if (sinkRequest.sqlStatement == null || sinkRequest.sqlStatement.isEmpty) {
+      logWarn(s"Skip empty sql statement")
+      return
+    }
+
+    val requests = buildRequest(sinkRequest)
+    requests.foreach(
+      request => {
+        logDebug(s"Ready to fire request: $request")
+        val whenResponse = asyncHttpClient.executeRequest(request)
+        val callback = respCallback(whenResponse, sinkRequest)
+        whenResponse.addListener(callback, callbackService)
+      })
   }
 
-  def buildRequest(sinkRequest: SinkRequest): Request = {
-    val host = clickHouseConf.getRandomHostUrl
-    val builder = asyncHttpClient
-      .preparePost(host)
-      .setRequestTimeout(clickHouseConf.timeout)
-      .setHeader(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8")
-      .setBody(sinkRequest.sqlStatement)
-    if (clickHouseConf.credentials != null) {
-      builder.setHeader(HttpHeaderNames.AUTHORIZATION, "Basic " + clickHouseConf.credentials)
-    }
-    builder.build
+  private def buildRequest(sinkRequest: SinkRequest): List[Request] = {
+    logDebug(s"There is [${sinkRequest.sqlStatement.size}] statement(s) in SinkRequest ")
+    sinkRequest.sqlStatement.map(
+      statement => {
+        val host = clickHouseConf.getRandomHostUrl
+        val builder = asyncHttpClient
+          .preparePost(host)
+          .setRequestTimeout(clickHouseConf.timeout)
+          .setHeader(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8")
+          .setBody(statement)
+        if (clickHouseConf.credentials != null) {
+          builder.setHeader(HttpHeaderNames.AUTHORIZATION, "Basic " + clickHouseConf.credentials)
+        }
+        builder.build
+      })
   }
 
   def respCallback(whenResponse: ListenableFuture[Response], sinkRequest: SinkRequest): Runnable =


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

This is a improved version of  #2919 .
Sorry to say that I found a bug on our production env.

## Brief change log

- Refactor val `SinkRequest.sqlStatement`: group and combine statements by the part before ‘values’ in insert statements.
- Refactor `ClickHouseWriterTask.buildRequest`: build List of `Request` by SinkRequest.sqlStatement.

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is just tested (and passed) on our production env, not tested by unit test code.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no