### PR TITLE
[Fix] The initialization of the configuration comes before the bean is loaded

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/StreamParkConsoleBootstrap.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/StreamParkConsoleBootstrap.java
@@ -25,6 +25,8 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
+ *
+ *
  * <pre>
  *
  *      _____ __                                             __
@@ -46,9 +48,9 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 public class StreamParkConsoleBootstrap {
 
-    public static void main(String[] args) {
-        new SpringApplicationBuilder(StreamParkConsoleBootstrap.class)
-            .initializers(new EnvApplicationContextInitializer())
-            .run(args);
-    }
+  public static void main(String[] args) {
+    new SpringApplicationBuilder(StreamParkConsoleBootstrap.class)
+        .initializers(new EnvApplicationContextInitializer())
+        .run(args);
+  }
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/StreamParkConsoleBootstrap.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/StreamParkConsoleBootstrap.java
@@ -17,14 +17,14 @@
 
 package org.apache.streampark.console;
 
+import org.apache.streampark.console.core.runner.EnvApplicationContextInitializer;
+
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
- *
- *
  * <pre>
  *
  *      _____ __                                             __
@@ -46,7 +46,9 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 public class StreamParkConsoleBootstrap {
 
-  public static void main(String[] args) {
-    SpringApplication.run(StreamParkConsoleBootstrap.class, args);
-  }
+    public static void main(String[] args) {
+        new SpringApplicationBuilder(StreamParkConsoleBootstrap.class)
+            .initializers(new EnvApplicationContextInitializer())
+            .run(args);
+    }
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvApplicationContextInitializer.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvApplicationContextInitializer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.console.core.runner;
+
+import org.apache.streampark.common.conf.ConfigKeys;
+import org.apache.streampark.common.conf.InternalConfigHolder;
+import org.apache.streampark.common.conf.InternalOption;
+import org.apache.streampark.common.util.Utils;
+import org.apache.streampark.console.base.util.WebUtils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.Environment;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public class EnvApplicationContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext context) {
+        Optional<String> profile =
+            Arrays.stream(context.getEnvironment().getActiveProfiles()).findFirst();
+        if ("test".equals(profile.orElse(null))) {
+            return;
+        }
+
+        String appHome = WebUtils.getAppHome();
+        if (StringUtils.isBlank(appHome)) {
+            throw new ExceptionInInitializerError(
+                String.format(
+                    "[StreamPark] System initialization check failed,"
+                        + " The system initialization check failed. If started local for development and debugging,"
+                        + " please ensure the -D%s parameter is clearly specified,"
+                        + " more detail: https://streampark.apache.org/docs/user-guide/deployment",
+                    ConfigKeys.KEY_APP_HOME()));
+        }
+
+        // init InternalConfig
+        initInternalConfig(context.getEnvironment());
+    }
+
+    private void initInternalConfig(Environment springEnv) {
+        // override config from spring application.yaml
+        InternalConfigHolder.keys().stream()
+            .filter(springEnv::containsProperty)
+            .forEach(
+                key -> {
+                    InternalOption config = InternalConfigHolder.getConfig(key);
+                    Utils.requireNotNull(config);
+                    InternalConfigHolder.set(config, springEnv.getProperty(key, config.classType()));
+                });
+    }
+
+}
+

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvApplicationContextInitializer.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvApplicationContextInitializer.java
@@ -32,42 +32,41 @@ import org.springframework.core.env.Environment;
 import java.util.Arrays;
 import java.util.Optional;
 
-public class EnvApplicationContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+public class EnvApplicationContextInitializer
+    implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-    @Override
-    public void initialize(ConfigurableApplicationContext context) {
-        Optional<String> profile =
-            Arrays.stream(context.getEnvironment().getActiveProfiles()).findFirst();
-        if ("test".equals(profile.orElse(null))) {
-            return;
-        }
-
-        String appHome = WebUtils.getAppHome();
-        if (StringUtils.isBlank(appHome)) {
-            throw new ExceptionInInitializerError(
-                String.format(
-                    "[StreamPark] System initialization check failed,"
-                        + " The system initialization check failed. If started local for development and debugging,"
-                        + " please ensure the -D%s parameter is clearly specified,"
-                        + " more detail: https://streampark.apache.org/docs/user-guide/deployment",
-                    ConfigKeys.KEY_APP_HOME()));
-        }
-
-        // init InternalConfig
-        initInternalConfig(context.getEnvironment());
+  @Override
+  public void initialize(ConfigurableApplicationContext context) {
+    Optional<String> profile =
+        Arrays.stream(context.getEnvironment().getActiveProfiles()).findFirst();
+    if ("test".equals(profile.orElse(null))) {
+      return;
     }
 
-    private void initInternalConfig(Environment springEnv) {
-        // override config from spring application.yaml
-        InternalConfigHolder.keys().stream()
-            .filter(springEnv::containsProperty)
-            .forEach(
-                key -> {
-                    InternalOption config = InternalConfigHolder.getConfig(key);
-                    Utils.requireNotNull(config);
-                    InternalConfigHolder.set(config, springEnv.getProperty(key, config.classType()));
-                });
+    String appHome = WebUtils.getAppHome();
+    if (StringUtils.isBlank(appHome)) {
+      throw new ExceptionInInitializerError(
+          String.format(
+              "[StreamPark] System initialization check failed,"
+                  + " The system initialization check failed. If started local for development and debugging,"
+                  + " please ensure the -D%s parameter is clearly specified,"
+                  + " more detail: https://streampark.apache.org/docs/user-guide/deployment",
+              ConfigKeys.KEY_APP_HOME()));
     }
 
+    // init InternalConfig
+    initInternalConfig(context.getEnvironment());
+  }
+
+  private void initInternalConfig(Environment springEnv) {
+    // override config from spring application.yaml
+    InternalConfigHolder.keys().stream()
+        .filter(springEnv::containsProperty)
+        .forEach(
+            key -> {
+              InternalOption config = InternalConfigHolder.getConfig(key);
+              Utils.requireNotNull(config);
+              InternalConfigHolder.set(config, springEnv.getProperty(key, config.classType()));
+            });
+  }
 }
-


### PR DESCRIPTION
The initialization of the configuration comes before the bean is loaded

## What changes were proposed in this pull request

Issue Number: close #3494 

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

The initial configuration load consists of two parts:
 - 1. one is the native java and scala default configuration
 - 2. the other is the environment variable passed into the ApplicationContext via yaml or parameter configuration

The current streampark flushes the yaml configuration into the global configuration cache after springboot starts. 

As a result, during bean initialization, if you want to use yaml or parameter configuration to pass the value, 

it will fail, and the default value will be used instead.

I recommend that the initialization of the configuration cache be advanced to before the bean is loaded

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
