### PR TITLE
[Feature-3754] Add Flink on Yarn per job mode and Flink on Yarn yarn application test cases

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,10 +109,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'adopt'
       - name: Cache local Maven repository
         uses: actions/cache@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,6 +97,12 @@ jobs:
             class: org.apache.streampark.e2e.cases.UserManagementTest
           - name: TeamManagementTest
             class: org.apache.streampark.e2e.cases.TeamManagementTest
+          - name: ApplicationsFlink116OnYarnTest
+            class: org.apache.streampark.e2e.cases.ApplicationsFlink116OnYarnTest
+          - name: ApplicationsFlink117OnYarnTest
+            class: org.apache.streampark.e2e.cases.ApplicationsFlink117OnYarnTest
+          - name: ApplicationsFlink118OnYarnTest
+            class: org.apache.streampark.e2e.cases.ApplicationsFlink118OnYarnTest
     env:
       RECORDING_PATH: /tmp/recording-${{ matrix.case.name }}
     steps:

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkAppHttpWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkAppHttpWatcher.java
@@ -243,10 +243,7 @@ public class FlinkAppHttpWatcher {
       processJobState(application, jobOptional);
     }
     log.debug(
-        "FlinkAppHttpWatcher getStateFromFlink, application: {}, jobsOverview: {}, jobOptional: {}",
-        application,
-        jobsOverview,
-        jobOptional);
+        "getStateFromFlink abnormal, application: {}, jobsOverview: {}", application, jobsOverview);
   }
 
   private void processJobState(Application application, Optional<JobsOverview.Job> jobOptional)

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkAppHttpWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkAppHttpWatcher.java
@@ -240,9 +240,13 @@ public class FlinkAppHttpWatcher {
     JobsOverview jobsOverview = httpJobsOverview(application);
     Optional<JobsOverview.Job> jobOptional = getJobsOverviewJob(application, jobsOverview);
     if (jobOptional.isPresent()) {
-
       processJobState(application, jobOptional);
     }
+    log.debug(
+        "FlinkAppHttpWatcher getStateFromFlink, application: {}, jobsOverview: {}, jobOptional: {}",
+        application,
+        jobsOverview,
+        jobOptional);
   }
 
   private void processJobState(Application application, Optional<JobsOverview.Job> jobOptional)
