### PR TITLE
[Fix-3226] If the user does not have any more attributes, they will not be able to log in.

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/security/impl/AuthenticatorImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/security/impl/AuthenticatorImpl.java
@@ -77,9 +77,6 @@ public class AuthenticatorImpl implements Authenticator {
 
   private User ldapAuthenticate(String username, String password) throws Exception {
     String ldapEmail = ldapService.ldapLogin(username, password);
-    if (StringUtils.isBlank(ldapEmail)) {
-      return null;
-    }
     // check if user exist
     User user = usersService.findByName(username);
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/security/impl/AuthenticatorImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/security/impl/AuthenticatorImpl.java
@@ -78,7 +78,7 @@ public class AuthenticatorImpl implements Authenticator {
   private User ldapAuthenticate(String username, String password) throws Exception {
     boolean ldapLoginStatus = ldapService.ldapLogin(username, password);
     if (!ldapLoginStatus) {
-        return null;
+      return null;
     }
     // check if user exist
     User user = usersService.findByName(username);

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/security/impl/AuthenticatorImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/security/impl/AuthenticatorImpl.java
@@ -76,7 +76,10 @@ public class AuthenticatorImpl implements Authenticator {
   }
 
   private User ldapAuthenticate(String username, String password) throws Exception {
-    String ldapEmail = ldapService.ldapLogin(username, password);
+    boolean ldapLoginStatus = ldapService.ldapLogin(username, password);
+    if (!ldapLoginStatus) {
+        return null;
+    }
     // check if user exist
     User user = usersService.findByName(username);
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/security/impl/LdapService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/security/impl/LdapService.java
@@ -70,7 +70,7 @@ public class LdapService {
    *
    * @param userId user identity id
    * @param userPwd user login password
-   * @return user email
+   * @return boolean ldapLoginStatus
    */
   public boolean ldapLogin(String userId, String userPwd) {
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/security/impl/LdapService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/security/impl/LdapService.java
@@ -72,7 +72,7 @@ public class LdapService {
    * @param userPwd user login password
    * @return user email
    */
-  public String ldapLogin(String userId, String userPwd) {
+  public boolean ldapLogin(String userId, String userPwd) {
 
     ApiAlertException.throwIfFalse(
         enable, "ldap is not enabled, Please check the configuration: ldap.enable");
@@ -90,7 +90,7 @@ public class LdapService {
     try {
       LdapContext ctx = new InitialLdapContext(ldapEnv, null);
       SearchControls sc = new SearchControls();
-      sc.setReturningAttributes(new String[] {ldapEmailAttribute});
+      sc.setReturningAttributes(new String[] {ldapUserIdentifyingAttribute});
       sc.setSearchScope(SearchControls.SUBTREE_SCOPE);
       EqualsFilter filter = new EqualsFilter(ldapUserIdentifyingAttribute, userId);
       NamingEnumeration<SearchResult> results = ctx.search(ldapBaseDn, filter.toString(), sc);
@@ -104,18 +104,18 @@ public class LdapService {
             new InitialDirContext(ldapEnv);
           } catch (Exception e) {
             log.warn("invalid ldap credentials or ldap search error", e);
-            return null;
+            return false;
           }
           Attribute attr = attrs.next();
-          if (attr.getID().equals(ldapEmailAttribute)) {
-            return (String) attr.get();
+          if (attr.getID().equals(ldapUserIdentifyingAttribute)) {
+            return true;
           }
         }
       }
     } catch (NamingException e) {
       log.error("ldap search error", e);
-      return null;
+      return false;
     }
-    return null;
+    return false;
   }
 }


### PR DESCRIPTION
fix #3226 

Remove email check logic in ldap auth since email is not mandatory when creating a user.