### PR TITLE
get cluster detail of flink session on k8s with ingress url bug fix

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/FlinkClusterController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/FlinkClusterController.java
@@ -48,7 +48,7 @@ public class FlinkClusterController {
   @Operation(summary = "List flink clusters")
   @PostMapping("list")
   public RestResponse list() {
-    List<FlinkCluster> flinkClusters = flinkClusterService.list();
+    List<FlinkCluster> flinkClusters = flinkClusterService.listCluster();
     return RestResponse.success(flinkClusters);
   }
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/FlinkClusterService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/FlinkClusterService.java
@@ -47,4 +47,6 @@ public interface FlinkClusterService extends IService<FlinkCluster> {
   Boolean existsByFlinkEnvId(Long id);
 
   List<FlinkCluster> getByExecutionModes(Collection<ExecutionMode> executionModes);
+
+  List<FlinkCluster> listCluster();
 }


### PR DESCRIPTION
fix the bug that flink session on k8s cluster can't use access ingress url by click view  detail button#issue:3522