### PR TITLE
[ISSUES-3534] Fix path resolution exception when submitting tasks in remote mode on Windows environment

### DIFF
--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/FlinkClientTrait.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/FlinkClientTrait.scala
@@ -102,7 +102,11 @@ trait FlinkClientTrait extends Logger {
         }
       case _ =>
         if (submitRequest.userJarFile != null) {
-          val uri = PackagedProgramUtils.resolveURI(submitRequest.userJarFile.getAbsolutePath)
+          var jarPath = submitRequest.userJarFile.getAbsolutePath
+          if (Utils.isWindows) {
+            jarPath = StringUtils.replace(jarPath, "\\", "/")
+          }
+          val uri = PackagedProgramUtils.resolveURI(jarPath)
           val programOptions = ProgramOptions.create(commandLine)
           val executionParameters = ExecutionConfigAccessor.fromProgramOptions(
             programOptions,


### PR DESCRIPTION
In a Windows environment, replace the `\` in the jar path with `/`.