### PR TITLE
[Improve] JAVA_OPTS improvement

### DIFF
--- a/streampark-console/streampark-console-service/src/main/assembly/bin/jvm_opts.sh
+++ b/streampark-console/streampark-console-service/src/main/assembly/bin/jvm_opts.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+-Xms1g
+-Xmx1g
+-Xmn512m
+
+-XX:+ExitOnOutOfMemoryError
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:+IgnoreUnrecognizedVMOptions
+
+-XX:+PrintGCDateStamps
+-XX:+PrintGCDetails
+-XX:+PrintGC
+
+-XX:+UseGCLogFileRotation
+-XX:GCLogFileSize=50M
+-XX:NumberOfGCLogFiles=10
+

--- a/streampark-console/streampark-console-service/src/main/assembly/bin/streampark.sh
+++ b/streampark-console/streampark-console-service/src/main/assembly/bin/streampark.sh
@@ -241,23 +241,25 @@ if [ "$USE_NOHUP" = "true" ]; then
   NOHUP="nohup"
 fi
 
-
 PARAM_CLI="org.apache.streampark.flink.core.conf.ParameterCli"
 
 APP_MAIN="org.apache.streampark.console.StreamParkConsoleBootstrap"
 
-DEFAULT_OPTS="""
-  -ea
-  -server
-  -Xms1024m
-  -Xmx1024m
-  -Xmn256m
-  -XX:NewSize=100m
-  -XX:+UseConcMarkSweepGC
-  -XX:CMSInitiatingOccupancyFraction=70
-  -Xloggc:${APP_HOME}/logs/gc.log
-  """
+JVM_OPTS_FILE=${APP_HOME}/bin/jvm_opts.sh
 
+JVM_ARGS="-server"
+if [ -f $JVM_OPTS_FILE ]; then
+  while read line
+  do
+      if [[ "$line" == -* ]]; then
+        JVM_ARGS="${JVM_ARGS} $line"
+      fi
+  done < $JVM_OPTS_FILE
+fi
+
+JVM_OPTS=${JVM_OPTS:-"${JVM_ARGS}"}
+JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=${APP_HOME}/logs/dump.hprof"
+JVM_OPTS="$JVM_OPTS -Xloggc:${APP_HOME}/logs/gc.log"
 DEBUG_OPTS=""
 
 # ----- Execute The Requested Command -----------------------------------------
@@ -417,13 +419,12 @@ start() {
 
   # shellcheck disable=SC2034
   # shellcheck disable=SC2006
-  local vmOption=`$_RUNJAVA -cp "$APP_CLASSPATH" $PARAM_CLI --vmopt`
+  # shellcheck disable=SC2155
+  local ADD_OPENS=`$_RUNJAVA -cp "$APP_CLASSPATH" $PARAM_CLI --vmopt`
 
-  local JAVA_OPTS="""
-  $vmOption
-  $DEFAULT_OPTS
-  $DEBUG_OPTS
-  """
+  local JAVA_OPTS="$ADD_OPENS $JVM_OPTS $DEBUG_OPTS"
+
+  echo_g "JAVA_OPTS:  ${JAVA_OPTS}"
 
   eval $NOHUP $_RUNJAVA $JAVA_OPTS \
     -classpath "$APP_CLASSPATH" \
@@ -498,13 +499,14 @@ start_docker() {
 
   # shellcheck disable=SC2034
   # shellcheck disable=SC2006
-  local vmOption=`$_RUNJAVA -cp "$APP_CLASSPATH" $PARAM_CLI --vmopt`
+  # shellcheck disable=SC2155
+  local ADD_OPENS=`$_RUNJAVA -cp "$APP_CLASSPATH" $PARAM_CLI --vmopt`
 
-  local JAVA_OPTS="""
-    $vmOption
-    $DEFAULT_OPTS
-    $DEBUG_OPTS
-    """
+  JVM_OPTS="${JVM_OPTS} -XX:-UseContainerSupport"
+
+  local JAVA_OPTS="$ADD_OPENS $JVM_OPTS $DEBUG_OPTS"
+
+  echo_g "JAVA_OPTS:  ${JAVA_OPTS}"
 
   $_RUNJAVA $JAVA_OPTS \
     -classpath "$APP_CLASSPATH" \


### PR DESCRIPTION

## [Improve] JAVA_OPTS improvement

Currently, setting the memory size, number of threads, and other JAVA_OPTS in StreamPark requires configuration in the startup script. which is inconvenient for users. We can improve this by using a separate configuration file to set JAVA_OPTS. Users only need to modify this configuration file, restart, and the changes to these parameters will take effect.


## What changes were proposed in this pull request

Issue Number: close #3575

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
