### PR TITLE
[Feature] [Flink-K8s-V2] Refactor the lifecycle control code of Flink clusters on Kubernetes

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkClusterServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkClusterServiceImpl.java
@@ -436,6 +436,7 @@ public class FlinkClusterServiceImpl extends ServiceImpl<FlinkClusterMapper, Fli
             flinkCluster.getFlinkExecutionModeEnum(),
             flinkCluster.getProperties(),
             flinkCluster.getClusterId(),
+            flinkCluster.getId(),
             getKubernetesDeployDesc(flinkCluster, "start"));
     log.info("Deploy cluster request " + deployRequest);
     Future<DeployResponse> future = executorService.submit(() -> FlinkClient.deploy(deployRequest));

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-api/src/main/scala/org/apache/streampark/flink/client/bean/DeployRequest.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-api/src/main/scala/org/apache/streampark/flink/client/bean/DeployRequest.scala
@@ -34,6 +34,7 @@ case class DeployRequest(
     executionMode: FlinkExecutionMode,
     properties: JavaMap[String, Any],
     clusterId: String,
+    id: Long,
     @Nullable k8sDeployParam: KubernetesDeployParam) {
 
   private[client] lazy val hdfsWorkspace = {

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesSessionClientV2.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesSessionClientV2.scala
@@ -20,7 +20,7 @@ import org.apache.streampark.common.util.Logger
 import org.apache.streampark.common.zio.ZIOExt.{IOOps, OptionZIOOps}
 import org.apache.streampark.flink.client.`trait`.KubernetesClientV2Trait
 import org.apache.streampark.flink.client.bean._
-import org.apache.streampark.flink.kubernetes.v2.model.FlinkSessionJobDef
+import org.apache.streampark.flink.kubernetes.v2.model.{FlinkDeploymentDef, FlinkSessionJobDef, JobManagerDef, TaskManagerDef}
 import org.apache.streampark.flink.kubernetes.v2.model.TrackKey.ClusterKey
 import org.apache.streampark.flink.kubernetes.v2.observer.FlinkK8sObserver
 import org.apache.streampark.flink.kubernetes.v2.operator.FlinkK8sOperator
@@ -30,11 +30,14 @@ import org.apache.streampark.flink.packer.pipeline.ShadedBuildResponse
 import org.apache.commons.lang3.StringUtils
 import org.apache.flink.client.deployment.application.ApplicationConfiguration
 import org.apache.flink.configuration._
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions
+import org.apache.flink.v1beta1.FlinkDeploymentSpec.FlinkVersion
 import zio.ZIO
 
+import scala.collection.mutable
 import scala.jdk.CollectionConverters.mapAsScalaMapConverter
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 /** Flink K8s session mode app operation client via Flink K8s Operator */
 object KubernetesSessionClientV2 extends KubernetesClientV2Trait with Logger {
@@ -120,6 +123,34 @@ object KubernetesSessionClientV2 extends KubernetesClientV2Trait with Logger {
       ))
   }
 
+  @throws[Throwable]
+  def deploy(deployRequest: DeployRequest): DeployResponse = {
+
+    val richMsg: String => String = s"[flink-submit][appId=${deployRequest.id}] " + _
+
+    val flinkConfig =
+      extractConfiguration(deployRequest.flinkVersion.flinkHome, deployRequest.properties)
+    // Convert to FlinkDeployment CR definition
+    val flinkDeployDef = genFlinkDeployDef(deployRequest, flinkConfig) match {
+      case Right(result) => result
+      case Left(errMsg) =>
+        throw new IllegalArgumentException(
+          richMsg(s"Error occurred while parsing parameters:$errMsg"))
+    }
+
+    // Submit FlinkDeployment CR to Kubernetes
+    FlinkK8sOperator.deployCluster(deployRequest.id, flinkDeployDef).runIOAsTry match {
+      case Success(_) =>
+        logInfo(richMsg("Flink Cluster has been submitted successfully."))
+        DeployResponse(null, deployRequest.clusterId)
+      case Failure(err) =>
+        logError(
+          richMsg(s"Submit Flink Cluster fail in${deployRequest.executionMode.getName}_V2 mode!"),
+          err)
+        throw err
+    }
+  }
+
   /** Shutdown Flink cluster. */
   @throws[Throwable]
   def shutdown(shutDownRequest: ShutDownRequest): ShutDownResponse = {
@@ -142,6 +173,107 @@ object KubernetesSessionClientV2 extends KubernetesClientV2Trait with Logger {
       case Success(result) => logInfo(richMsg("Shutdown Flink cluster successfully.")); result
       case Failure(err) => logError(richMsg(s"Fail to shutdown Flink cluster"), err); throw err
     }
+  }
+
+  private def genFlinkDeployDef(
+      deployRequest: DeployRequest,
+      originFlinkConfig: Configuration): Either[FailureMessage, FlinkDeploymentDef] = {
+    val flinkConfObj = originFlinkConfig.clone()
+    val flinkConfMap = originFlinkConfig.toMap.asScala.toMap
+
+    val namespace = Option(deployRequest.k8sDeployParam.kubernetesNamespace)
+      .getOrElse("default")
+
+    val name = Option(deployRequest.k8sDeployParam.clusterId)
+      .filter(str => StringUtils.isNotBlank(str))
+      .getOrElse(return Left("Kubernetes CR name should not be empty"))
+
+    val imagePullPolicy = flinkConfObj
+      .getOption(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY)
+      .map(_.toString)
+
+    val image = Option(deployRequest.k8sDeployParam.flinkImage)
+      .filter(str => StringUtils.isNotBlank(str))
+      .getOrElse(return Left("Flink base image should not be empty"))
+
+    val serviceAccount = Option(deployRequest.k8sDeployParam.serviceAccount)
+      .getOrElse(FlinkDeploymentDef.DEFAULT_SERVICE_ACCOUNT)
+
+    val flinkVersion = Option(deployRequest.flinkVersion.majorVersion)
+      .map(majorVer => "V" + majorVer.replace(".", "_"))
+      .flatMap(v => FlinkVersion.values().find(_.name() == v))
+      .getOrElse(
+        return Left(s"Unsupported Flink version:${deployRequest.flinkVersion.majorVersion}"))
+
+    val jobManager = {
+      val cpu = flinkConfMap
+        .get(KUBERNETES_JM_CPU_AMOUNT_KEY)
+        .orElse(flinkConfMap.get(KUBERNETES_JM_CPU_KEY))
+        .flatMap(value => Try(value.toDouble).toOption)
+        .getOrElse(KUBERNETES_JM_CPU_DEFAULT)
+
+      val mem = flinkConfObj
+        .getOption(JobManagerOptions.TOTAL_PROCESS_MEMORY)
+        .map(_.toString)
+        .getOrElse(KUBERNETES_JM_MEMORY_DEFAULT)
+
+      JobManagerDef(cpu = cpu, memory = mem, ephemeralStorage = None, podTemplate = None)
+    }
+
+    val taskManager = {
+      val cpu = flinkConfMap
+        .get(KUBERNETES_TM_CPU_AMOUNT_KEY)
+        .orElse(flinkConfMap.get(KUBERNETES_TM_CPU_KEY))
+        .flatMap(value => Try(value.toDouble).toOption)
+        .getOrElse(KUBERNETES_TM_CPU_DEFAULT)
+
+      val mem = flinkConfObj
+        .getOption(TaskManagerOptions.TOTAL_PROCESS_MEMORY)
+        .map(_.toString)
+        .getOrElse(KUBERNETES_TM_MEMORY_DEFAULT)
+
+      TaskManagerDef(cpu = cpu, memory = mem, ephemeralStorage = None, podTemplate = None)
+    }
+
+    val extraFlinkConfiguration = {
+      // Remove conflicting configuration items
+      val result: mutable.Map[String, String] = flinkConfObj
+        .remove(DeploymentOptions.TARGET)
+        .remove(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY)
+        .remove(KubernetesConfigOptions.KUBERNETES_SERVICE_ACCOUNT)
+        .remove(JobManagerOptions.TOTAL_PROCESS_MEMORY)
+        .remove(TaskManagerOptions.TOTAL_PROCESS_MEMORY)
+        .remove(PipelineOptions.JARS)
+        .remove(CoreOptions.DEFAULT_PARALLELISM)
+        .remove(ApplicationConfiguration.APPLICATION_ARGS)
+        .remove(ApplicationConfiguration.APPLICATION_MAIN_CLASS)
+        .remove(SavepointConfigOptions.SAVEPOINT_PATH)
+        .remove(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE)
+        .toMap
+        .asScala
+        .removeKey(KUBERNETES_JM_CPU_AMOUNT_KEY)
+        .removeKey(KUBERNETES_TM_CPU_KEY)
+        .removeKey(KUBERNETES_JM_CPU_AMOUNT_KEY)
+        .removeKey(KUBERNETES_JM_CPU_KEY)
+      Option(deployRequest.k8sDeployParam.flinkRestExposedType).foreach {
+        exposedType => result += KUBERNETES_REST_SERVICE_EXPORTED_TYPE_KEY -> exposedType.getName
+      }
+      result.toMap
+    }
+
+    Right(
+      FlinkDeploymentDef(
+        namespace = namespace,
+        name = name,
+        image = image,
+        imagePullPolicy = imagePullPolicy,
+        serviceAccount = serviceAccount,
+        flinkVersion = flinkVersion,
+        jobManager = jobManager,
+        taskManager = taskManager,
+        flinkConfiguration = extraFlinkConfiguration,
+        extJarPaths = Array.empty
+      ))
   }
 
 }


### PR DESCRIPTION
Refactor the lifecycle control code of Flink clusters on Kubernetes
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #2884

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->
•

[FlinkClusterService.start](https://github.com/apache/incubator-streampark/blob/dev/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkClusterServiceImpl.java#L153) 中 KUBERNETES_NATIVE_SESSION 类型的适配到 [FlinkK8sOperator.deployCluster](https://github.com/Al-assad/streampark-flink-kubernetes-v2/blob/master/src/main/scala/org/apache/streampark/flink/kubernetes/operator/FlinkK8sOperator.scala#L26);
•

[FlinkClusterService.shutdown](https://github.com/apache/incubator-streampark/blob/dev/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkClusterServiceImpl.java#L247) 中 KUBERNETES_NATIVE_SESSION 类型的适配到 [FlinkK8sOperator.delete](https://github.com/Al-assad/streampark-flink-kubernetes-v2/blob/master/src/main/scala/org/apache/streampark/flink/kubernetes/operator/FlinkK8sOperator.scala#L41);

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