@@ -279,12 +283,16 @@ public class FlinkAppHttpWatcher {
     Optional<JobsOverview.Job> optional;
     FlinkExecutionMode execMode = application.getFlinkExecutionMode();
     if (FlinkExecutionMode.isYarnPerJobOrAppMode(execMode)) {
-      optional =
-          !jobsOverview.getJobs().isEmpty()
-              ? jobsOverview.getJobs().stream()
-                  .filter(a -> StringUtils.equals(application.getJobId(), a.getId()))
-                  .findFirst()
-              : Optional.empty();
+      if (jobsOverview.getJobs() != null) {
+        optional =
+            jobsOverview.getJobs().size() > 1
+                ? jobsOverview.getJobs().stream()
+                    .filter(a -> StringUtils.equals(application.getJobId(), a.getId()))
+                    .findFirst()
+                : jobsOverview.getJobs().stream().findFirst();
+      } else {
+        optional = Optional.empty();
+      }
     } else {
       optional =
           jobsOverview.getJobs().stream()

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink116OnYarnTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink116OnYarnTest.java
@@ -69,7 +69,7 @@ public class ApplicationsFlink116OnYarnTest {
 
     @Test
     @Order(10)
-    void testCreateFlinkApplication() {
+    void testCreateFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         ApplicationsDynamicParams applicationsDynamicParams = new ApplicationsDynamicParams();
@@ -114,7 +114,7 @@ public class ApplicationsFlink116OnYarnTest {
 
     @Test
     @Order(20)
-    void testReleaseFlinkApplication() {
+    void testReleaseFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.releaseApplication(applicationName);
@@ -127,7 +127,7 @@ public class ApplicationsFlink116OnYarnTest {
 
     @Test
     @Order(30)
-    void testStartFlinkApplication() {
+    void testStartFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.startApplication(applicationName);
@@ -146,7 +146,7 @@ public class ApplicationsFlink116OnYarnTest {
 
     @Test
     @Order(40)
-    void testDeleteFlinkApplication() {
+    void testDeleteFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.deleteApplication(applicationName);

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink116OnYarnTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink116OnYarnTest.java
@@ -218,24 +218,25 @@ public class ApplicationsFlink116OnYarnTest {
             .anyMatch(it -> it.contains("SUCCESS")));
     }
 
-    @Test
-    @Order(70)
-    void testStartFlinkApplicationOnYarnPerJobMode() {
-        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
-
-        applicationsPage.startApplication(applicationName);
-
-        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
-            .as("Applications list should contain started application")
-            .extracting(WebElement::getText)
-            .anyMatch(it -> it.contains("RUNNING")));
-
-        Awaitility.await()
-            .untilAsserted(() -> assertThat(applicationsPage.applicationsList())
-                .as("Applications list should contain finished application")
-                .extracting(WebElement::getText)
-                .anyMatch(it -> it.contains("FINISHED")));
-    }
+//    This test cannot be executed due to a bug, and will be put online after issue #3761 fixed
+//    @Test
+//    @Order(70)
+//    void testStartFlinkApplicationOnYarnPerJobMode() {
+//        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+//
+//        applicationsPage.startApplication(applicationName);
+//
+//        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+//            .as("Applications list should contain started application")
+//            .extracting(WebElement::getText)
+//            .anyMatch(it -> it.contains("RUNNING")));
+//
+//        Awaitility.await()
+//            .untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+//                .as("Applications list should contain finished application")
+//                .extracting(WebElement::getText)
+//                .anyMatch(it -> it.contains("FINISHED")));
+//    }
 
     @Test
     @Order(80)

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink116OnYarnTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink116OnYarnTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.cases;
+
+
+import org.apache.streampark.e2e.core.StreamPark;
+import org.apache.streampark.e2e.pages.LoginPage;
+import org.apache.streampark.e2e.pages.apacheflink.ApacheFlinkPage;
+import org.apache.streampark.e2e.pages.apacheflink.FlinkHomePage;
+import org.apache.streampark.e2e.pages.apacheflink.applications.ApplicationForm;
+import org.apache.streampark.e2e.pages.apacheflink.applications.ApplicationsPage;
+import org.apache.streampark.e2e.pages.apacheflink.applications.entity.ApplicationsDynamicParams;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@StreamPark(composeFiles = "docker/flink-1.16-on-yarn/docker-compose.yaml")
+public class ApplicationsFlink116OnYarnTest {
+    private static RemoteWebDriver browser;
+
+    private static final String userName = "admin";
+
+    private static final String password = "streampark";
+
+    private static final String teamName = "default";
+
+    private static final String flinkName = "flink-1.16.3";
+
+    private static final String flinkHome = "/flink-1.16.3";
+
+    private static final String applicationName = "flink-116-e2e-test";
+
+    @BeforeAll
+    public static void setup() {
+        FlinkHomePage flinkHomePage = new LoginPage(browser)
+            .login(userName, password, teamName)
+            .goToNav(ApacheFlinkPage.class)
+            .goToTab(FlinkHomePage.class);
+
+        flinkHomePage.createFlinkHome(flinkName, flinkHome, "");
+
+        flinkHomePage.goToNav(ApacheFlinkPage.class)
+            .goToTab(ApplicationsPage.class);
+    }
+
+    @Test
+    @Order(10)
+    void testCreateFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        ApplicationsDynamicParams applicationsDynamicParams = new ApplicationsDynamicParams();
+        String flinkSQL = "CREATE TABLE datagen (\n" +
+            "f_sequence INT,\n" +
+            "f_random INT,\n" +
+            "f_random_str STRING,\n" +
+            "ts AS localtimestamp,\n" +
+            "WATERMARK FOR ts AS ts\n" +
+            ") WITH (\n" +
+            "'connector' = 'datagen',\n" +
+            "'rows-per-second'='5',\n" +
+            "'fields.f_sequence.kind'='sequence',\n" +
+            "'fields.f_sequence.start'='1',\n" +
+            "'fields.f_sequence.end'='100',\n" +
+            "'fields.f_random.min'='1',\n" +
+            "'fields.f_random.max'='100',\n" +
+            "'fields.f_random_str.length'='10'\n" +
+            ");\n" +
+            "\n" +
+            "CREATE TABLE print_table (\n" +
+            "f_sequence INT,\n" +
+            "f_random INT,\n" +
+            "f_random_str STRING\n" +
+            ") WITH (\n" +
+            "'connector' = 'print'\n" +
+            ");\n" +
+            "\n" +
+            "INSERT INTO print_table select f_sequence,f_random,f_random_str from datagen;";
+        applicationsDynamicParams.flinkSQL(flinkSQL);
+        applicationsPage.createApplication().addApplication(ApplicationForm.DevelopmentMode.FLINK_SQL,
+            ApplicationForm.ExecutionMode.YARN_APPLICATION,
+            applicationName,
+            flinkName,
+            applicationsDynamicParams);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain newly-created application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains(applicationName)));
+    }
+
+    @Test
+    @Order(20)
+    void testReleaseFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.releaseApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain released application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("SUCCESS")));
+    }
+
+    @Test
+    @Order(30)
+    void testStartFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.startApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain started application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("RUNNING")));
+
+        Awaitility.await()
+            .untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain finished application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("FINISHED")));
+    }
+
+    @Test
+    @Order(40)
+    void testDeleteFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.deleteApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> {
+            browser.navigate().refresh();
+
+            assertThat(
+                applicationsPage.applicationsList()
+            ).noneMatch(
+                it -> it.getText().contains(applicationName)
+            );
+        });
+    }
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink116OnYarnTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink116OnYarnTest.java
@@ -34,8 +34,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
-import java.time.Duration;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 @StreamPark(composeFiles = "docker/flink-1.16-on-yarn/docker-compose.yaml")
@@ -147,6 +145,101 @@ public class ApplicationsFlink116OnYarnTest {
     @Test
     @Order(40)
     void testDeleteFlinkApplicationOnYarnApplicationMode() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.deleteApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> {
+            browser.navigate().refresh();
+
+            assertThat(
+                applicationsPage.applicationsList()
+            ).noneMatch(
+                it -> it.getText().contains(applicationName)
+            );
+        });
+    }
+
+    @Test
+    @Order(50)
+    void testCreateFlinkApplicationOnYarnPerJobMode() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        ApplicationsDynamicParams applicationsDynamicParams = new ApplicationsDynamicParams();
+        String flinkSQL = "CREATE TABLE datagen (\n" +
+            "f_sequence INT,\n" +
+            "f_random INT,\n" +
+            "f_random_str STRING,\n" +
+            "ts AS localtimestamp,\n" +
+            "WATERMARK FOR ts AS ts\n" +
+            ") WITH (\n" +
+            "'connector' = 'datagen',\n" +
+            "'rows-per-second'='5',\n" +
+            "'fields.f_sequence.kind'='sequence',\n" +
+            "'fields.f_sequence.start'='1',\n" +
+            "'fields.f_sequence.end'='100',\n" +
+            "'fields.f_random.min'='1',\n" +
+            "'fields.f_random.max'='100',\n" +
+            "'fields.f_random_str.length'='10'\n" +
+            ");\n" +
+            "\n" +
+            "CREATE TABLE print_table (\n" +
+            "f_sequence INT,\n" +
+            "f_random INT,\n" +
+            "f_random_str STRING\n" +
+            ") WITH (\n" +
+            "'connector' = 'print'\n" +
+            ");\n" +
+            "\n" +
+            "INSERT INTO print_table select f_sequence,f_random,f_random_str from datagen;";
+        applicationsDynamicParams.flinkSQL(flinkSQL);
+        applicationsPage.createApplication().addApplication(ApplicationForm.DevelopmentMode.FLINK_SQL,
+            ApplicationForm.ExecutionMode.YARN_PER_JOB,
+            applicationName,
+            flinkName,
+            applicationsDynamicParams);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain newly-created application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains(applicationName)));
+    }
+
+    @Test
+    @Order(60)
+    void testReleaseFlinkApplicationOnYarnPerJobMode() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.releaseApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain released application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("SUCCESS")));
+    }
+
+    @Test
+    @Order(70)
+    void testStartFlinkApplicationOnYarnPerJobMode() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.startApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain started application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("RUNNING")));
+
+        Awaitility.await()
+            .untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+                .as("Applications list should contain finished application")
+                .extracting(WebElement::getText)
+                .anyMatch(it -> it.contains("FINISHED")));
+    }
+
+    @Test
+    @Order(80)
+    void testDeleteFlinkApplicationOnYarnPerJobMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.deleteApplication(applicationName);

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink117OnYarnTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink117OnYarnTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.cases;
+
+
+import org.apache.streampark.e2e.core.StreamPark;
+import org.apache.streampark.e2e.pages.LoginPage;
+import org.apache.streampark.e2e.pages.apacheflink.ApacheFlinkPage;
+import org.apache.streampark.e2e.pages.apacheflink.FlinkHomePage;
+import org.apache.streampark.e2e.pages.apacheflink.applications.ApplicationForm;
+import org.apache.streampark.e2e.pages.apacheflink.applications.ApplicationsPage;
+import org.apache.streampark.e2e.pages.apacheflink.applications.entity.ApplicationsDynamicParams;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@StreamPark(composeFiles = "docker/flink-1.17-on-yarn/docker-compose.yaml")
+public class ApplicationsFlink117OnYarnTest {
+    private static RemoteWebDriver browser;
+
+    private static final String userName = "admin";
+
+    private static final String password = "streampark";
+
+    private static final String teamName = "default";
+
+    private static final String flinkName = "flink-1.17.2";
+
+    private static final String flinkHome = "/flink-1.17.2";
+
+    private static final String applicationName = "flink-117-e2e-test";
+
+    @BeforeAll
+    public static void setup() {
+        FlinkHomePage flinkHomePage = new LoginPage(browser)
+            .login(userName, password, teamName)
+            .goToNav(ApacheFlinkPage.class)
+            .goToTab(FlinkHomePage.class);
+
+        flinkHomePage.createFlinkHome(flinkName, flinkHome, "");
+
+        flinkHomePage.goToNav(ApacheFlinkPage.class)
+            .goToTab(ApplicationsPage.class);
+    }
+
+    @Test
+    @Order(10)
+    void testCreateFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        ApplicationsDynamicParams applicationsDynamicParams = new ApplicationsDynamicParams();
+        String flinkSQL = "CREATE TABLE datagen (\n" +
+            "f_sequence INT,\n" +
+            "f_random INT,\n" +
+            "f_random_str STRING,\n" +
+            "ts AS localtimestamp,\n" +
+            "WATERMARK FOR ts AS ts\n" +
+            ") WITH (\n" +
+            "'connector' = 'datagen',\n" +
+            "'rows-per-second'='5',\n" +
+            "'fields.f_sequence.kind'='sequence',\n" +
+            "'fields.f_sequence.start'='1',\n" +
+            "'fields.f_sequence.end'='100',\n" +
+            "'fields.f_random.min'='1',\n" +
+            "'fields.f_random.max'='100',\n" +
+            "'fields.f_random_str.length'='10'\n" +
+            ");\n" +
+            "\n" +
+            "CREATE TABLE print_table (\n" +
+            "f_sequence INT,\n" +
+            "f_random INT,\n" +
+            "f_random_str STRING\n" +
+            ") WITH (\n" +
+            "'connector' = 'print'\n" +
+            ");\n" +
+            "\n" +
+            "INSERT INTO print_table select f_sequence,f_random,f_random_str from datagen;";
+        applicationsDynamicParams.flinkSQL(flinkSQL);
+        applicationsPage.createApplication().addApplication(ApplicationForm.DevelopmentMode.FLINK_SQL,
+            ApplicationForm.ExecutionMode.YARN_APPLICATION,
+            applicationName,
+            flinkName,
+            applicationsDynamicParams);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain newly-created application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains(applicationName)));
+    }
+
+    @Test
+    @Order(20)
+    void testReleaseFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.releaseApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain released application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("SUCCESS")));
+    }
+
+    @Test
+    @Order(30)
+    void testStartFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.startApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain started application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("RUNNING")));
+
+        Awaitility.await()
+            .untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain finished application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("FINISHED")));
+    }
+
+    @Test
+    @Order(40)
+    void testDeleteFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.deleteApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> {
+            browser.navigate().refresh();
+
+            assertThat(
+                applicationsPage.applicationsList()
+            ).noneMatch(
+                it -> it.getText().contains(applicationName)
+            );
+        });
+    }
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink117OnYarnTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink117OnYarnTest.java
@@ -69,7 +69,7 @@ public class ApplicationsFlink117OnYarnTest {
 
     @Test
     @Order(10)
-    void testCreateFlinkApplication() {
+    void testCreateFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         ApplicationsDynamicParams applicationsDynamicParams = new ApplicationsDynamicParams();
@@ -114,7 +114,7 @@ public class ApplicationsFlink117OnYarnTest {
 
     @Test
     @Order(20)
-    void testReleaseFlinkApplication() {
+    void testReleaseFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.releaseApplication(applicationName);
@@ -127,7 +127,7 @@ public class ApplicationsFlink117OnYarnTest {
 
     @Test
     @Order(30)
-    void testStartFlinkApplication() {
+    void testStartFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.startApplication(applicationName);
@@ -146,7 +146,7 @@ public class ApplicationsFlink117OnYarnTest {
 
     @Test
     @Order(40)
-    void testDeleteFlinkApplication() {
+    void testDeleteFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.deleteApplication(applicationName);

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink117OnYarnTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink117OnYarnTest.java
@@ -218,24 +218,25 @@ public class ApplicationsFlink117OnYarnTest {
             .anyMatch(it -> it.contains("SUCCESS")));
     }
 
-    @Test
-    @Order(70)
-    void testStartFlinkApplicationOnYarnPerJobMode() {
-        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
-
-        applicationsPage.startApplication(applicationName);
-
-        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
-            .as("Applications list should contain started application")
-            .extracting(WebElement::getText)
-            .anyMatch(it -> it.contains("RUNNING")));
-
-        Awaitility.await()
-            .untilAsserted(() -> assertThat(applicationsPage.applicationsList())
-                .as("Applications list should contain finished application")
-                .extracting(WebElement::getText)
-                .anyMatch(it -> it.contains("FINISHED")));
-    }
+//    This test cannot be executed due to a bug, and will be put online after issue #3761 fixed
+//    @Test
+//    @Order(70)
+//    void testStartFlinkApplicationOnYarnPerJobMode() {
+//        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+//
+//        applicationsPage.startApplication(applicationName);
+//
+//        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+//            .as("Applications list should contain started application")
+//            .extracting(WebElement::getText)
+//            .anyMatch(it -> it.contains("RUNNING")));
+//
+//        Awaitility.await()
+//            .untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+//                .as("Applications list should contain finished application")
+//                .extracting(WebElement::getText)
+//                .anyMatch(it -> it.contains("FINISHED")));
+//    }
 
     @Test
     @Order(80)

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink118OnYarnTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink118OnYarnTest.java
@@ -20,6 +20,7 @@
 package org.apache.streampark.e2e.cases;
 
 
+import lombok.SneakyThrows;
 import org.apache.streampark.e2e.core.StreamPark;
 import org.apache.streampark.e2e.pages.LoginPage;
 import org.apache.streampark.e2e.pages.apacheflink.ApacheFlinkPage;
@@ -33,8 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
-
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -147,6 +146,101 @@ public class ApplicationsFlink118OnYarnTest {
     @Test
     @Order(40)
     void testDeleteFlinkApplicationOnYarnApplicationMode() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.deleteApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> {
+            browser.navigate().refresh();
+
+            assertThat(
+                applicationsPage.applicationsList()
+            ).noneMatch(
+                it -> it.getText().contains(applicationName)
+            );
+        });
+    }
+
+    @Test
+    @Order(50)
+    void testCreateFlinkApplicationOnYarnPerJobMode() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        ApplicationsDynamicParams applicationsDynamicParams = new ApplicationsDynamicParams();
+        String flinkSQL = "CREATE TABLE datagen (\n" +
+            "f_sequence INT,\n" +
+            "f_random INT,\n" +
+            "f_random_str STRING,\n" +
+            "ts AS localtimestamp,\n" +
+            "WATERMARK FOR ts AS ts\n" +
+            ") WITH (\n" +
+            "'connector' = 'datagen',\n" +
+            "'rows-per-second'='5',\n" +
+            "'fields.f_sequence.kind'='sequence',\n" +
+            "'fields.f_sequence.start'='1',\n" +
+            "'fields.f_sequence.end'='100',\n" +
+            "'fields.f_random.min'='1',\n" +
+            "'fields.f_random.max'='100',\n" +
+            "'fields.f_random_str.length'='10'\n" +
+            ");\n" +
+            "\n" +
+            "CREATE TABLE print_table (\n" +
+            "f_sequence INT,\n" +
+            "f_random INT,\n" +
+            "f_random_str STRING\n" +
+            ") WITH (\n" +
+            "'connector' = 'print'\n" +
+            ");\n" +
+            "\n" +
+            "INSERT INTO print_table select f_sequence,f_random,f_random_str from datagen;";
+        applicationsDynamicParams.flinkSQL(flinkSQL);
+        applicationsPage.createApplication().addApplication(ApplicationForm.DevelopmentMode.FLINK_SQL,
+            ApplicationForm.ExecutionMode.YARN_PER_JOB,
+            applicationName,
+            flinkName,
+            applicationsDynamicParams);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain newly-created application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains(applicationName)));
+    }
+
+    @Test
+    @Order(60)
+    void testReleaseFlinkApplicationOnYarnPerJobMode() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.releaseApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain released application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("SUCCESS")));
+    }
+
+    @Test
+    @Order(70)
+    void testStartFlinkApplicationOnYarnPerJobMode() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.startApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain started application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("RUNNING")));
+
+        Awaitility.await()
+            .untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+                .as("Applications list should contain finished application")
+                .extracting(WebElement::getText)
+                .anyMatch(it -> it.contains("FINISHED")));
+    }
+
+    @Test
+    @Order(80)
+    void testDeleteFlinkApplicationOnYarnPerJobMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.deleteApplication(applicationName);

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink118OnYarnTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink118OnYarnTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.cases;
+
+
+import org.apache.streampark.e2e.core.StreamPark;
+import org.apache.streampark.e2e.pages.LoginPage;
+import org.apache.streampark.e2e.pages.apacheflink.ApacheFlinkPage;
+import org.apache.streampark.e2e.pages.apacheflink.FlinkHomePage;
+import org.apache.streampark.e2e.pages.apacheflink.applications.ApplicationForm;
+import org.apache.streampark.e2e.pages.apacheflink.applications.ApplicationsPage;
+import org.apache.streampark.e2e.pages.apacheflink.applications.entity.ApplicationsDynamicParams;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@StreamPark(composeFiles = "docker/flink-1.18-on-yarn/docker-compose.yaml")
+public class ApplicationsFlink118OnYarnTest {
+    private static RemoteWebDriver browser;
+
+    private static final String userName = "admin";
+
+    private static final String password = "streampark";
+
+    private static final String teamName = "default";
+
+    private static final String flinkName = "flink-1.18.1";
+
+    private static final String flinkHome = "/flink-1.18.1";
+
+    private static final String applicationName = "flink-118-e2e-test";
+
+    @BeforeAll
+    public static void setup() {
+        FlinkHomePage flinkHomePage = new LoginPage(browser)
+            .login(userName, password, teamName)
+            .goToNav(ApacheFlinkPage.class)
+            .goToTab(FlinkHomePage.class);
+
+        flinkHomePage.createFlinkHome(flinkName, flinkHome, "");
+
+        flinkHomePage.goToNav(ApacheFlinkPage.class)
+            .goToTab(ApplicationsPage.class);
+    }
+
+    @Test
+    @Order(10)
+    void testCreateFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        ApplicationsDynamicParams applicationsDynamicParams = new ApplicationsDynamicParams();
+        String flinkSQL = "CREATE TABLE datagen (\n" +
+            "f_sequence INT,\n" +
+            "f_random INT,\n" +
+            "f_random_str STRING,\n" +
+            "ts AS localtimestamp,\n" +
+            "WATERMARK FOR ts AS ts\n" +
+            ") WITH (\n" +
+            "'connector' = 'datagen',\n" +
+            "'rows-per-second'='5',\n" +
+            "'fields.f_sequence.kind'='sequence',\n" +
+            "'fields.f_sequence.start'='1',\n" +
+            "'fields.f_sequence.end'='100',\n" +
+            "'fields.f_random.min'='1',\n" +
+            "'fields.f_random.max'='100',\n" +
+            "'fields.f_random_str.length'='10'\n" +
+            ");\n" +
+            "\n" +
+            "CREATE TABLE print_table (\n" +
+            "f_sequence INT,\n" +
+            "f_random INT,\n" +
+            "f_random_str STRING\n" +
+            ") WITH (\n" +
+            "'connector' = 'print'\n" +
+            ");\n" +
+            "\n" +
+            "INSERT INTO print_table select f_sequence,f_random,f_random_str from datagen;";
+        applicationsDynamicParams.flinkSQL(flinkSQL);
+        applicationsPage.createApplication().addApplication(ApplicationForm.DevelopmentMode.FLINK_SQL,
+            ApplicationForm.ExecutionMode.YARN_APPLICATION,
+            applicationName,
+            flinkName,
+            applicationsDynamicParams);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain newly-created application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains(applicationName)));
+    }
+
+    @Test
+    @Order(20)
+    void testReleaseFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.releaseApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain released application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("SUCCESS")));
+    }
+
+    @Test
+    @Order(30)
+    void testStartFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.startApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain started application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("RUNNING")));
+
+        Awaitility.await()
+            .untilAsserted(() -> assertThat(applicationsPage.applicationsList())
+            .as("Applications list should contain finished application")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains("FINISHED")));
+    }
+
+    @Test
+    @Order(40)
+    void testDeleteFlinkApplication() {
+        final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
+
+        applicationsPage.deleteApplication(applicationName);
+
+        Awaitility.await().untilAsserted(() -> {
+            browser.navigate().refresh();
+
+            assertThat(
+                applicationsPage.applicationsList()
+            ).noneMatch(
+                it -> it.getText().contains(applicationName)
+            );
+        });
+    }
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink118OnYarnTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ApplicationsFlink118OnYarnTest.java
@@ -69,7 +69,7 @@ public class ApplicationsFlink118OnYarnTest {
 
     @Test
     @Order(10)
-    void testCreateFlinkApplication() {
+    void testCreateFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         ApplicationsDynamicParams applicationsDynamicParams = new ApplicationsDynamicParams();
@@ -114,7 +114,7 @@ public class ApplicationsFlink118OnYarnTest {
 
     @Test
     @Order(20)
-    void testReleaseFlinkApplication() {
+    void testReleaseFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.releaseApplication(applicationName);
@@ -127,7 +127,7 @@ public class ApplicationsFlink118OnYarnTest {
 
     @Test
     @Order(30)
-    void testStartFlinkApplication() {
+    void testStartFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.startApplication(applicationName);
@@ -146,7 +146,7 @@ public class ApplicationsFlink118OnYarnTest {
 
     @Test
     @Order(40)
-    void testDeleteFlinkApplication() {
+    void testDeleteFlinkApplicationOnYarnApplicationMode() {
         final ApplicationsPage applicationsPage = new ApplicationsPage(browser);
 
         applicationsPage.deleteApplication(applicationName);

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/FlinkHomeTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/FlinkHomeTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.cases;
+
+import org.apache.streampark.e2e.core.StreamPark;
+import org.apache.streampark.e2e.pages.LoginPage;
+import org.apache.streampark.e2e.pages.apacheflink.ApacheFlinkPage;
+import org.apache.streampark.e2e.pages.apacheflink.FlinkHomePage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@StreamPark(composeFiles = "docker/flink-1.18-on-yarn/docker-compose.yaml")
+public class FlinkHomeTest {
+    private static RemoteWebDriver browser;
+
+    private static final String userName = "admin";
+
+    private static final String password = "streampark";
+
+    private static final String teamName = "default";
+
+    private static final String flinkName = "flink-1.18.1";
+
+    private static final String flinkHome = "/flink-1.18.1";
+
+    private static final String flinkDescription = "description test";
+
+    private static final String newFlinkHome = "flink_1.18.1";
+
+    @BeforeAll
+    public static void setup() {
+        new LoginPage(browser)
+            .login(userName, password, teamName)
+            .goToNav(ApacheFlinkPage.class)
+            .goToTab(FlinkHomePage.class);
+    }
+
+    @Test
+    @Order(10)
+    void testCreateFlinkHome() {
+        final FlinkHomePage flinkHomePage = new FlinkHomePage(browser);
+        flinkHomePage.createFlinkHome(flinkName, flinkHome, flinkDescription);
+
+        Awaitility.await().untilAsserted(() -> assertThat(flinkHomePage.flinkHomeList())
+            .as("Flink Home list should contain newly-created flink home")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains(flinkName)));
+    }
+
+    @Test
+    @Order(20)
+    void testEditFlinkHome() {
+        final FlinkHomePage flinkHomePage = new FlinkHomePage(browser);
+        flinkHomePage.editFlinkHome(flinkName, newFlinkHome);
+
+        Awaitility.await().untilAsserted(() -> assertThat(flinkHomePage.flinkHomeList())
+            .as("Flink Home list should contain edited flink home")
+            .extracting(WebElement::getText)
+            .anyMatch(it -> it.contains(newFlinkHome)));
+    }
+
+    @Test
+    @Order(30)
+    void testDeleteFlinkHome() {
+        final FlinkHomePage flinkHomePage = new FlinkHomePage(browser);
+        flinkHomePage.deleteFlinkHome(newFlinkHome);
+
+        Awaitility.await().untilAsserted(() -> {
+            browser.navigate().refresh();
+
+            assertThat(
+                flinkHomePage.flinkHomeList()
+            ).noneMatch(
+                it -> it.getText().contains(newFlinkHome)
+            );
+        });
+    }
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/ApacheFlinkPage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/ApacheFlinkPage.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.pages.apacheflink;
+
+import lombok.Getter;
+import org.apache.streampark.e2e.pages.common.NavBarPage;
+import org.apache.streampark.e2e.pages.common.NavBarPage.NavBarItem;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+
+@Getter
+public final class ApacheFlinkPage extends NavBarPage implements NavBarItem {
+    @FindBy(xpath = "//span[contains(@class, 'streampark-simple-menu-sub-title') and contains(text(), 'Applications')]//..")
+    private WebElement menuApplications;
+
+    @FindBy(xpath = "//span[contains(@class, 'streampark-simple-menu-sub-title') and contains(text(), 'Flink Home')]//..")
+    private WebElement menuFlinkHome;
+
+    @FindBy(xpath = "//span[contains(@class, 'streampark-simple-menu-sub-title') and contains(text(), 'Clusters')]//..")
+    private WebElement menuClusters;
+
+
+    public ApacheFlinkPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    public <T extends ApacheFlinkPage.Tab> T goToTab(Class<T> tab) {
+        if (tab == ApplicationsPage.class) {
+            new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(menuApplications));
+            menuApplications.click();
+            return tab.cast(new ApplicationsPage(driver));
+        }
+
+        if (tab == FlinkHomePage.class) {
+            new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(menuFlinkHome));
+            menuFlinkHome.click();
+            return tab.cast(new FlinkHomePage(driver));
+        }
+
+        throw new UnsupportedOperationException("Unknown tab: " + tab.getName());
+    }
+
+    public interface Tab {
+    }
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/ApacheFlinkPage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/ApacheFlinkPage.java
@@ -20,6 +20,7 @@
 package org.apache.streampark.e2e.pages.apacheflink;
 
 import lombok.Getter;
+import org.apache.streampark.e2e.pages.apacheflink.applications.ApplicationsPage;
 import org.apache.streampark.e2e.pages.common.NavBarPage;
 import org.apache.streampark.e2e.pages.common.NavBarPage.NavBarItem;
 import org.openqa.selenium.WebElement;

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/ApplicationsPage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/ApplicationsPage.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.pages.apacheflink;
+
+import lombok.Getter;
+import org.apache.streampark.e2e.pages.common.NavBarPage;
+import org.apache.streampark.e2e.pages.system.SystemPage;
+import org.apache.streampark.e2e.pages.system.entity.UserManagementStatus;
+import org.apache.streampark.e2e.pages.system.entity.UserManagementUserType;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.FindBys;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+import java.util.List;
+
+@Getter
+public class ApplicationsPage extends NavBarPage implements ApacheFlinkPage.Tab {
+    @FindBy(xpath = "//span[contains(., 'User List')]/..//button[contains(@class, 'ant-btn-primary')]/span[contains(text(), 'Add New')]")
+    private WebElement buttonCreateUser;
+
+    @FindBy(xpath = "//tbody[contains(@class, 'ant-table-tbody')]")
+    private List<WebElement> userList;
+
+    @FindBy(className = "ant-form-item-explain-error")
+    private List<WebElement> errorMessageList;
+
+    private final CreateUserForm createUserForm = new CreateUserForm();
+
+    public ApplicationsPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    public ApplicationsPage createUser(String userName, String nickName, String password, String email, UserManagementUserType userManagementUserType) {
+        waitForPageLoading();
+
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(buttonCreateUser));
+        buttonCreateUser.click();
+        createUserForm.inputUserName().sendKeys(userName);
+        createUserForm.inputNickName().sendKeys(nickName);
+        createUserForm.inputPassword().sendKeys(password);
+        createUserForm.inputEmail().sendKeys(email);
+
+        createUserForm.btnSelectUserTypeDropdown().click();
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElements(createUserForm.selectUserType));
+        createUserForm.selectUserType
+            .stream()
+            .filter(e -> e.getText().equalsIgnoreCase(String.valueOf(userManagementUserType)))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException(String.format("No %s in userType dropdown list", userManagementUserType)))
+            .click();
+
+        createUserForm.buttonSubmit().click();
+        return this;
+    }
+
+    public ApplicationsPage editUser(String userName, String email, UserManagementUserType userManagementUserType, UserManagementStatus userManagementStatus) {
+        waitForPageLoading();
+
+        userList()
+            .stream()
+            .filter(it -> it.getText().contains(userName))
+            .flatMap(it -> it.findElements(By.xpath("//button[contains(@tooltip,'modify user')]")).stream())
+            .filter(WebElement::isDisplayed)
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("No edit button in user list"))
+            .click();
+
+        createUserForm.inputEmail().sendKeys(Keys.CONTROL+"a");
+        createUserForm.inputEmail().sendKeys(Keys.BACK_SPACE);
+        createUserForm.inputEmail().sendKeys(email);
+
+        createUserForm.btnSelectUserTypeDropdown().click();
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElements(createUserForm.selectUserType));
+        createUserForm.selectUserType
+            .stream()
+            .filter(e -> e.getText().equalsIgnoreCase(String.valueOf(userManagementUserType)))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException(String.format("No %s in userType dropdown list", userManagementUserType)))
+            .click();
+
+        switch (userManagementStatus) {
+            case LOCKED:
+                createUserForm.radioLocked.click();
+                break;
+            case EFFECTIVE:
+                createUserForm.radioEffective.click();
+                break;
+            default:
+                throw new RuntimeException("Unknown user management status");
+        }
+
+        createUserForm.buttonSubmit().click();
+
+        return this;
+    }
+
+    private void waitForPageLoading() {
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.urlContains("/system/user"));
+    }
+
+    @Getter
+    public class CreateUserForm {
+        CreateUserForm() {
+            PageFactory.initElements(driver, this);
+        }
+
+        @FindBy(id = "formUserName")
+        private WebElement inputUserName;
+
+        @FindBy(id = "form_item_nickName")
+        private WebElement inputNickName;
+
+        @FindBy(id = "form_item_password")
+        private WebElement inputPassword;
+
+        @FindBy(id = "form_item_email")
+        private WebElement inputEmail;
+
+        @FindBys({
+            @FindBy(css = "[codefield=userType]"),
+            @FindBy(className = "ant-select-item-option-content")
+        })
+        private List<WebElement> selectUserType;
+
+        @FindBy(css = "[codefield=userType] > .ant-select-selector")
+        private WebElement btnSelectUserTypeDropdown;
+
+        @FindBy(xpath = "//label[contains(@class, 'ant-radio-wrapper')]/span[contains(., 'lock')]")
+        private WebElement radioLocked;
+
+        @FindBy(xpath = "//label[contains(@class, 'ant-radio-wrapper')]/span[contains(., 'effective')]")
+        private WebElement radioEffective;
+
+        @FindBy(xpath = "//button[contains(@class, 'ant-btn')]//span[contains(text(), 'Submit')]")
+        private WebElement buttonSubmit;
+
+        @FindBy(xpath = "//button[contains(@class, 'ant-btn')]//span[contains(text(), 'Cancel')]")
+        private WebElement buttonCancel;
+    }
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/FlinkHomePage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/FlinkHomePage.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.pages.apacheflink;
+
+import lombok.Getter;
+import org.apache.streampark.e2e.pages.common.NavBarPage;
+import org.apache.streampark.e2e.pages.system.entity.UserManagementStatus;
+import org.apache.streampark.e2e.pages.system.entity.UserManagementUserType;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.FindBys;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+import java.util.List;
+
+@Getter
+public class FlinkHomePage extends NavBarPage implements ApacheFlinkPage.Tab {
+    @FindBy(xpath = "//span[contains(., 'Flink Home')]/..//button[contains(@class, 'ant-btn')]/span[contains(text(), 'Add New')]")
+    private WebElement buttonCreateUser;
+
+    @FindBy(xpath = "//tbody[contains(@class, 'ant-table-tbody')]")
+    private List<WebElement> userList;
+
+    @FindBy(className = "ant-form-item-explain-error")
+    private List<WebElement> errorMessageList;
+
+    private final CreateFlinkHomeForm createFlinkHomeForm = new CreateFlinkHomeForm();
+
+    public FlinkHomePage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    public FlinkHomePage createUser(String userName, String nickName, String password, String email, UserManagementUserType userManagementUserType) {
+        waitForPageLoading();
+
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(buttonCreateUser));
+        buttonCreateUser.click();
+        createFlinkHomeForm.inputUserName().sendKeys(userName);
+        createFlinkHomeForm.inputNickName().sendKeys(nickName);
+        createFlinkHomeForm.inputPassword().sendKeys(password);
+        createFlinkHomeForm.inputEmail().sendKeys(email);
+
+        createFlinkHomeForm.btnSelectUserTypeDropdown().click();
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElements(createFlinkHomeForm.selectUserType));
+        createFlinkHomeForm.selectUserType
+            .stream()
+            .filter(e -> e.getText().equalsIgnoreCase(String.valueOf(userManagementUserType)))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException(String.format("No %s in userType dropdown list", userManagementUserType)))
+            .click();
+
+        createFlinkHomeForm.buttonSubmit().click();
+        return this;
+    }
+
+    public FlinkHomePage editUser(String userName, String email, UserManagementUserType userManagementUserType, UserManagementStatus userManagementStatus) {
+        waitForPageLoading();
+
+        userList()
+            .stream()
+            .filter(it -> it.getText().contains(userName))
+            .flatMap(it -> it.findElements(By.xpath("//button[contains(@tooltip,'modify user')]")).stream())
+            .filter(WebElement::isDisplayed)
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("No edit button in user list"))
+            .click();
+
+        createFlinkHomeForm.inputEmail().sendKeys(Keys.CONTROL+"a");
+        createFlinkHomeForm.inputEmail().sendKeys(Keys.BACK_SPACE);
+        createFlinkHomeForm.inputEmail().sendKeys(email);
+
+        createFlinkHomeForm.btnSelectUserTypeDropdown().click();
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElements(createFlinkHomeForm.selectUserType));
+        createFlinkHomeForm.selectUserType
+            .stream()
+            .filter(e -> e.getText().equalsIgnoreCase(String.valueOf(userManagementUserType)))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException(String.format("No %s in userType dropdown list", userManagementUserType)))
+            .click();
+
+        switch (userManagementStatus) {
+            case LOCKED:
+                createFlinkHomeForm.radioLocked.click();
+                break;
+            case EFFECTIVE:
+                createFlinkHomeForm.radioEffective.click();
+                break;
+            default:
+                throw new RuntimeException("Unknown user management status");
+        }
+
+        createFlinkHomeForm.buttonSubmit().click();
+
+        return this;
+    }
+
+    private void waitForPageLoading() {
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.urlContains("/system/user"));
+    }
+
+    @Getter
+    public class CreateFlinkHomeForm {
+        CreateFlinkHomeForm() {
+            PageFactory.initElements(driver, this);
+        }
+
+        @FindBy(id = "form_item_flinkName")
+        private WebElement inputFlinkName;
+
+        @FindBy(id = "form_item_flinkHome")
+        private WebElement inputFlinkHome;
+
+        @FindBy(id = "form_item_description")
+        private WebElement inputDescription;
+
+        @FindBy(xpath = "//button[contains(@class, 'ant-btn')]//span[contains(text(), 'OK')]")
+        private WebElement buttonSubmit;
+
+        @FindBy(xpath = "//button[contains(@class, 'ant-btn')]//span[contains(text(), 'Cancel')]")
+        private WebElement buttonCancel;
+    }
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/FlinkHomePage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/FlinkHomePage.java
@@ -28,7 +28,6 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.FindBys;
 import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -39,13 +38,13 @@ import java.util.List;
 @Getter
 public class FlinkHomePage extends NavBarPage implements ApacheFlinkPage.Tab {
     @FindBy(xpath = "//span[contains(., 'Flink Home')]/..//button[contains(@class, 'ant-btn')]/span[contains(text(), 'Add New')]")
-    private WebElement buttonCreateUser;
+    private WebElement buttonCreateFlinkHome;
 
-    @FindBy(xpath = "//tbody[contains(@class, 'ant-table-tbody')]")
-    private List<WebElement> userList;
+    @FindBy(xpath = "//div[contains(@class, 'ant-spin-container')]")
+    private List<WebElement> flinkHomeList;
 
-    @FindBy(className = "ant-form-item-explain-error")
-    private List<WebElement> errorMessageList;
+    @FindBy(xpath = "//button[contains(@class, 'ant-btn')]/span[contains(., 'Yes')]")
+    private WebElement deleteConfirmButton;
 
     private final CreateFlinkHomeForm createFlinkHomeForm = new CreateFlinkHomeForm();
 
@@ -53,72 +52,58 @@ public class FlinkHomePage extends NavBarPage implements ApacheFlinkPage.Tab {
         super(driver);
     }
 
-    public FlinkHomePage createUser(String userName, String nickName, String password, String email, UserManagementUserType userManagementUserType) {
+    public FlinkHomePage createFlinkHome(String flinkName, String flinkHome, String description) {
         waitForPageLoading();
 
-        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(buttonCreateUser));
-        buttonCreateUser.click();
-        createFlinkHomeForm.inputUserName().sendKeys(userName);
-        createFlinkHomeForm.inputNickName().sendKeys(nickName);
-        createFlinkHomeForm.inputPassword().sendKeys(password);
-        createFlinkHomeForm.inputEmail().sendKeys(email);
-
-        createFlinkHomeForm.btnSelectUserTypeDropdown().click();
-        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElements(createFlinkHomeForm.selectUserType));
-        createFlinkHomeForm.selectUserType
-            .stream()
-            .filter(e -> e.getText().equalsIgnoreCase(String.valueOf(userManagementUserType)))
-            .findFirst()
-            .orElseThrow(() -> new RuntimeException(String.format("No %s in userType dropdown list", userManagementUserType)))
-            .click();
-
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(buttonCreateFlinkHome));
+        buttonCreateFlinkHome.click();
+        createFlinkHomeForm.inputFlinkName().sendKeys(flinkName);
+        createFlinkHomeForm.inputFlinkHome().sendKeys(flinkHome);
+        createFlinkHomeForm.inputDescription().sendKeys(description);
         createFlinkHomeForm.buttonSubmit().click();
