### PR TITLE
Resolving streampark flink on k8s that flink task status is failed but k8s pod still alive

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkK8sChangeEventListener.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/FlinkK8sChangeEventListener.java
@@ -71,8 +71,11 @@ public class FlinkK8sChangeEventListener {
     TrackId trackId = event.trackId();
     // get pre application record
     Application app = applicationService.getById(trackId.appId());
-    if (app == null || FlinkAppState.isEndState(app.getState())) {
+    if (app == null) {
       return;
+    }
+    if (FlinkAppState.isEndState(app.getState())) {
+      log.info("job [{}] is EndState, but also update it.", app.getJobName());
     }
 
     // update application record


### PR DESCRIPTION
Resolving streampark flink on k8s that flink task status is failed but k8s pod still alive

## What changes were proposed in this pull request

Issue Number: close #3618  <!-- REMOVE this line if no issue to close -->

The status of flink task is failed or other end state in database, but  is running in memory, which lead to show failed in streampark but is running actually.
This change reslove the streampark flink status and the real task status not consistent.


## Brief change log
Remove the check and return that state on database is end state then not update the state.

## Verifying this change
Show in #3618 

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
