### PR TITLE
[Improve] Rename 'streampark.yarn.http-auth' configuration option from 'sample' to 'simple'

### DIFF
--- a/deploy/helm/streampark/conf/streampark-console-config/application.yml
+++ b/deploy/helm/streampark/conf/streampark-console-config/application.yml
@@ -92,8 +92,8 @@ streampark:
     # lark alert proxy,default https://open.feishu.cn
     lark-url:
   yarn:
-    # default sample, or kerberos
-    http-auth: sample
+    # default simple, or kerberos
+    http-auth: simple
 
   # HADOOP_USER_NAME
   hadoop-user-name: hdfs

--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/CommonConfig.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/CommonConfig.scala
@@ -45,7 +45,7 @@ object CommonConfig {
     key = "streampark.yarn.http-auth",
     defaultValue = "",
     classType = classOf[String],
-    description = "yarn http auth type. ex: sample, kerberos")
+    description = "yarn http auth type. ex: simple, kerberos")
 
   val DOCKER_HOST: InternalOption = InternalOption(
     key = "streampark.docker.http-client.docker-host",

--- a/streampark-common/src/main/scala/org/apache/streampark/common/util/YarnUtils.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/util/YarnUtils.scala
@@ -47,7 +47,7 @@ object YarnUtils extends Logger {
   lazy val PROXY_YARN_URL = InternalConfigHolder.get[String](CommonConfig.STREAMPARK_PROXY_YARN_URL)
 
   /**
-   * hadoop.http.authentication.type<br> get yarn http authentication mode.<br> ex: sample, kerberos
+   * hadoop.http.authentication.type<br> get yarn http authentication mode.<br> ex: simple, kerberos
    *
    * @return
    */
@@ -56,9 +56,9 @@ object YarnUtils extends Logger {
     "kerberos".equalsIgnoreCase(yarnHttpAuth)
   }
 
-  lazy val hasYarnHttpSampleAuth: Boolean = {
+  lazy val hasYarnHttpSimpleAuth: Boolean = {
     val yarnHttpAuth: String = InternalConfigHolder.get[String](CommonConfig.STREAMPARK_YARN_AUTH)
-    "sample".equalsIgnoreCase(yarnHttpAuth)
+    "simple".equalsIgnoreCase(yarnHttpAuth)
   }
 
   /**
@@ -289,7 +289,7 @@ object YarnUtils extends Logger {
         })
     } else {
       val url =
-        if (!hasYarnHttpSampleAuth) reqUrl
+        if (!hasYarnHttpSimpleAuth) reqUrl
         else {
           s"$reqUrl?user.name=${HadoopUtils.hadoopUserName}"
         }

--- a/streampark-console/streampark-console-service/src/main/resources/application.yml
+++ b/streampark-console/streampark-console-service/src/main/resources/application.yml
@@ -77,8 +77,8 @@ streampark:
     # lark alert proxy,default https://open.feishu.cn
     lark-url:
   yarn:
-    # default sample, or kerberos
-    http-auth: sample
+    # default simple, or kerberos
+    http-auth: simple
 
   # HADOOP_USER_NAME
   hadoop-user-name: hdfs


### PR DESCRIPTION
This PR is intended to rename the 'streampark.yarn.http-auth' configuration option from 'sample' to 'simple'. The change is made to ensure compatibility with Hadoop, as Hadoop does not support the 'sample' authentication mode. This modification prevents potential issues and confusion in the future.