+
         return this;
     }
 
-    public FlinkHomePage editUser(String userName, String email, UserManagementUserType userManagementUserType, UserManagementStatus userManagementStatus) {
+    public FlinkHomePage editFlinkHome(String oldFlinkName, String newFlinkName) {
         waitForPageLoading();
 
-        userList()
+        flinkHomeList()
             .stream()
-            .filter(it -> it.getText().contains(userName))
-            .flatMap(it -> it.findElements(By.xpath("//button[contains(@tooltip,'modify user')]")).stream())
+            .filter(it -> it.getText().contains(oldFlinkName))
+            .flatMap(it -> it.findElements(By.xpath("//button[contains(@class,'ant-btn')]/span[contains(@aria-label,'edit')]")).stream())
             .filter(WebElement::isDisplayed)
             .findFirst()
-            .orElseThrow(() -> new RuntimeException("No edit button in user list"))
+            .orElseThrow(() -> new RuntimeException("No edit button in flink home list"))
             .click();
 
-        createFlinkHomeForm.inputEmail().sendKeys(Keys.CONTROL+"a");
-        createFlinkHomeForm.inputEmail().sendKeys(Keys.BACK_SPACE);
-        createFlinkHomeForm.inputEmail().sendKeys(email);
-
-        createFlinkHomeForm.btnSelectUserTypeDropdown().click();
-        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElements(createFlinkHomeForm.selectUserType));
-        createFlinkHomeForm.selectUserType
-            .stream()
-            .filter(e -> e.getText().equalsIgnoreCase(String.valueOf(userManagementUserType)))
-            .findFirst()
-            .orElseThrow(() -> new RuntimeException(String.format("No %s in userType dropdown list", userManagementUserType)))
-            .click();
-
-        switch (userManagementStatus) {
-            case LOCKED:
-                createFlinkHomeForm.radioLocked.click();
-                break;
-            case EFFECTIVE:
-                createFlinkHomeForm.radioEffective.click();
-                break;
-            default:
-                throw new RuntimeException("Unknown user management status");
-        }
-
+        createFlinkHomeForm.inputFlinkName().sendKeys(Keys.CONTROL+"a");
+        createFlinkHomeForm.inputFlinkName().sendKeys(Keys.BACK_SPACE);
+        createFlinkHomeForm.inputFlinkName().sendKeys(newFlinkName);
         createFlinkHomeForm.buttonSubmit().click();
+
+        return this;
+    }
+
+    public FlinkHomePage deleteFlinkHome(String flinkName) {
+        waitForPageLoading();
+
+        flinkHomeList()
+                .stream()
+                .filter(it -> it.getText().contains(flinkName))
+                .flatMap(it -> it.findElements(By.xpath("//button[contains(@class,'ant-btn')]/span[contains(@aria-label,'delete')]")).stream())
+                .filter(WebElement::isDisplayed)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("No delete button in flink home list"))
+                .click();
+
+        deleteConfirmButton.click();
 
         return this;
     }
 
     private void waitForPageLoading() {
-        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.urlContains("/system/user"));
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.urlContains("/flink/home"));
     }
 
     @Getter

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/FlinkHomePage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/FlinkHomePage.java
@@ -62,6 +62,7 @@ public class FlinkHomePage extends NavBarPage implements ApacheFlinkPage.Tab {
         createFlinkHomeForm.inputDescription().sendKeys(description);
         createFlinkHomeForm.buttonSubmit().click();
 
+        waitForClickFinish();
         return this;
     }
 
