### PR TITLE
[Feature] Flink remote support pyflink maven dependency

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/AppBuildPipeServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/AppBuildPipeServiceImpl.java
@@ -467,7 +467,7 @@ public class AppBuildPipeServiceImpl
                 app.getLocalAppHome(),
                 mainClass,
                 flinkUserJar,
-                app.isCustomCodeOrPyFlinkJob(),
+                app.isCustomCodeJob(),
                 app.getExecutionModeEnum(),
                 app.getDevelopmentMode(),
                 flinkEnv.getFlinkVersion(),

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/FlinkClientTrait.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/FlinkClientTrait.scala
@@ -21,7 +21,7 @@ import org.apache.streampark.common.conf.{ConfigConst, Workspace}
 import org.apache.streampark.common.conf.ConfigConst._
 import org.apache.streampark.common.enums.{ApplicationType, DevelopmentMode, ExecutionMode, RestoreMode}
 import org.apache.streampark.common.fs.FsOperator
-import org.apache.streampark.common.util.{DeflaterUtils, Logger, SystemPropertyUtils}
+import org.apache.streampark.common.util.{DeflaterUtils, FileUtils, Logger, SystemPropertyUtils}
 import org.apache.streampark.flink.client.bean._
 import org.apache.streampark.flink.core.FlinkClusterClient
 import org.apache.streampark.flink.core.conf.FlinkRunOption
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.jobgraph.{JobGraph, SavepointConfigOptions}
 import org.apache.flink.util.FlinkException
 import org.apache.flink.util.Preconditions.checkNotNull
 
+import java.util
 import java.util.{Collections, List => JavaList, Map => JavaMap}
 
 import scala.annotation.tailrec
@@ -240,6 +241,12 @@ trait FlinkClientTrait extends Logger {
       if (!FsOperator.lfs.exists(pythonVenv)) {
         throw new RuntimeException(s"$pythonVenv File does not exist")
       }
+
+      val localLib: String = s"${Workspace.local.APP_WORKSPACE}/${submitRequest.id}/lib"
+      if (FileUtils.exists(localLib) && FileUtils.directoryNotBlank(localLib)) {
+        flinkConfig.safeSet(PipelineOptions.JARS, util.Arrays.asList(localLib))
+      }
+
       flinkConfig
         // python.archives
         .safeSet(PythonOptions.PYTHON_ARCHIVES, pythonVenv)

--- a/streampark-flink/streampark-flink-packer/src/main/scala/org/apache/streampark/flink/packer/pipeline/impl/FlinkRemoteBuildPipeline.scala
+++ b/streampark-flink/streampark-flink-packer/src/main/scala/org/apache/streampark/flink/packer/pipeline/impl/FlinkRemoteBuildPipeline.scala
@@ -17,9 +17,15 @@
 
 package org.apache.streampark.flink.packer.pipeline.impl
 
-import org.apache.streampark.common.fs.LfsOperator
+import org.apache.streampark.common.enums.DevelopmentMode
+import org.apache.streampark.common.fs.{FsOperator, LfsOperator}
 import org.apache.streampark.flink.packer.maven.MavenTool
 import org.apache.streampark.flink.packer.pipeline._
+
+import java.io.File
+
+import scala.collection.JavaConverters._
+import scala.collection.convert.ImplicitConversions._
 
 /** Building pipeline for flink standalone session mode */
 class FlinkRemoteBuildPipeline(request: FlinkRemotePerJobBuildRequest) extends BuildPipeline {
@@ -43,13 +49,47 @@ class FlinkRemoteBuildPipeline(request: FlinkRemotePerJobBuildRequest) extends B
       // build flink job shaded jar
       val shadedJar =
         execStep(2) {
-          val output = MavenTool.buildFatJar(
-            request.mainClass,
-            request.providedLibs,
-            request.getShadedJarPath(request.workspace))
-          logInfo(s"output shaded flink job jar: ${output.getAbsolutePath}")
-          output
+          request.developmentMode match {
+            case DevelopmentMode.FLINK_SQL =>
+              val output = MavenTool.buildFatJar(
+                request.mainClass,
+                request.providedLibs,
+                request.getShadedJarPath(request.workspace))
+              logInfo(s"output shaded flink job jar: ${output.getAbsolutePath}")
+              output
+            case _ => new File(request.customFlinkUserJar);
+          }
         }.getOrElse(throw getError.exception)
+
+      val mavenJars =
+        execStep(3) {
+          request.developmentMode match {
+            case DevelopmentMode.PYFLINK =>
+              val mavenArts = MavenTool.resolveArtifacts(request.dependencyInfo.mavenArts.asJava)
+              mavenArts.map(_.getAbsolutePath) ++ request.dependencyInfo.extJarLibs
+            case _ => List[String]()
+          }
+        }.getOrElse(throw getError.exception)
+
+      execStep(4) {
+        request.developmentMode match {
+          case DevelopmentMode.PYFLINK =>
+            mavenJars.foreach(
+              jar => {
+                val lfs: FsOperator = FsOperator.lfs
+                val lib = request.workspace.concat("/lib")
+                if (!lfs.exists(lib)) {
+                  lfs.mkdirs(lib)
+                }
+                val originFile = new File(jar)
+                if (originFile.isFile) {
+                  lfs.copy(originFile.getAbsolutePath, lib)
+                }
+
+              })
+          case _ =>
+        }
+      }.getOrElse(throw getError.exception)
       ShadedBuildResponse(request.workspace, shadedJar.getAbsolutePath)
     }
 

--- a/streampark-flink/streampark-flink-packer/src/main/scala/org/apache/streampark/flink/packer/pipeline/impl/FlinkRemoteBuildPipeline.scala
+++ b/streampark-flink/streampark-flink-packer/src/main/scala/org/apache/streampark/flink/packer/pipeline/impl/FlinkRemoteBuildPipeline.scala
@@ -78,9 +78,7 @@ class FlinkRemoteBuildPipeline(request: FlinkRemotePerJobBuildRequest) extends B
               jar => {
                 val lfs: FsOperator = FsOperator.lfs
                 val lib = request.workspace.concat("/lib")
-                if (!lfs.exists(lib)) {
-                  lfs.mkdirs(lib)
-                }
+                lfs.mkdirsIfNotExists(lib)
                 val originFile = new File(jar)
                 if (originFile.isFile) {
                   lfs.copy(originFile.getAbsolutePath, lib)


### PR DESCRIPTION
Importing dependency Jars via maven dependency is supported when submitting pyflink tasks using the remote pattern
