### PR TITLE
[Bug][Get Yarn Proxy] delete result data value '/cluster/app'

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/ApplicationController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/ApplicationController.java
@@ -285,7 +285,9 @@ public class ApplicationController {
   @Operation(summary = "Get application on yarn proxy address")
   @PostMapping("yarn")
   public RestResponse yarn() {
-    return RestResponse.success(YarnUtils.getRMWebAppProxyURL());
+    String rmWebAppProxyURL = YarnUtils.getRMWebAppProxyURL();
+    return RestResponse.success(
+        rmWebAppProxyURL == null ? null : rmWebAppProxyURL.replaceAll("/cluster/app", ""));
   }
 
   @Operation(summary = "Get application on yarn name")


### PR DESCRIPTION
#3030 
Below is a demonstration of the comparison before and after the repair:

一、Before repair
![修改前yarn](https://github.com/apache/incubator-streampark/assets/46134044/b6deef68-0aef-4040-8afb-b475376143c4)
![applicatid](https://github.com/apache/incubator-streampark/assets/46134044/63d2c69d-c430-4bf6-b99c-94056b6cba98)


![修改
![applicatid](https://github.com/apache/incubator-streampark/assets/46134044/d81d78ff-8107-4e60-9312-d92033816f83)
前动态](https://github.com/apache/incubator-streampark/assets/46134044/f6eaf7be-8b58-445b-8ec1-39a60f6e45fa)

二、After repair
![修改后yarn](https://github.com/apache/incubator-streampark/assets/46134044/e7fe2581-854c-426a-8bd0-f807149a5eca)
![修改后 appli id](https://github.com/apache/incubator-streampark/assets/46134044/79a66487-ff1e-42ec-a5b8-070e4b07816e)
![修改后模式](https://github.com/apache/incubator-streampark/assets/46134044/ce89e9cf-ea3d-47a2-a220-e501dd0ae3b1)