@@ -82,6 +83,7 @@ public class FlinkHomePage extends NavBarPage implements ApacheFlinkPage.Tab {
         createFlinkHomeForm.inputFlinkName().sendKeys(newFlinkName);
         createFlinkHomeForm.buttonSubmit().click();
 
+        waitForClickFinish();
         return this;
     }
 
@@ -99,11 +101,16 @@ public class FlinkHomePage extends NavBarPage implements ApacheFlinkPage.Tab {
 
         deleteConfirmButton.click();
 
+        waitForClickFinish();
         return this;
     }
 
     private void waitForPageLoading() {
         new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.urlContains("/flink/home"));
+    }
+
+    private void waitForClickFinish() {
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(buttonCreateFlinkHome));
     }
 
     @Getter

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/ApplicationForm.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/ApplicationForm.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.pages.apacheflink.applications;
+
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.FindBys;
+import org.openqa.selenium.support.PageFactory;
+
+import java.util.List;
+
+
+@Getter
+public final class ApplicationForm {
+    private WebDriver driver;
+
+    @FindBy(xpath = "//div[contains(@codefield, 'jobType')]//div[contains(@class, 'ant-select-selector')]")
+    private WebElement buttonDevelopmentModeDropdown;
+
+    @FindBys({
+        @FindBy(css = "[codefield=jobType]"),
+        @FindBy(className = "ant-select-item-option-content")
+    })
+    private List<WebElement> selectDevelopmentMode;
+
+    @FindBy(xpath = "//div[contains(@codefield, 'executionMode')]//div[contains(@class, 'ant-select-selector')]")
+    private WebElement buttonExecutionModeDropdown;
+
+    @FindBys({
+        @FindBy(css = "[codefield=executionMode]"),
+        @FindBy(className = "ant-select-item-option-content")
+    })
+    private List<WebElement> selectExecutionMode;
+
+    @FindBy(id = "form_item_jobName")
+    private WebElement inputApplicationName;
+
+    @FindBy(xpath = "//button[contains(@class, 'ant-btn')]//span[contains(text(), 'Submit')]")
+    private WebElement buttonSubmit;
+
+    @FindBy(xpath = "//button[contains(@class, 'ant-btn')]//span[contains(text(), 'Cancel')]")
+    private WebElement buttonCancel;
+
+    public ApplicationForm(WebDriver driver) {
+        this.driver = driver;
+
+        PageFactory.initElements(driver, this);
+    }
+
+    @SneakyThrows
+    public ApplicationForm addApplication(DevelopmentMode developmentMode, ExecutionMode executionMode, String applicationName) {
+        return this;
+    }
+
+    public enum DevelopmentMode {
+        CUSTOM_CODE,
+        FLINK_SQL,
+        PYTHON_FLINK
+    }
+
+    public enum ExecutionMode {
+        REMOTE,
+        YARN_APPLICATION,
+        YARN_SESSION,
+        KUBERNETES_SESSION,
+        KUBERNETES_APPLICATION,
+        YARN_PER_JOB
+    }
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/ApplicationForm.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/ApplicationForm.java
@@ -19,10 +19,10 @@
  */
 package org.apache.streampark.e2e.pages.apacheflink.applications;
 
-import lombok.Data;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.streampark.e2e.pages.apacheflink.applications.entity.ApplicationsDynamicParams;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -78,6 +78,7 @@ public final class ApplicationForm {
                                           String applicationName,
                                           String flinkVersion,
                                           ApplicationsDynamicParams applicationsDynamicParams) {
+        Thread.sleep(1000);
         new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(buttonDevelopmentModeDropdown));
         buttonDevelopmentModeDropdown.click();
         new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElements(selectDevelopmentMode));
