### PR TITLE
[Bug] Correct spark app submitting process

### DIFF
--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/SparkVersion.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/SparkVersion.scala
@@ -43,7 +43,7 @@ class SparkVersion(val sparkHome: String) extends Serializable with Logger {
     if (matcher.matches()) {
       matcher.group(1)
     } else {
-      "2.12"
+      throw new IllegalArgumentException(s"[StreamPark] can not found scala version in $sparkCoreJar")
     }
   }
 

--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/SparkVersion.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/SparkVersion.scala
@@ -20,6 +20,8 @@ package org.apache.streampark.common.conf
 import org.apache.streampark.common.util.{CommandUtils, Logger}
 import org.apache.streampark.common.util.Implicits._
 
+import org.apache.commons.lang3.StringUtils
+
 import java.io.File
 import java.net.URL
 import java.util.function.Consumer
@@ -36,7 +38,14 @@ class SparkVersion(val sparkHome: String) extends Serializable with Logger {
 
   private[this] lazy val SPARK_SCALA_VERSION_PATTERN = Pattern.compile("^spark-core_(.*)-[0-9].*.jar$")
 
-  lazy val scalaVersion: String = SPARK_SCALA_VERSION_PATTERN.matcher(sparkCoreJar.getName).group(1)
+  lazy val scalaVersion: String = {
+    val matcher = SPARK_SCALA_VERSION_PATTERN.matcher(sparkCoreJar.getName)
+    if (matcher.matches()) {
+      matcher.group(1)
+    } else {
+      "2.12"
+    }
+  }
 
   lazy val sparkCoreJar: File = {
     val distJar = sparkLib.listFiles().filter(_.getName.matches("spark-core.*\\.jar"))
@@ -98,7 +107,7 @@ class SparkVersion(val sparkHome: String) extends Serializable with Logger {
         override def accept(out: String): Unit = {
           buffer.append(out).append("\n")
           val matcher = SPARK_VERSION_PATTERN.matcher(out)
-          if (matcher.find) {
+          if (matcher.find && StringUtils.isBlank(sparkVersion)) {
             sparkVersion = matcher.group(2)
           }
         }

--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/SparkVersion.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/SparkVersion.scala
@@ -20,10 +20,7 @@ package org.apache.streampark.common.conf
 import org.apache.streampark.common.util.{CommandUtils, Logger}
 import org.apache.streampark.common.util.Implicits._
 
-import org.apache.commons.lang3.StringUtils
-
 import java.io.File
-import java.net.URL
 import java.util.function.Consumer
 import java.util.regex.Pattern
 
@@ -34,41 +31,49 @@ class SparkVersion(val sparkHome: String) extends Serializable with Logger {
 
   private[this] lazy val SPARK_VER_PATTERN = Pattern.compile("^(\\d+\\.\\d+)(\\.)?.*$")
 
-  private[this] lazy val SPARK_VERSION_PATTERN = Pattern.compile("(version) (\\d+\\.\\d+\\.\\d+)")
+  private[this] lazy val SPARK_VERSION_PATTERN = Pattern.compile("\\s{2}version\\s(\\d+\\.\\d+\\.\\d+)")
 
-  private[this] lazy val SPARK_SCALA_VERSION_PATTERN = Pattern.compile("^spark-core_(.*)-[0-9].*.jar$")
+  private[this] lazy val SPARK_SCALA_VERSION_PATTERN = Pattern.compile("Using\\sScala\\sversion\\s(\\d+\\.\\d+)")
 
-  lazy val scalaVersion: String = {
-    val matcher = SPARK_SCALA_VERSION_PATTERN.matcher(sparkCoreJar.getName)
-    if (matcher.matches()) {
-      matcher.group(1)
-    } else {
-      throw new IllegalArgumentException(s"[StreamPark] can not found scala version in $sparkCoreJar")
-    }
-  }
+  val (version, scalaVersion) = {
+    var sparkVersion: String = null
+    var scalaVersion: String = null
+    val cmd = List(s"$sparkHome/bin/spark-submit --version")
+    val buffer = new mutable.StringBuilder
 
-  lazy val sparkCoreJar: File = {
-    val distJar = sparkLib.listFiles().filter(_.getName.matches("spark-core.*\\.jar"))
-    distJar match {
-      case x if x.isEmpty =>
-        throw new IllegalArgumentException(s"[StreamPark] can no found spark-core jar in $sparkLib")
-      case x if x.length > 1 =>
-        throw new IllegalArgumentException(
-          s"[StreamPark] found multiple spark-core jar in $sparkLib")
-      case _ =>
-    }
-    distJar.head
-  }
-
-  def checkVersion(throwException: Boolean = true): Boolean = {
-    version.split("\\.").map(_.trim.toInt) match {
-      case Array(3, v, _) if v >= 1 && v <= 3 => true
-      case _ =>
-        if (throwException) {
-          throw new UnsupportedOperationException(s"Unsupported spark version: $version")
-        } else {
-          false
+    CommandUtils.execute(
+      sparkHome,
+      cmd,
+      new Consumer[String]() {
+        override def accept(out: String): Unit = {
+          buffer.append(out).append("\n")
+          val matcher = SPARK_VERSION_PATTERN.matcher(out)
+          if (matcher.find) {
+            sparkVersion = matcher.group(1)
+          } else {
+            val matcher1 = SPARK_SCALA_VERSION_PATTERN.matcher(out)
+            if (matcher1.find) {
+              scalaVersion = matcher1.group(1)
+            }
+          }
         }
+      })
+
+    logInfo(buffer.toString())
+    if (sparkVersion == null || scalaVersion == null) {
+      throw new IllegalStateException(s"[StreamPark] parse spark version failed. $buffer")
+    }
+    buffer.clear()
+    (sparkVersion, scalaVersion)
+  }
+
+  lazy val majorVersion: String = {
+    if (version == null) {
+      null
+    } else {
+      val matcher = SPARK_VER_PATTERN.matcher(version)
+      matcher.matches()
+      matcher.group(1)
     }
   }
 
@@ -84,41 +89,16 @@ class SparkVersion(val sparkHome: String) extends Serializable with Logger {
     lib
   }
 
-  lazy val sparkLibs: List[URL] = sparkLib.listFiles().map(_.toURI.toURL).toList
-
-  lazy val majorVersion: String = {
-    if (version == null) {
-      null
-    } else {
-      val matcher = SPARK_VER_PATTERN.matcher(version)
-      matcher.matches()
-      matcher.group(1)
-    }
-  }
-
-  lazy val version: String = {
-    var sparkVersion: String = null
-    val cmd = List(s"$sparkHome/bin/spark-submit --version")
-    val buffer = new mutable.StringBuilder
-    CommandUtils.execute(
-      sparkHome,
-      cmd,
-      new Consumer[String]() {
-        override def accept(out: String): Unit = {
-          buffer.append(out).append("\n")
-          val matcher = SPARK_VERSION_PATTERN.matcher(out)
-          if (matcher.find && StringUtils.isBlank(sparkVersion)) {
-            sparkVersion = matcher.group(2)
-          }
+  def checkVersion(throwException: Boolean = true): Boolean = {
+    version.split("\\.").map(_.trim.toInt) match {
+      case Array(3, v, _) if v >= 1 && v <= 3 => true
+      case _ =>
+        if (throwException) {
+          throw new UnsupportedOperationException(s"Unsupported spark version: $version")
+        } else {
+          false
         }
-      })
-
-    logInfo(buffer.toString())
-    if (sparkVersion == null) {
-      throw new IllegalStateException(s"[StreamPark] parse spark version failed. $buffer")
     }
-    buffer.clear()
-    sparkVersion
   }
 
   override def toString: String =

--- a/streampark-spark/streampark-spark-client/streampark-spark-client-core/src/main/scala/org/apache/streampark/spark/client/impl/YarnClient.scala
+++ b/streampark-spark/streampark-spark-client/streampark-spark-client-core/src/main/scala/org/apache/streampark/spark/client/impl/YarnClient.scala
@@ -72,7 +72,7 @@ object YarnClient extends SparkClientTrait {
         if (SparkAppHandle.State.FAILED == handle.getState) {
           logger.error("Task run failure stateChanged :{}", handle.getState.toString)
         }
-        if (handle.getState.isFinal) {
+        if (handle.getAppId != null && submitFinished.getCount != 0) {
           submitFinished.countDown()
         }
       }


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

1. For `java.util.regex.Pattern`, `matcher.group()` should be used after matching method like `matches()` and `find()`, or an exception will be thrown.
2. `spark-submit --version` prints spark version and scala version, so `StringUtils.isBlank(sparkVersion)` is need to ensure `version`  be assigned the correct value.<img width="1260" alt="image" src="https://github.com/user-attachments/assets/3b29e635-db5a-4ecf-a61e-8cc096a354ed">
3. `SparkHandle.State` represents the state of job rather than the submission. So if we want to return the result after the submission finished, we should not use `handle.getState.isFinal`.

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
