### PR TITLE
[FIX] Missing Default Value for t_flink_app Column Causes Abnormal H2 Data Initialization

### DIFF
--- a/streampark-console/streampark-console-service/src/main/resources/db/data-h2.sql
+++ b/streampark-console/streampark-console-service/src/main/resources/db/data-h2.sql
@@ -24,7 +24,7 @@ insert into `t_team` values (100001, 'test', 'The test team', now(), now());
 -- ----------------------------
 -- Records of t_flink_app
 -- ----------------------------
-insert into `t_flink_app` values (100000, 100000, 2, 4, null, null, 'Flink SQL Demo', null, null, null, null, null, null , null, 100000, null, 1, null, null, null, null, null, null, null, null, '0', 0, null, null, null, null, null, null, 'Flink SQL Demo', 0, null, null, null, null, null, null, null, 0, 0, now(), now(), null, 1, 1, null, null, null, null, null, null, 0, null, null, null, 'streampark,test', 0);
+insert into `t_flink_app` values (100000, 100000, 2, 4, null, null, 'Flink SQL Demo', null, null, null, null, null, null , null, 100000, null, 1, null, null, null, null, null, null, null, null, '0', 0, null, null, null, null, null, null, 'Flink SQL Demo', 0, null, null, null, null, null, null, null, 0, 0, now(), now(), null, 1, 1, null, null, null, null, null, null, 0, null, null, null, 'streampark,test', 0, null);
 
 -- ----------------------------
 -- Records of t_flink_effective


### PR DESCRIPTION
When initializing h2 t_flink_app table, each column must have a default value
## Contribution Checklist


## What changes were proposed in this pull request

Issue Number: close #3531


## Brief change log

add default value

## Verifying this change



This change is a trivial rework / code cleanup without any test coverage.




## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