@@ -113,7 +114,7 @@ public final class ApplicationForm {
                             )
                             .click();
                         new FlinkSQLYarnApplicationForm(driver)
-                            .addYarnApplication(flinkVersion, applicationsDynamicParams.flinkSQL());
+                            .add(flinkVersion, applicationsDynamicParams.flinkSQL());
                         break;
                     case YARN_SESSION:
                         selectExecutionMode.stream()
@@ -146,6 +147,8 @@ public final class ApplicationForm {
                             .orElseThrow(() -> new IllegalArgumentException(String.format("Execution mode not found: %s", executionMode.desc()))
                             )
                             .click();
+                        new FlinkSQLYarnApplicationForm(driver)
+                            .add(flinkVersion, applicationsDynamicParams.flinkSQL());
                         break;
                     default:
                         throw new IllegalArgumentException(String.format("Unknown execution mode: %s", executionMode.desc()));

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/ApplicationsPage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/ApplicationsPage.java
@@ -17,11 +17,11 @@
  * under the License.
  *
  */
-package org.apache.streampark.e2e.pages.apacheflink;
+package org.apache.streampark.e2e.pages.apacheflink.applications;
 
 import lombok.Getter;
+import org.apache.streampark.e2e.pages.apacheflink.ApacheFlinkPage;
 import org.apache.streampark.e2e.pages.common.NavBarPage;
-import org.apache.streampark.e2e.pages.system.SystemPage;
 import org.apache.streampark.e2e.pages.system.entity.UserManagementStatus;
 import org.apache.streampark.e2e.pages.system.entity.UserManagementUserType;
 import org.openqa.selenium.By;
@@ -39,11 +39,11 @@ import java.util.List;
 
 @Getter
 public class ApplicationsPage extends NavBarPage implements ApacheFlinkPage.Tab {
-    @FindBy(xpath = "//span[contains(., 'User List')]/..//button[contains(@class, 'ant-btn-primary')]/span[contains(text(), 'Add New')]")
-    private WebElement buttonCreateUser;
+    @FindBy(xpath = "//div[contains(@class, 'app_list')]//button[contains(@class, 'ant-btn-primary')]/span[contains(text(), 'Add New')]")
+    private WebElement buttonCreateApplication;
 
     @FindBy(xpath = "//tbody[contains(@class, 'ant-table-tbody')]")
-    private List<WebElement> userList;
+    private List<WebElement> applicationsList;
 
     @FindBy(className = "ant-form-item-explain-error")
     private List<WebElement> errorMessageList;
@@ -54,33 +54,18 @@ public class ApplicationsPage extends NavBarPage implements ApacheFlinkPage.Tab 
         super(driver);
     }
 
-    public ApplicationsPage createUser(String userName, String nickName, String password, String email, UserManagementUserType userManagementUserType) {
+    public ApplicationForm createApplication() {
         waitForPageLoading();
 
-        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(buttonCreateUser));
-        buttonCreateUser.click();
-        createUserForm.inputUserName().sendKeys(userName);
-        createUserForm.inputNickName().sendKeys(nickName);
-        createUserForm.inputPassword().sendKeys(password);
-        createUserForm.inputEmail().sendKeys(email);
+        buttonCreateApplication.click();
 
-        createUserForm.btnSelectUserTypeDropdown().click();
-        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElements(createUserForm.selectUserType));
-        createUserForm.selectUserType
-            .stream()
-            .filter(e -> e.getText().equalsIgnoreCase(String.valueOf(userManagementUserType)))
-            .findFirst()
-            .orElseThrow(() -> new RuntimeException(String.format("No %s in userType dropdown list", userManagementUserType)))
-            .click();
-
-        createUserForm.buttonSubmit().click();
-        return this;
+        return new ApplicationForm(driver);
     }
 
     public ApplicationsPage editUser(String userName, String email, UserManagementUserType userManagementUserType, UserManagementStatus userManagementStatus) {
         waitForPageLoading();
 
-        userList()
+        applicationsList()
             .stream()
             .filter(it -> it.getText().contains(userName))
             .flatMap(it -> it.findElements(By.xpath("//button[contains(@tooltip,'modify user')]")).stream())
@@ -119,7 +104,7 @@ public class ApplicationsPage extends NavBarPage implements ApacheFlinkPage.Tab 
     }
 
     private void waitForPageLoading() {
-        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.urlContains("/system/user"));
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.urlContains("/flink/app"));
     }
 
     @Getter

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/FlinkSQLEditor.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/FlinkSQLEditor.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.pages.apacheflink.applications;
+
+import lombok.Getter;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+
+@Getter
+public final class FlinkSQLEditor {
+    @FindBy(xpath = "//label[contains(@for, 'form_item_flinkSql')]/../..//div[contains(@class, 'monaco-editor')]//div[contains(@class, 'view-line')]")
+    private WebElement flinkSqlEditor;
+
+    private WebDriver driver;
+
+    public FlinkSQLEditor(WebDriver driver) {
+        PageFactory.initElements(driver, this);
+        this.driver = driver;
+    }
+
+    public FlinkSQLEditor content(String content) {
+        new WebDriverWait(this.driver, Duration.ofSeconds(20)).until(ExpectedConditions.elementToBeClickable(flinkSqlEditor));
+
+        flinkSqlEditor.click();
+
+        Actions actions = new Actions(this.driver);
+        actions.moveToElement(flinkSqlEditor).sendKeys(content).perform();
+
+        return this;
+    }
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/FlinkSQLYarnApplicationForm.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/FlinkSQLYarnApplicationForm.java
@@ -52,7 +52,7 @@ public final class FlinkSQLYarnApplicationForm {
     }
 
     @SneakyThrows
-    public FlinkSQLYarnApplicationForm addYarnApplication(String flinkVersion, String flinkSql) {
+    public FlinkSQLYarnApplicationForm add(String flinkVersion, String flinkSql) {
         buttonFlinkVersionDropdown.click();
         new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElements(selectFlinkVersion));
         selectFlinkVersion.stream()
@@ -64,20 +64,5 @@ public final class FlinkSQLYarnApplicationForm {
         new FlinkSQLEditor(driver).content(flinkSql);
 
         return this;
-    }
-
-    public enum DevelopmentMode {
-        CUSTOM_CODE,
-        FLINK_SQL,
-        PYTHON_FLINK
-    }
-
-    public enum ExecutionMode {
-        REMOTE,
-        YARN_APPLICATION,
-        YARN_SESSION,
-        KUBERNETES_SESSION,
-        KUBERNETES_APPLICATION,
-        YARN_PER_JOB
     }
 }

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/FlinkSQLYarnApplicationForm.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/FlinkSQLYarnApplicationForm.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.pages.apacheflink.applications;
+
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.FindBys;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+import java.util.List;
+
+@Getter
+public final class FlinkSQLYarnApplicationForm {
+    private WebDriver driver;
+
+    @FindBy(xpath = "//div[contains(@codefield, 'versionId')]//div[contains(@class, 'ant-select-selector')]")
+    private WebElement buttonFlinkVersionDropdown;
+
+    @FindBys({
+        @FindBy(css = "[codefield=versionId]"),
+        @FindBy(className = "ant-select-item-option-content")
+    })
+    private List<WebElement> selectFlinkVersion;
+
+    public FlinkSQLYarnApplicationForm(WebDriver driver) {
+        this.driver = driver;
+
+        PageFactory.initElements(driver, this);
+    }
+
+    @SneakyThrows
+    public FlinkSQLYarnApplicationForm addYarnApplication(String flinkVersion, String flinkSql) {
+        buttonFlinkVersionDropdown.click();
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElements(selectFlinkVersion));
+        selectFlinkVersion.stream()
+            .filter(e -> e.getText().equalsIgnoreCase(flinkVersion))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Flink version not found"))
+            .click();
+
+        new FlinkSQLEditor(driver).content(flinkSql);
+
+        return this;
+    }
+
+    public enum DevelopmentMode {
+        CUSTOM_CODE,
+        FLINK_SQL,
+        PYTHON_FLINK
+    }
+
+    public enum ExecutionMode {
+        REMOTE,
+        YARN_APPLICATION,
+        YARN_SESSION,
+        KUBERNETES_SESSION,
+        KUBERNETES_APPLICATION,
+        YARN_PER_JOB
+    }
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/entity/ApplicationsDynamicParams.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/apacheflink/applications/entity/ApplicationsDynamicParams.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.streampark.e2e.pages.apacheflink.applications.entity;
+
+import lombok.Data;
+
+@Data
+public class ApplicationsDynamicParams {
+    private String flinkSQL;
+}

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/common/NavBarPage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/common/NavBarPage.java
@@ -20,8 +20,10 @@
 
 package org.apache.streampark.e2e.pages.common;
 
+import org.apache.streampark.e2e.pages.apacheflink.ApacheFlinkPage;
 import org.apache.streampark.e2e.pages.system.SystemPage;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.FindBy;
@@ -55,9 +57,21 @@ public class NavBarPage {
     }
 
     public <T extends NavBarItem> T goToNav(Class<T> nav) {
+        if (nav == ApacheFlinkPage.class) {
+            new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(apacheFlinkTab));
+            String tabOpenStateXpath = "//span[contains(@class, 'ml-2') and contains(@class, 'streampark-simple-menu-sub-title') and contains(text(), 'Apache Flink')]/../../li[contains(@class, 'streampark-menu-opened')]";
+            if (driver.findElements(By.xpath(tabOpenStateXpath)).isEmpty()) {
+                apacheFlinkTab.click();
+            }
+            return nav.cast(new ApacheFlinkPage(driver));
+        }
+
         if (nav == SystemPage.class) {
-            new WebDriverWait(driver, Duration.ofSeconds(60)).until(ExpectedConditions.elementToBeClickable(systemTab));
-            systemTab.click();
+            new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(systemTab));
+            String tabOpenStateXpath = "//span[contains(@class, 'ml-2') and contains(@class, 'streampark-simple-menu-sub-title') and contains(text(), 'System')]/../../li[contains(@class, 'streampark-menu-opened')]";
+            if (driver.findElements(By.xpath(tabOpenStateXpath)).isEmpty()) {
+                systemTab.click();
+            }
             return nav.cast(new SystemPage(driver));
         }
 

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/Dockerfile
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM apache/streampark:ci as base-image
+
+# Install streampark
+FROM sbloodys/hadoop:3.3.6
+COPY --from=base-image /streampark /streampark
+RUN sudo chown -R hadoop.hadoop /streampark \
+    && sed -i "s/hadoop-user-name: hdfs$/hadoop-user-name: hadoop/g" /streampark/conf/config.yaml
+
+ENV FLINK_VERSION 1.16.3
+
+# Install Flink
+RUN sudo wget --no-check-certificate -O /flink-${FLINK_VERSION}-bin-scala_2.12.tgz https://dlcdn.apache.org/flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_2.12.tgz \
+    && cd / \
+    && sudo tar -zxf flink-${FLINK_VERSION}-bin-scala_2.12.tgz \
+    && sudo chown -R hadoop.hadoop /flink-${FLINK_VERSION}

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/docker-compose.config
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/docker-compose.config
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HADOOP_HOME=/opt/hadoop
+CORE-SITE.XML_fs.default.name=hdfs://namenode
+CORE-SITE.XML_fs.defaultFS=hdfs://namenode
+HDFS-SITE.XML_dfs.namenode.rpc-address=namenode:8020
+HDFS-SITE.XML_dfs.replication=1
+MAPRED-SITE.XML_mapreduce.framework.name=yarn
+MAPRED-SITE.XML_yarn.app.mapreduce.am.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.map.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.reduce.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+YARN-SITE.XML_yarn.resourcemanager.hostname=resourcemanager
+YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
+YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600
+YARN-SITE.XML_yarn.nodemanager.vmem-check-enabled=false
+YARN-SITE.XML_yarn.nodemanager.aux-services=mapreduce_shuffle
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-applications=10000
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-am-resource-percent=0.1
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.resource-calculator=org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.queues=default
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.capacity=100
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.user-limit-factor=1
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.maximum-capacity=100
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.state=RUNNING
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.acl_submit_applications=*
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.acl_administer_queue=*
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.node-locality-delay=40
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.queue-mappings=
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.queue-mappings-override.enable=false

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/docker-compose.yaml
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/docker-compose.yaml
@@ -17,7 +17,7 @@ version: "3"
 
 services:
   namenode:
