### PR TITLE
Fixed the issue that SSO could not jump when debugging the front-end …

### DIFF
--- a/streampark-console/streampark-console-webapp/.env.development
+++ b/streampark-console/streampark-console-webapp/.env.development
@@ -20,6 +20,8 @@ VITE_PUBLIC_PATH=/
 # Please note that no line breaks
 VITE_PROXY=[["/basic-api","http://localhost:10000"]]
 
+VITE_BASE_ADDRESS=http://localhost:10000
+
 # Delete console
 VITE_DROP_CONSOLE=false
 

--- a/streampark-console/streampark-console-webapp/src/views/base/login/LoginForm.vue
+++ b/streampark-console/streampark-console-webapp/src/views/base/login/LoginForm.vue
@@ -68,7 +68,7 @@
     </FormItem>
 
     <FormItem class="enter-x text-left">
-      <Button :href="SSO_LOGIN_PATH" type="link" v-if="enableSSO">
+      <Button :href="BASE_ADDRESS+SSO_LOGIN_PATH" type="link" v-if="enableSSO">
         {{ t('sys.login.ssoSignIn') }}
       </Button>
       <Button type="link" class="float-right" @click="changeLoginType" v-if="enableLDAP">
@@ -117,6 +117,7 @@
     account: string;
     password: string;
   }
+  const BASE_ADDRESS= import.meta.env.VITE_BASE_ADDRESS;
   const formRef = ref();
   const loading = ref(false);
   const userId = ref('');

--- a/streampark-console/streampark-console-webapp/types/global.d.ts
+++ b/streampark-console/streampark-console-webapp/types/global.d.ts
@@ -62,6 +62,7 @@ declare global {
     VITE_USE_PWA: boolean;
     VITE_PUBLIC_PATH: string;
     VITE_PROXY: [string, string][];
+    VITE_BASE_ADDRESS : string;
     VITE_GLOB_APP_TITLE: string;
     VITE_GLOB_APP_SHORT_NAME: string;
     VITE_USE_CDN: boolean;


### PR DESCRIPTION
修复sso在本地调试前后端分离时无法跳转

当前本地运行streampark时是前后端分离的形式，但sso登录按钮所携带的链接是相对路径/sso/signin,前端会访问localhost:10001/sso/signin并不会访问到后端localhost:10000/sso/signin所以会出现无法跳转到认证页面的现象。
![image](https://github.com/apache/incubator-streampark/assets/76773988/2d96cf5c-7cf0-486c-94fb-609779df5071)
我在配置文件中加入了BASE_ADDRESS变量指向后端地址与SSO_LOGIN_PATH拼接于是页面可以正确跳转到认证页面


Fixed the issue that SSO could not jump when debugging the front-end and backend separation locally

When StreamPark is run locally, it is in the form of front-end and back-end separation, but the link carried by the SSO login button is the relative path /sso/signin, and the front-end will access localhost:10001/sso/signin and will not access the back-end localhost:10000/sso/signin, so it will not be able to jump to the authentication page.

I added BASE_ADDRESS variable to the config file to point to the backend address and concatenate it with the SSO_LOGIN_PATH, so that the page can jump to the authentication page correctly



