### PR TITLE
[Improve] Optimize equals method conflicts

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/bean/Dependency.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/bean/Dependency.java
@@ -26,7 +26,7 @@ import org.apache.streampark.flink.packer.maven.Artifact;
 import org.apache.streampark.flink.packer.maven.DependencyInfo;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.Data;
+import lombok.Getter;
 import lombok.SneakyThrows;
 
 import java.io.File;
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Data
+@Getter
 public class Dependency {
   private List<MavenPom> pom = Collections.emptyList();
   private List<String> jar = Collections.emptyList();


### PR DESCRIPTION
Improve the conflict issue between the equals method in lombok's `@Data`  annotation and the equals method in the same class during the install packaging process.