-    image: apache/streampark-flink-1.18.1-on-yarn:ci
+    image: apache/streampark-flink-1.16.3-on-yarn:ci
     hostname: namenode
     command: [ "hdfs", "namenode" ]
     networks:
@@ -44,7 +44,7 @@ services:
       timeout: 5s
       retries: 120
   datanode:
-    image: apache/streampark-flink-1.18.1-on-yarn:ci
+    image: apache/streampark-flink-1.16.3-on-yarn:ci
     hostname: datanode
     command: [ "hdfs", "datanode" ]
     networks:
@@ -70,7 +70,7 @@ services:
       namenode:
         condition: service_healthy
   resourcemanager:
-    image: apache/streampark-flink-1.18.1-on-yarn:ci
+    image: apache/streampark-flink-1.16.3-on-yarn:ci
     hostname: resourcemanager
     command: [ "yarn", "resourcemanager" ]
     networks:
@@ -95,7 +95,7 @@ services:
       timeout: 5s
       retries: 120
   nodemanager:
-    image: apache/streampark-flink-1.18.1-on-yarn:ci
+    image: apache/streampark-flink-1.16.3-on-yarn:ci
     hostname: nodemanager
     command: [ "yarn", "nodemanager" ]
     networks:
@@ -121,7 +121,7 @@ services:
       timeout: 5s
       retries: 120
   streampark:
