### PR TITLE
[ISSUE-3085][Improve] Improve streampark-flink module based on [3.4 Collection Rule]

### DIFF
--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-doris/src/main/java/org/apache/streampark/flink/connector/doris/bean/DorisSinkBufferEntry.java
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-doris/src/main/java/org/apache/streampark/flink/connector/doris/bean/DorisSinkBufferEntry.java
@@ -26,11 +26,11 @@ public class DorisSinkBufferEntry implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  public ArrayList<byte[]> getBuffer() {
+  public List<byte[]> getBuffer() {
     return buffer;
   }
 
-  private ArrayList<byte[]> buffer = new ArrayList<>();
+  private List<byte[]> buffer = new ArrayList<>();
   private int batchCount = 0;
   private long batchSize = 0;
   private String label;


### PR DESCRIPTION
1. FOR`collection`returned values, unless there are special`concurrent`(such as thread safety), always return the`interface`, such as:
returns List if use ArrayList

3.Use isEmpty() instead of length() == 0 or size() == 0

I didn't find this way of writing in the `streampark-flink` module.

## What changes were proposed in this pull request

Issue Number: close #3085  

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
