### PR TITLE
[Improve] Use isEmpty() instead of length() == 0 or size() == 0 for collections

### DIFF
--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-doris/src/main/java/org/apache/streampark/flink/connector/doris/util/DorisDelimiterParser.java
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-doris/src/main/java/org/apache/streampark/flink/connector/doris/util/DorisDelimiterParser.java
@@ -24,7 +24,7 @@ public class DorisDelimiterParser {
   private static final String HEX_STRING = "0123456789ABCDEF";
 
   public static String parse(String sp) throws RuntimeException {
-    if (sp == null || sp.length() == 0) {
+    if (sp == null || sp.isEmpty()) {
       throw new RuntimeException("Delimiter can't be empty");
     }
     if (!sp.toUpperCase().startsWith("\\X")) {

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-doris/src/main/java/org/apache/streampark/flink/connector/doris/util/DorisDelimiterParser.java
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-doris/src/main/java/org/apache/streampark/flink/connector/doris/util/DorisDelimiterParser.java
@@ -24,7 +24,7 @@ public class DorisDelimiterParser {
   private static final String HEX_STRING = "0123456789ABCDEF";
 
   public static String parse(String sp) throws RuntimeException {
-    if (sp == null || sp.isEmpty()) {
+    if (sp == null || sp.isBlank()) {
       throw new RuntimeException("Delimiter can't be empty");
     }
     if (!sp.toUpperCase().startsWith("\\X")) {


### PR DESCRIPTION
[Improve] Use isEmpty() instead of length() == 0 or size() == 0 for collections

<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #3334 

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
