### PR TITLE
[CI] Fix flaky e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -112,16 +112,13 @@ jobs:
           root-reserve-mb: 512
           swap-size-mb: 1024
           remove-dotnet: 'true'
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Echo free space
-        run: |
-          echo "Free space:"
-          df -h
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Echo free space
+        run: |
+          echo "Runner Free space:"
+          df -h
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,7 +107,7 @@ jobs:
       RECORDING_PATH: /tmp/recording-${{ matrix.case.name }}
     steps:
       - name: Maximize runner space
-        uses: easimon/maximize-build-space@v10
+        uses: ./.github/actions/maximize-build-space
         with:
           root-reserve-mb: 512
           swap-size-mb: 1024

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,6 +106,19 @@ jobs:
     env:
       RECORDING_PATH: /tmp/recording-${{ matrix.case.name }}
     steps:
+      - name: Maximize runner space
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Echo free space
+        run: |
+          echo "Free space:"
+          df -h
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -137,7 +137,8 @@ jobs:
           path: /tmp
       - name: Load Docker Images
         run: |
-          docker load -i /tmp/standalone-image.tar
+          docker load -i /tmp/standalone-image.tar \
+          && rm -f /tmp/standalone-image.tar
       - name: Run Test
         run: |
           ./mvnw -B -f streampark-e2e/pom.xml -am \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,12 +106,6 @@ jobs:
     env:
       RECORDING_PATH: /tmp/recording-${{ matrix.case.name }}
     steps:
-      - name: Maximize runner space
-        uses: ./.github/actions/maximize-build-space
-        with:
-          root-reserve-mb: 512
-          swap-size-mb: 1024
-          remove-dotnet: 'true'
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,5 +17,10 @@
 
 [submodule ".github/actions/paths-filter"]
 	path = .github/actions/paths-filter
-	url = https://github.com/dorny/paths-filter.git
+	url = https://github.com/dorny/paths-filter
 	branch = de90cc6fb38fc0963ad72b210f1f284cd68cea36
+
+[submodule ".github/actions/maximize-build-space"]
+	path = .github/actions/maximize-build-space
+	url = https://github.com/easimon/maximize-build-space
+	branch = fc881a613ad2a34aca9c9624518214ebc21dfc0c

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/docker-compose.config
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/docker-compose.config
@@ -27,6 +27,7 @@ YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
 YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600
 YARN-SITE.XML_yarn.nodemanager.vmem-check-enabled=false
 YARN-SITE.XML_yarn.nodemanager.aux-services=mapreduce_shuffle
+YARN-SITE.XML_yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage=99.9
 CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-applications=10000
 CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-am-resource-percent=0.1
 CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.resource-calculator=org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/docker-compose.config
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/docker-compose.config
@@ -27,6 +27,7 @@ YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
 YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600
 YARN-SITE.XML_yarn.nodemanager.vmem-check-enabled=false
 YARN-SITE.XML_yarn.nodemanager.aux-services=mapreduce_shuffle
+YARN-SITE.XML_yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage=99.9
 CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-applications=10000
 CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-am-resource-percent=0.1
 CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.resource-calculator=org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/docker-compose.config
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/docker-compose.config
@@ -27,6 +27,7 @@ YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
 YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600
 YARN-SITE.XML_yarn.nodemanager.vmem-check-enabled=false
 YARN-SITE.XML_yarn.nodemanager.aux-services=mapreduce_shuffle
+YARN-SITE.XML_yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage=99.9
 CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-applications=10000
 CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-am-resource-percent=0.1
 CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.resource-calculator=org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator

--- a/streampark-e2e/streampark-e2e-core/src/main/java/org/apache/streampark/e2e/core/StreamParkExtension.java
+++ b/streampark-e2e/streampark-e2e-core/src/main/java/org/apache/streampark/e2e/core/StreamParkExtension.java
@@ -77,7 +77,7 @@ final class StreamParkExtension implements BeforeAllCallback, AfterAllCallback, 
     @Override
     @SuppressWarnings("UnstableApiUsage")
     public void beforeAll(ExtensionContext context) throws IOException {
-        Awaitility.setDefaultTimeout(Duration.ofSeconds(120));
+        Awaitility.setDefaultTimeout(Duration.ofSeconds(180));
         Awaitility.setDefaultPollInterval(Duration.ofSeconds(2));
 
         setRecordPath();

--- a/streampark-e2e/streampark-e2e-core/src/main/java/org/apache/streampark/e2e/core/StreamParkExtension.java
+++ b/streampark-e2e/streampark-e2e-core/src/main/java/org/apache/streampark/e2e/core/StreamParkExtension.java
@@ -77,7 +77,7 @@ final class StreamParkExtension implements BeforeAllCallback, AfterAllCallback, 
     @Override
     @SuppressWarnings("UnstableApiUsage")
     public void beforeAll(ExtensionContext context) throws IOException {
-        Awaitility.setDefaultTimeout(Duration.ofSeconds(180));
+        Awaitility.setDefaultTimeout(Duration.ofSeconds(240));
         Awaitility.setDefaultPollInterval(Duration.ofSeconds(2));
 
         setRecordPath();

--- a/streampark-e2e/streampark-e2e-core/src/main/java/org/apache/streampark/e2e/core/StreamParkExtension.java
+++ b/streampark-e2e/streampark-e2e-core/src/main/java/org/apache/streampark/e2e/core/StreamParkExtension.java
@@ -77,7 +77,7 @@ final class StreamParkExtension implements BeforeAllCallback, AfterAllCallback, 
     @Override
     @SuppressWarnings("UnstableApiUsage")
     public void beforeAll(ExtensionContext context) throws IOException {
-        Awaitility.setDefaultTimeout(Duration.ofSeconds(240));
+        Awaitility.setDefaultTimeout(Duration.ofSeconds(120));
         Awaitility.setDefaultPollInterval(Duration.ofSeconds(2));
 
         setRecordPath();


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Fix flaky e2e test in https://github.com/apache/incubator-streampark/actions/runs/9560745535/job/26353946856?pr=3771.

The main reason for this is that
``
2024-06-18 08:34:50,328 org.testcontainers.containers.ComposeDelegate 66 [docker-java-stream-712489708] INFO  [] - [/9c2jnhykded5-resourcemanager-1] STDOUT: 2024-06-18 08:34:50 INFO  RMNodeImpl:1365 - Node nodemanager:35491 reported UNHEALTHY with details: 1/1 local-dirs usable space is below configured utilization percentage/no more usable space [ /tmp/hadoop-hadoop/nm-local-dir : used space above threshold of 90.0% ] ; 1/1 log-dirs usable space is below configured utilization percentage/no more usable space [ /var/log/hadoop/userlogs : used space above threshold of 90.0% ] 
``