-    image: apache/streampark-flink-1.18.1-on-yarn:ci
+    image: apache/streampark-flink-1.16.3-on-yarn:ci
     hostname: streampark
     command:
       - sh

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/Dockerfile
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM apache/streampark:ci as base-image
+
+# Install streampark
+FROM sbloodys/hadoop:3.3.6
+COPY --from=base-image /streampark /streampark
+RUN sudo chown -R hadoop.hadoop /streampark \
+    && sed -i "s/hadoop-user-name: hdfs$/hadoop-user-name: hadoop/g" /streampark/conf/config.yaml
+
+ENV FLINK_VERSION 1.17.2
+
+# Install Flink
+RUN sudo wget --no-check-certificate -O /flink-${FLINK_VERSION}-bin-scala_2.12.tgz https://dlcdn.apache.org/flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_2.12.tgz \
+    && cd / \
+    && sudo tar -zxf flink-${FLINK_VERSION}-bin-scala_2.12.tgz \
+    && sudo chown -R hadoop.hadoop /flink-${FLINK_VERSION}

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/docker-compose.config
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/docker-compose.config
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HADOOP_HOME=/opt/hadoop
+CORE-SITE.XML_fs.default.name=hdfs://namenode
+CORE-SITE.XML_fs.defaultFS=hdfs://namenode
+HDFS-SITE.XML_dfs.namenode.rpc-address=namenode:8020
+HDFS-SITE.XML_dfs.replication=1
+MAPRED-SITE.XML_mapreduce.framework.name=yarn
+MAPRED-SITE.XML_yarn.app.mapreduce.am.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.map.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.reduce.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+YARN-SITE.XML_yarn.resourcemanager.hostname=resourcemanager
+YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
+YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600
+YARN-SITE.XML_yarn.nodemanager.vmem-check-enabled=false
+YARN-SITE.XML_yarn.nodemanager.aux-services=mapreduce_shuffle
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-applications=10000
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-am-resource-percent=0.1
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.resource-calculator=org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.queues=default
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.capacity=100
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.user-limit-factor=1
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.maximum-capacity=100
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.state=RUNNING
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.acl_submit_applications=*
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.acl_administer_queue=*
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.node-locality-delay=40
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.queue-mappings=
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.queue-mappings-override.enable=false

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/docker-compose.yaml
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/docker-compose.yaml
@@ -17,7 +17,7 @@ version: "3"
 
 services:
   namenode:
