### PR TITLE
[Bug] fix FlinkKubernetesClient.getService() bug

### DIFF
--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.16/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClient.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.16/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClient.scala
@@ -17,6 +17,7 @@
 package org.apache.streampark.flink.core
 
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient
+import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService
 
 import java.util.Optional
@@ -25,7 +26,7 @@ class FlinkKubernetesClient(kubeClient: FlinkKubeClient)
   extends FlinkKubernetesClientTrait(kubeClient) {
 
   override def getService(serviceName: String): Optional[KubernetesService] = {
-    kubeClient.getService(serviceName)
+    kubeClient.getService(ExternalServiceDecorator.getExternalServiceName(serviceName))
   }
 
 }

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.17/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClient.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.17/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClient.scala
@@ -17,6 +17,7 @@
 package org.apache.streampark.flink.core
 
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient
+import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService
 
 import java.util.Optional
@@ -25,7 +26,7 @@ class FlinkKubernetesClient(kubeClient: FlinkKubeClient)
   extends FlinkKubernetesClientTrait(kubeClient) {
 
   override def getService(serviceName: String): Optional[KubernetesService] = {
-    kubeClient.getService(serviceName)
+    kubeClient.getService(ExternalServiceDecorator.getExternalServiceName(serviceName))
   }
 
 }


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Closing k8s flink HA cluster will throw an ApiAlertException("Get shutdown response failed"), because we use directly clusterId as the service name at invoking `FlinkKubernetesClient.getService()`. We need convert clusterId to the service name by adding a suffix `-rest`.
This flink api changed at Flink-26112

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

- *Manually verified the change by testing locally.*

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (no)
