### PR TITLE
[Bug]Fix#3635 Check project name add team query condition

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ProjectServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ProjectServiceImpl.java
@@ -296,7 +296,9 @@ public class ProjectServiceImpl extends ServiceImpl<ProjectMapper, Project>
       }
     }
     LambdaQueryWrapper<Project> queryWrapper =
-        new LambdaQueryWrapper<Project>().eq(Project::getName, project.getName());
+        new LambdaQueryWrapper<Project>()
+            .eq(Project::getName, project.getName())
+            .eq(Project::getTeamId, project.getTeamId());
     return this.baseMapper.selectCount(queryWrapper) > 0;
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #3635 

## Brief change log
When create the same name project in diffrent team, it will lead to the project exists error, but the exists project only show in one of team.
The check query need to add team id condition.

## Verifying this change
Add the team id query condition to check name sql.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