-    image: apache/streampark-flink-1.18.1-on-yarn:ci
+    image: apache/streampark-flink-1.17.2-on-yarn:ci
     hostname: namenode
     command: [ "hdfs", "namenode" ]
     networks:
@@ -44,7 +44,7 @@ services:
       timeout: 5s
       retries: 120
   datanode:
-    image: apache/streampark-flink-1.18.1-on-yarn:ci
+    image: apache/streampark-flink-1.17.2-on-yarn:ci
     hostname: datanode
     command: [ "hdfs", "datanode" ]
     networks:
@@ -70,7 +70,7 @@ services:
       namenode:
         condition: service_healthy
   resourcemanager:
-    image: apache/streampark-flink-1.18.1-on-yarn:ci
+    image: apache/streampark-flink-1.17.2-on-yarn:ci
     hostname: resourcemanager
     command: [ "yarn", "resourcemanager" ]
     networks:
@@ -95,7 +95,7 @@ services:
       timeout: 5s
       retries: 120
   nodemanager:
-    image: apache/streampark-flink-1.18.1-on-yarn:ci
+    image: apache/streampark-flink-1.17.2-on-yarn:ci
     hostname: nodemanager
     command: [ "yarn", "nodemanager" ]
     networks:
@@ -121,7 +121,7 @@ services:
       timeout: 5s
       retries: 120
   streampark:
-    image: apache/streampark-flink-1.18.1-on-yarn:ci
+    image: apache/streampark-flink-1.17.2-on-yarn:ci
     hostname: streampark
     command:
       - sh

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/Dockerfile
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM apache/streampark:ci as base-image
+
+# Install streampark
+FROM sbloodys/hadoop:3.3.6
+COPY --from=base-image /streampark /streampark
+RUN sudo chown -R hadoop.hadoop /streampark \
+    && sed -i "s/hadoop-user-name: hdfs$/hadoop-user-name: hadoop/g" /streampark/conf/config.yaml
+
+ENV FLINK_VERSION 1.18.1
+
+# Install Flink
+RUN sudo wget --no-check-certificate -O /flink-${FLINK_VERSION}-bin-scala_2.12.tgz https://dlcdn.apache.org/flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_2.12.tgz \
+    && cd / \
+    && sudo tar -zxf flink-${FLINK_VERSION}-bin-scala_2.12.tgz \
+    && sudo chown -R hadoop.hadoop /flink-${FLINK_VERSION}

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/docker-compose.config
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/docker-compose.config
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HADOOP_HOME=/opt/hadoop
+CORE-SITE.XML_fs.default.name=hdfs://namenode
+CORE-SITE.XML_fs.defaultFS=hdfs://namenode
+HDFS-SITE.XML_dfs.namenode.rpc-address=namenode:8020
+HDFS-SITE.XML_dfs.replication=1
+MAPRED-SITE.XML_mapreduce.framework.name=yarn
+MAPRED-SITE.XML_yarn.app.mapreduce.am.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.map.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.reduce.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+YARN-SITE.XML_yarn.resourcemanager.hostname=resourcemanager
+YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
+YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600
+YARN-SITE.XML_yarn.nodemanager.vmem-check-enabled=false
+YARN-SITE.XML_yarn.nodemanager.aux-services=mapreduce_shuffle
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-applications=10000
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-am-resource-percent=0.1
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.resource-calculator=org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.queues=default
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.capacity=100
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.user-limit-factor=1
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.maximum-capacity=100
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.state=RUNNING
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.acl_submit_applications=*
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.acl_administer_queue=*
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.node-locality-delay=40
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.queue-mappings=
+CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.queue-mappings-override.enable=false

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/docker-compose.yaml
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/docker-compose.yaml
@@ -1,0 +1,170 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3"
+
+services:
+  namenode:
+    image: apache/streampark-flink-on-yarn:ci
+    hostname: namenode
+    container_name: namenode
+    command: [ "hdfs", "namenode" ]
+    networks:
+      - e2e
+    build:
+      context: ./
+    ports:
+      - "19870:9870"
+    env_file:
+      - docker-compose.config
+    environment:
+      ENSURE_NAMENODE_DIR: "/tmp/hadoop-root/dfs/name"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200m"
+        max-file: "1"
+    tty: true
+    stdin_open: true
+    restart: always
+    healthcheck:
+      test: [ "CMD", "curl", "http://namenode:9870" ]
+      interval: 5s
+      timeout: 5s
+      retries: 120
+  datanode:
+    image: apache/streampark-flink-on-yarn:ci
+    hostname: datanode
+    container_name: datanode
+    command: [ "hdfs", "datanode" ]
+    networks:
+      - e2e
+    build:
+      context: ./
+    env_file:
+      - docker-compose.config
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200m"
+        max-file: "1"
+    tty: true
+    stdin_open: true
+    restart: always
+    healthcheck:
+      test: [ "CMD", "curl", "http://datanode:9864" ]
+      interval: 5s
+      timeout: 5s
+      retries: 120
+    depends_on:
+      namenode:
+        condition: service_healthy
+  resourcemanager:
+    image: apache/streampark-flink-on-yarn:ci
+    hostname: resourcemanager
+    container_name: resourcemanager
+    command: [ "yarn", "resourcemanager" ]
+    networks:
+      - e2e
+    build:
+      context: ./
+    ports:
+      - "18088:8088"
+    env_file:
+      - docker-compose.config
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200m"
+        max-file: "1"
+    tty: true
+    stdin_open: true
+    restart: always
+    healthcheck:
+      test: [ "CMD", "curl", "http://resourcemanager:8088" ]
+      interval: 5s
+      timeout: 5s
+      retries: 120
+  nodemanager:
+    image: apache/streampark-flink-on-yarn:ci
+    hostname: nodemanager
+    container_name: nodemanager
+    command: [ "yarn", "nodemanager" ]
+    networks:
+      - e2e
+    build:
+      context: ./
+    env_file:
+      - docker-compose.config
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200m"
+        max-file: "1"
+    tty: true
+    stdin_open: true
+    restart: always
+    depends_on:
+      resourcemanager:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "http://nodemanager:8042" ]
+      interval: 5s
+      timeout: 5s
+      retries: 120
+  streampark:
+    image: apache/streampark-flink-on-yarn:ci
+    hostname: streampark
+    container_name: streampark
+    command:
+      - sh
+      - -c
+      - /streampark/bin/streampark.sh start_docker
+    networks:
+      - e2e
+    build:
+      context: ./
+    ports:
+      - "20000:10000"
+    environment:
+      - SPRING_PROFILES_ACTIVE=h2
+      - TZ=Asia/Shanghai
+    env_file:
+      - docker-compose.config
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200m"
+        max-file: "1"
+    tty: true
+    stdin_open: true
+    restart: always
+    depends_on:
+      resourcemanager:
+        condition: service_healthy
+      nodemanager:
+        condition: service_healthy
+      namenode:
+        condition: service_healthy
+      datanode:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "http://streampark:10000" ]
+      interval: 5s
+      timeout: 5s
+      retries: 120
+
+networks:
+  e2e:

--- a/streampark-e2e/streampark-e2e-core/src/main/java/org/apache/streampark/e2e/core/StreamParkExtension.java
+++ b/streampark-e2e/streampark-e2e-core/src/main/java/org/apache/streampark/e2e/core/StreamParkExtension.java
@@ -77,7 +77,7 @@ final class StreamParkExtension implements BeforeAllCallback, AfterAllCallback, 
     @Override
     @SuppressWarnings("UnstableApiUsage")
     public void beforeAll(ExtensionContext context) throws IOException {
-        Awaitility.setDefaultTimeout(Duration.ofSeconds(60));
+        Awaitility.setDefaultTimeout(Duration.ofSeconds(120));
         Awaitility.setDefaultPollInterval(Duration.ofSeconds(2));
 
         setRecordPath();


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #3754
- Add Flink on Yarn per job mode and Flink on Yarn yarn application test cases  with `flink 1.16/1.17/1.18`. 
- The test cases including `createApplication/deleteApplication/releaseApplication/startApplication`.
- Temporary comment out `testStartFlinkApplicationOnYarnPerJobMode` in `flink 1.16` and `flink 1.17` until this bug fixed. #3761 
