### PR TITLE
[ISSUE -3638][Fix]  Flink native k8s application task with INITIALIZING…

### DIFF
--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/KubernetesRetriever.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/KubernetesRetriever.scala
@@ -136,17 +136,14 @@ object KubernetesRetriever extends Logger {
 
   /** retrieve flink jobManager rest url */
   def retrieveFlinkRestUrl(clusterKey: ClusterKey): Option[String] = {
-    Utils.using(
-      KubernetesRetriever
-        .newFinkClusterClient(clusterKey.clusterId, clusterKey.namespace, clusterKey.executeMode)
-        .getOrElse(return None)) {
-      client =>
-        val url =
-          IngressController.getIngressUrl(clusterKey.namespace, clusterKey.clusterId, client)
-        logger.info(s"retrieve flink jobManager rest url: $url")
-        client.close()
-        Some(url)
-    }
+    val url =
+      IngressController.getIngressUrl(clusterKey.namespace, clusterKey.clusterId) {
+        KubernetesRetriever
+          .newFinkClusterClient(clusterKey.clusterId, clusterKey.namespace, clusterKey.executeMode)
+          .getOrElse(return None)
+      }
+    logger.info(s"retrieve flink jobManager rest url: $url")
+    Some(url)
   }
 
   def getSessionClusterIngressURL(namespace: String, clusterId: String): String = {

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/ingress/IngressController.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/ingress/IngressController.scala
@@ -47,9 +47,9 @@ object IngressController extends Logger {
 
   def getIngressUrl(
       nameSpace: String,
-      clusterId: String,
-      clusterClient: ClusterClient[_]): String = {
-    ingressStrategy.getIngressUrl(nameSpace, clusterId, clusterClient)
+      clusterId: String
+  )(clusterClient: => ClusterClient[_]): String = {
+    ingressStrategy.getIngressUrl(nameSpace, clusterId)(clusterClient)
   }
 
   def prepareIngressTemplateFiles(buildWorkspace: String, ingressTemplates: String): String = {

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/ingress/IngressStrategy.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/ingress/IngressStrategy.scala
@@ -28,9 +28,12 @@ import java.io.File
 
 trait IngressStrategy {
 
+  val REST_SERVICE_IDENTIFICATION = "rest"
+
   lazy val ingressClass: String = InternalConfigHolder.get[String](K8sFlinkConfig.ingressClass)
 
-  def getIngressUrl(nameSpace: String, clusterId: String, clusterClient: ClusterClient[_]): String
+  def getIngressUrl(nameSpace: String, clusterId: String)(
+      clusterClient: => ClusterClient[_]): String
 
   def configureIngress(domainName: String, clusterId: String, nameSpace: String): Unit
 


### PR DESCRIPTION
Flink native k8s application task with INITIALIZING status .

1) k8s Ingress the Port Is Explicitly Specified At CreationTime .
2) lazy initialize DefaultKubernetesClient, compatible Flink K8s Application clusterIP Running Mode .