### PR TITLE
[Fix] Interceptors add /resource/upload

### DIFF
--- a/streampark-common/pom.xml
+++ b/streampark-common/pom.xml
@@ -156,6 +156,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!--tika -->
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>1.20</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/streampark-common/src/main/scala/org/apache/streampark/common/util/FileUtils.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/util/FileUtils.scala
@@ -18,6 +18,8 @@ package org.apache.streampark.common.util
 
 import org.apache.streampark.common.util.ImplicitsUtils._
 
+import org.apache.commons.lang3.StringUtils
+
 import java.io._
 import java.net.URL
 import java.nio.ByteBuffer
@@ -56,6 +58,16 @@ object FileUtils {
         in.read(b, 0, b.length)
         bytesToHexString(b)
       }) == "504B0304"
+  }
+
+  def isPythonFileType(contentType: String): Boolean = {
+    if (
+      StringUtils.isNotBlank(contentType) && contentType.equalsIgnoreCase("text/x-python-script")
+    ) {
+      true
+    } else {
+      false
+    }
   }
 
   def isJarFileType(file: File): Boolean = {

--- a/streampark-common/src/main/scala/org/apache/streampark/common/util/FileUtils.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/util/FileUtils.scala
@@ -60,15 +60,8 @@ object FileUtils {
       }) == "504B0304"
   }
 
-  def isPythonFileType(contentType: String): Boolean = {
-    if (
-      StringUtils.isNotBlank(contentType) && contentType.equalsIgnoreCase("text/x-python-script")
-    ) {
-      true
-    } else {
-      false
-    }
-  }
+  def isPythonFileType(contentType: String): Boolean =
+    StringUtils.isNotBlank(contentType) && contentType.equalsIgnoreCase("text/x-python-script")
 
   def isJarFileType(file: File): Boolean = {
     if (!file.exists || !file.isFile) {

--- a/streampark-common/src/main/scala/org/apache/streampark/common/util/FileUtils.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/util/FileUtils.scala
@@ -68,14 +68,7 @@ object FileUtils {
     if (StringUtils.isBlank(contentType) || input == null) {
       throw new RuntimeException("The contentType or inputStream can not be null")
     }
-
-    if (
-      contentType.contains("text/x-python") && getMimeType(input).equals(
-        MediaType.TEXT_PLAIN.toString)
-    ) {
-      return true
-    }
-    false
+    getMimeType(input) == MediaType.TEXT_PLAIN.toString && contentType.contains("text/x-python")
   }
 
   def getMimeType(stream: InputStream): String = {

--- a/streampark-common/src/main/scala/org/apache/streampark/common/util/FileUtils.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/util/FileUtils.scala
@@ -61,7 +61,8 @@ object FileUtils {
   }
 
   def isPythonFileType(contentType: String): Boolean =
-    StringUtils.isNotBlank(contentType) && contentType.equalsIgnoreCase("text/x-python-script")
+    StringUtils.isNotBlank(
+      contentType) && ("text/x-python" == contentType || "text/x-python-script" == contentType)
 
   def isJarFileType(file: File): Boolean = {
     if (!file.exists || !file.isFile) {

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/config/WebMvcConfig.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/config/WebMvcConfig.java
@@ -79,6 +79,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
-    registry.addInterceptor(uploadFileTypeInterceptor).addPathPatterns("/flink/app/upload");
+    registry
+        .addInterceptor(uploadFileTypeInterceptor)
+        .addPathPatterns("/flink/app/upload", "/resource/upload");
   }
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/interceptor/UploadFileTypeInterceptor.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/interceptor/UploadFileTypeInterceptor.java
@@ -44,11 +44,11 @@ public class UploadFileTypeInterceptor implements HandlerInterceptor {
         MultipartFile multipartFile = multipartRequest.getFile(file);
         ApiAlertException.throwIfNull(
             multipartFile, "File to upload can't be null. Upload file failed.");
-        boolean fileType =
+        boolean isJarOrPyFile =
             FileUtils.isJarFileType(multipartFile.getInputStream())
                 || FileUtils.isPythonFileType(multipartFile.getContentType());
         ApiAlertException.throwIfFalse(
-            fileType,
+            isJarOrPyFile,
             "Illegal file type, Only support standard jar or py files. Upload file failed.");
       }
     }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/interceptor/UploadFileTypeInterceptor.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/interceptor/UploadFileTypeInterceptor.java
@@ -48,7 +48,8 @@ public class UploadFileTypeInterceptor implements HandlerInterceptor {
             FileUtils.isJarFileType(multipartFile.getInputStream())
                 || FileUtils.isPythonFileType(multipartFile.getContentType());
         ApiAlertException.throwIfFalse(
-            fileType, "Illegal file type, Only support standard jar files. Upload file failed.");
+            fileType,
+            "Illegal file type, Only support standard jar or py files. Upload file failed.");
       }
     }
     return true;

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/interceptor/UploadFileTypeInterceptor.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/interceptor/UploadFileTypeInterceptor.java
@@ -44,7 +44,9 @@ public class UploadFileTypeInterceptor implements HandlerInterceptor {
         MultipartFile multipartFile = multipartRequest.getFile(file);
         ApiAlertException.throwIfNull(
             multipartFile, "File to upload can't be null. Upload file failed.");
-        boolean fileType = FileUtils.isJarFileType(multipartFile.getInputStream());
+        boolean fileType =
+            FileUtils.isJarFileType(multipartFile.getInputStream())
+                || FileUtils.isPythonFileType(multipartFile.getContentType());
         ApiAlertException.throwIfFalse(
             fileType, "Illegal file type, Only support standard jar files. Upload file failed.");
       }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/interceptor/UploadFileTypeInterceptor.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/interceptor/UploadFileTypeInterceptor.java
@@ -46,7 +46,8 @@ public class UploadFileTypeInterceptor implements HandlerInterceptor {
             multipartFile, "File to upload can't be null. Upload file failed.");
         boolean isJarOrPyFile =
             FileUtils.isJarFileType(multipartFile.getInputStream())
-                || FileUtils.isPythonFileType(multipartFile.getContentType());
+                || FileUtils.isPythonFileType(
+                    multipartFile.getContentType(), multipartFile.getInputStream());
         ApiAlertException.throwIfFalse(
             isJarOrPyFile,
             "Illegal file type, Only support standard jar or py files. Upload file failed.");


### PR DESCRIPTION
Web Interceptors add "/resource/upload", and validate python file