### PR TITLE
Fix path resolution exception when submitting tasks in remote mode on Windows environment

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/bean/Dependency.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/bean/Dependency.java
@@ -26,7 +26,7 @@ import org.apache.streampark.flink.packer.maven.Artifact;
 import org.apache.streampark.flink.packer.maven.DependencyInfo;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import lombok.Data;
+import lombok.Getter;
 import lombok.SneakyThrows;
 
 import java.io.File;
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Data
+@Getter
 public class Dependency {
   private List<MavenPom> pom = Collections.emptyList();
   private List<String> jar = Collections.emptyList();

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/FlinkClientTrait.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/FlinkClientTrait.scala
@@ -102,7 +102,11 @@ trait FlinkClientTrait extends Logger {
         }
       case _ =>
         if (submitRequest.userJarFile != null) {
-          val uri = PackagedProgramUtils.resolveURI(submitRequest.userJarFile.getAbsolutePath)
+          var jarPath = submitRequest.userJarFile.getAbsolutePath
+          if (Utils.isWindows) {
+            jarPath = StringUtils.replace(jarPath, "\\", "/")
+          }
+          val uri = PackagedProgramUtils.resolveURI(jarPath)
           val programOptions = ProgramOptions.create(commandLine)
           val executionParameters = ExecutionConfigAccessor.fromProgramOptions(
             programOptions,


### PR DESCRIPTION
In a Windows environment, replace the `\` in the jar path with `/`.  #3534 