### PR TITLE
[BUG][FLINK-DEPEND]Fix flink lib to exclude dependencies that do not end in.jar 

### DIFF
--- a/streampark-flink/streampark-flink-proxy/src/main/scala/org/apache/streampark/flink/proxy/FlinkShimsProxy.scala
+++ b/streampark-flink/streampark-flink-proxy/src/main/scala/org/apache/streampark/flink/proxy/FlinkShimsProxy.scala
@@ -165,7 +165,7 @@ object FlinkShimsProxy extends Logger {
     SHIMS_CLASS_LOADER_CACHE.getOrElseUpdate(
       s"${flinkVersion.fullVersion}", {
         // 1) flink/lib
-        val libURL = getFlinkHomeLib(flinkVersion.flinkHome, "lib", !_.getName.startsWith("log4j"))
+        val libURL = getFlinkHomeLib(flinkVersion.flinkHome, "lib", file=>(!file.getName.startsWith("log4j") && file.getName.endsWith(".jar")))
         val shimsUrls = ListBuffer[URL](libURL: _*)
 
         // 2) add all shims jar

--- a/streampark-flink/streampark-flink-proxy/src/main/scala/org/apache/streampark/flink/proxy/FlinkShimsProxy.scala
+++ b/streampark-flink/streampark-flink-proxy/src/main/scala/org/apache/streampark/flink/proxy/FlinkShimsProxy.scala
@@ -165,7 +165,10 @@ object FlinkShimsProxy extends Logger {
     SHIMS_CLASS_LOADER_CACHE.getOrElseUpdate(
       s"${flinkVersion.fullVersion}", {
         // 1) flink/lib
-        val libURL = getFlinkHomeLib(flinkVersion.flinkHome, "lib", file=>(!file.getName.startsWith("log4j") && file.getName.endsWith(".jar")))
+        val libURL = getFlinkHomeLib(
+          flinkVersion.flinkHome,
+          "lib",
+          file => (!file.getName.startsWith("log4j") && file.getName.endsWith(".jar")))
         val shimsUrls = ListBuffer[URL](libURL: _*)
 
         // 2) add all shims jar


### PR DESCRIPTION

<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close 
### What issues are fixed

<img width="731" alt="image" src="https://github.com/apache/incubator-streampark/assets/76689593/71c3c7b3-2eae-4a1b-b48e-3c5d4ae3494d">
<img width="1316" alt="image" src="https://github.com/apache/incubator-streampark/assets/76689593/7eeb476e-4ee6-4c28-a534-69cfc81ae3d6">

This problem was resolved when I eliminated the need to rely on.jar endings. Many developers get used to the name.bak for easy backup, but applications shouldn't load it 

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no

