### PR TITLE
[improve] update sql in xml for cross-compatibility with mysql, h2, and pgsql in like concat expressions

### DIFF
--- a/streampark-console/streampark-console-service/src/main/resources/mapper/core/ApplicationMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/core/ApplicationMapper.xml
@@ -163,10 +163,10 @@
                 and t.execution_mode = #{application.executionMode}
             </if>
             <if test="application.jobName != null and application.jobName != ''">
-                and t.job_name like concat('%',#{application.jobName},'%')
+                and t.job_name like concat('%', CAST(#{application.jobName} AS CHAR), '%')
             </if>
             <if test="application.projectName != null and application.projectName != ''">
-                and p.name like concat('%',#{application.projectName},'%')
+                and p.name like concat('%', CAST(#{application.projectName} AS CHAR), '%')
             </if>
             <if test="application.appId != null and application.appId != ''">
                 and t.app_id = #{application.appId}
@@ -185,7 +185,7 @@
                 </foreach>
             </if>
             <if test="application.tags != null and application.tags != ''">
-                and t.tags like concat('%',#{application.tags},'%')
+                and t.tags like concat('%', CAST(#{application.tags} AS CHAR), '%')
             </if>
         </where>
     </select>

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/core/ProjectMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/core/ProjectMapper.xml
@@ -72,7 +72,7 @@
         <where>
             t.team_id = #{project.teamId}
             <if test="project.name != null and project.name != ''">
-                and t.name like concat('%',#{project.name},'%')
+                and t.name like concat('%', CAST(#{project.name} AS CHAR), '%')
             </if>
             <if test="project.buildState != null">
                 and t.build_state = #{project.buildState}

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/core/VariableMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/core/VariableMapper.xml
@@ -38,10 +38,10 @@
         on v.creator_id = u.user_id
         and v.team_id = #{variable.teamId}
         <if test="variable.description != null and variable.description != ''">
-            and v.description like concat('%',#{variable.description},'%')
+            and v.description like concat('%', CAST(#{variable.description} AS CHAR), '%')
         </if>
         <if test="variable.variableCode != null and variable.variableCode != ''">
-            and v.variable_code like concat('%',#{variable.variableCode},'%')
+            and v.variable_code like concat('%', CAST(#{variable.variableCode} AS CHAR), '%')
         </if>
     </select>
 
@@ -61,7 +61,7 @@
         <where>
             team_id = #{teamId}
             <if test="keyword != null and keyword != ''">
-                and variable_code like concat('%', #{keyword}, '%') or description like concat('%', #{keyword}, '%')
+                and variable_code like concat('%', CAST(#{keyword} AS CHAR), '%') or description like concat('%', CAST(#{keyword} AS CHAR), '%')
             </if>
         </where>
     </select>

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/core/YarnQueueMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/core/YarnQueueMapper.xml
@@ -33,7 +33,7 @@
                 team_id = #{yarnQueue.teamId}
             </if>
             <if test="yarnQueue.queueLabel != null and yarnQueue.queueLabel != ''">
-                and queue_label like concat('%',#{yarnQueue.queueLabel},'%')
+                and queue_label like concat('%', CAST(#{yarnQueue.queueLabel} AS CHAR), '%')
             </if>
             <if test="yarnQueue.createTimeFrom != null and yarnQueue.createTimeFrom !=''">
                 and create_time &gt; #{yarnQueue.createTimeFrom}

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/MemberMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/MemberMapper.xml
@@ -51,7 +51,7 @@
         <where>
             tur.team_id = #{member.teamId}
             <if test="member.userName != null and member.userName != ''">
-                and u.username like concat('%',#{member.userName},'%')
+                and u.username like concat('%', CAST(#{member.userName} AS CHAR), '%')
             </if>
             <if test="member.roleName != null and member.roleName != ''">
                 and r.role_name = #{member.roleName}

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/RoleMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/RoleMapper.xml
@@ -29,7 +29,7 @@
         select * from t_role
         <where>
             <if test="role.roleName != null and role.roleName != ''">
-                and role_name like concat('%',#{role.roleName},'%')
+                and role_name like concat('%', CAST(#{role.roleName} AS CHAR), '%')
             </if>
             <if test="role.createTimeFrom != null and role.createTimeFrom !=''">
                 and  create_time &gt; #{role.createTimeFrom}

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/TeamMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/TeamMapper.xml
@@ -29,7 +29,7 @@
         select * from t_team
         <where>
             <if test="team.teamName != null and team.teamName != ''">
-                and team_name like concat('%',#{team.teamName},'%')
+                and team_name like concat('%', CAST(#{team.teamName} AS CHAR), '%')
             </if>
             <if test="team.createTimeFrom != null and team.createTimeFrom !=''">
                 and create_time &gt; #{team.createTimeFrom}

--- a/streampark-console/streampark-console-service/src/main/resources/mapper/system/UserMapper.xml
+++ b/streampark-console/streampark-console-service/src/main/resources/mapper/system/UserMapper.xml
@@ -38,7 +38,7 @@
         select * from t_user
         <where>
             <if test="user.username != null and user.username != ''">
-                and username like concat('%',#{user.username},'%')
+                and username like concat('%', CAST(#{user.username} AS CHAR), '%')
             </if>
             <if test="user.createTimeFrom != null and user.createTimeFrom !=''">
                 and create_time &gt; #{user.createTimeFrom}


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #3451 <!-- REPLACE 'xxx' with the issue number this PR addresses -->

This pull request proposes changes to SQL statements within XML files, specifically updating `LIKE CONCAT` expressions for cross-database compatibility with MySQL, H2, and PostgreSQL.

## Brief change log

- Modified SQL `LIKE CONCAT` expressions in XML files to ensure compatibility across MySQL, H2, and PostgreSQL databases.

## Verifying this change

This change is a refactoring of existing SQL statements and does not alter functionality. It does not directly require new tests, but existing tests should pass to ensure that the changes maintain backward compatibility with previous database behaviors.

Existing tests covering database interactions were rerun to verify that the SQL changes function as expected in different database environments.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no