### PR TITLE
[Improve][Flink-Kubernetes-V2] add exception throw

### DIFF
--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesApplicationClientV2.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesApplicationClientV2.scala
@@ -174,7 +174,7 @@ object KubernetesApplicationClientV2 extends KubernetesClientV2Trait with Logger
         .getOrElse(KUBERNETES_TM_MEMORY_DEFAULT)
 
       val ephemeralStorage = Option(submitReq.k8sSubmitParam.taskManagerEphemeralStorage)
-        .getOrElse(return Left(s"JobManagerEphemeralStorage should not be empty"))
+        .getOrElse(return Left(s"TaskManagerEphemeralStorage should not be empty"))
 
       val podTemplate = submitReq.k8sSubmitParam.taskManagerPodTemplate.map(
         yaml =>

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesApplicationClientV2.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesApplicationClientV2.scala
@@ -103,14 +103,15 @@ object KubernetesApplicationClientV2 extends KubernetesClientV2Trait with Logger
       .filter(str => StringUtils.isNotBlank(str))
       .getOrElse(return Left("Flink base image should not be empty"))
 
-    val ingress = submitReq.k8sSubmitParam.ingressDefinition
-      .getOrElse(return Left("Flink base ingress should not be empty"))
+    val ingress = Option(submitReq.k8sSubmitParam.ingressDefinition)
+      .getOrElse(return Left("Ingress should not be empty"))
 
-    val imagePullPolicy = flinkConfObj
-      .getOption(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY)
-      .map(_.toString)
-      .orElse(submitReq.k8sSubmitParam.imagePullPolicy)
-      .getOrElse(return Left("Flink base imagePullPolicy should not be empty"))
+    val imagePullPolicy = Option(
+      flinkConfObj
+        .getOption(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY)
+        .map(_.toString)
+        .orElse(submitReq.k8sSubmitParam.imagePullPolicy))
+      .getOrElse(return Left("Flink imagePullPolicy should not be empty"))
 
     val serviceAccount = flinkConfObj
       .getOption(KubernetesConfigOptions.KUBERNETES_SERVICE_ACCOUNT)

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesApplicationClientV2.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesApplicationClientV2.scala
@@ -104,11 +104,13 @@ object KubernetesApplicationClientV2 extends KubernetesClientV2Trait with Logger
       .getOrElse(return Left("Flink base image should not be empty"))
 
     val ingress = submitReq.k8sSubmitParam.ingressDefinition
+      .getOrElse(return Left("Flink base ingress should not be empty"))
 
     val imagePullPolicy = flinkConfObj
       .getOption(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY)
       .map(_.toString)
       .orElse(submitReq.k8sSubmitParam.imagePullPolicy)
+      .getOrElse(return Left("Flink base imagePullPolicy should not be empty"))
 
     val serviceAccount = flinkConfObj
       .getOption(KubernetesConfigOptions.KUBERNETES_SERVICE_ACCOUNT)
@@ -142,6 +144,9 @@ object KubernetesApplicationClientV2 extends KubernetesClientV2Trait with Logger
         .orElse(submitReq.k8sSubmitParam.jobManagerMemory)
         .getOrElse(KUBERNETES_JM_MEMORY_DEFAULT)
 
+      val ephemeralStorage = Option(submitReq.k8sSubmitParam.jobManagerEphemeralStorage)
+        .getOrElse(return Left(s"JobManagerEphemeralStorage should not be empty"))
+
       val podTemplate = submitReq.k8sSubmitParam.jobManagerPodTemplate.map(
         yaml =>
           unmarshalPodTemplate(yaml)
@@ -149,7 +154,7 @@ object KubernetesApplicationClientV2 extends KubernetesClientV2Trait with Logger
       JobManagerDef(
         cpu = cpu,
         memory = mem,
-        ephemeralStorage = submitReq.k8sSubmitParam.jobManagerEphemeralStorage,
+        ephemeralStorage = ephemeralStorage,
         podTemplate = podTemplate)
     }
 
@@ -167,6 +172,9 @@ object KubernetesApplicationClientV2 extends KubernetesClientV2Trait with Logger
         .orElse(submitReq.k8sSubmitParam.taskManagerMemory)
         .getOrElse(KUBERNETES_TM_MEMORY_DEFAULT)
 
+      val ephemeralStorage = Option(submitReq.k8sSubmitParam.jobManagerEphemeralStorage)
+        .getOrElse(return Left(s"JobManagerEphemeralStorage should not be empty"))
+
       val podTemplate = submitReq.k8sSubmitParam.taskManagerPodTemplate.map(
         yaml =>
           unmarshalPodTemplate(yaml)
@@ -174,7 +182,7 @@ object KubernetesApplicationClientV2 extends KubernetesClientV2Trait with Logger
       TaskManagerDef(
         cpu = cpu,
         memory = mem,
-        ephemeralStorage = submitReq.k8sSubmitParam.taskManagerEphemeralStorage,
+        ephemeralStorage = ephemeralStorage,
         podTemplate = podTemplate)
     }
 

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesApplicationClientV2.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesApplicationClientV2.scala
@@ -172,7 +172,7 @@ object KubernetesApplicationClientV2 extends KubernetesClientV2Trait with Logger
         .orElse(submitReq.k8sSubmitParam.taskManagerMemory)
         .getOrElse(KUBERNETES_TM_MEMORY_DEFAULT)
 
-      val ephemeralStorage = Option(submitReq.k8sSubmitParam.jobManagerEphemeralStorage)
+      val ephemeralStorage = Option(submitReq.k8sSubmitParam.taskManagerEphemeralStorage)
         .getOrElse(return Left(s"JobManagerEphemeralStorage should not be empty"))
 
       val podTemplate = submitReq.k8sSubmitParam.taskManagerPodTemplate.map(

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesSessionClientV2.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesSessionClientV2.scala
@@ -205,10 +205,11 @@ object KubernetesSessionClientV2 extends KubernetesClientV2Trait with Logger {
       .filter(str => StringUtils.isNotBlank(str))
       .getOrElse(return Left("Kubernetes CR name should not be empty"))
 
-    val imagePullPolicy = flinkConfObj
-      .getOption(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY)
-      .map(_.toString)
-      .getOrElse(return Left("Flink base imagePullPolicy should not be empty"))
+    val imagePullPolicy = Option(
+      flinkConfObj
+        .getOption(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY)
+        .map(_.toString))
+      .getOrElse(return Left("Flink imagePullPolicy should not be empty"))
 
     val image = Option(deployReq.k8sDeployParam.flinkImage)
       .filter(str => StringUtils.isNotBlank(str))

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesSessionClientV2.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/KubernetesSessionClientV2.scala
@@ -208,6 +208,7 @@ object KubernetesSessionClientV2 extends KubernetesClientV2Trait with Logger {
     val imagePullPolicy = flinkConfObj
       .getOption(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY)
       .map(_.toString)
+      .getOrElse(return Left("Flink base imagePullPolicy should not be empty"))
 
     val image = Option(deployReq.k8sDeployParam.flinkImage)
       .filter(str => StringUtils.isNotBlank(str))


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->
In some places where it might be null, I add an exception throw
①[KubernetesApplicationClientV2.scala]
②[KubernetesSesionClientV2.scala]

## What changes were proposed in this pull request

fix: #2882 and #2884 <!-- REMOVE this line if no issue to close -->

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
