### PR TITLE
[Bug] Fix: Kerberos authentication issues may occur in Flink on YARN

### DIFF
--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/YarnApplicationClient.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/YarnApplicationClient.scala
@@ -46,19 +46,6 @@ object YarnApplicationClient extends YarnClientTrait {
 
   override def setConfig(submitRequest: SubmitRequest, flinkConfig: Configuration): Unit = {
     super.setConfig(submitRequest, flinkConfig)
-    // val flinkDefaultConfiguration = getFlinkDefaultConfiguration(
-    //   submitRequest.flinkVersion.flinkHome)
-    // val currentUser = UserGroupInformation.getCurrentUser
-    // logDebug(s"UserGroupInformation currentUser: $currentUser")
-    // if (HadoopUtils.isKerberosSecurityEnabled(currentUser)) {
-    //   logDebug(s"kerberos Security is Enabled...")
-    //   val useTicketCache =
-    //     flinkDefaultConfiguration.get(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE)
-    //   if (!HadoopUtils.areKerberosCredentialsValid(currentUser, useTicketCache)) {
-    //     throw new RuntimeException(
-    //       s"Hadoop security with Kerberos is enabled but the login user $currentUser does not have Kerberos credentials or delegation tokens!")
-    //   }
-    // }
     val providedLibs = {
       val array = ListBuffer(
         submitRequest.hdfsWorkspace.flinkLib,

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/YarnSessionClient.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/impl/YarnSessionClient.scala
@@ -61,21 +61,6 @@ object YarnSessionClient extends YarnClientTrait {
   private def deployClusterConfig(
       deployRequest: DeployRequest,
       flinkConfig: Configuration): Unit = {
-
-    // val flinkDefaultConfiguration = getFlinkDefaultConfiguration(
-    //   deployRequest.flinkVersion.flinkHome)
-    // val currentUser = UserGroupInformation.getCurrentUser
-    // logDebug(s"UserGroupInformation currentUser: $currentUser")
-    // if (HadoopUtils.isKerberosSecurityEnabled(currentUser)) {
-    //   logDebug(s"kerberos Security is Enabled...")
-    //   val useTicketCache =
-    //     flinkDefaultConfiguration.get(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE)
-    //   if (!HadoopUtils.areKerberosCredentialsValid(currentUser, useTicketCache)) {
-    //     throw new RuntimeException(
-    //       s"Hadoop security with Kerberos is enabled but the login user $currentUser does not have Kerberos credentials or delegation tokens!")
-    //   }
-    // }
-
     val shipFiles = new util.ArrayList[String]()
     shipFiles.add(s"${deployRequest.flinkVersion.flinkHome}/lib")
     shipFiles.add(s"${deployRequest.flinkVersion.flinkHome}/plugins")

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/YarnClientTrait.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/YarnClientTrait.scala
@@ -125,8 +125,10 @@ trait YarnClientTrait extends FlinkClientTrait {
   /**
    * Retrieves the YarnClusterDescriptor and the application ID.
    *
-   * @param flinkConfig the Flink configuration
-   * @return a tuple containing the application ID and the YarnClusterDescriptor
+   * @param flinkConfig
+   *   the Flink configuration
+   * @return
+   *   a tuple containing the application ID and the YarnClusterDescriptor
    */
   private[client] def getYarnClusterDescriptor(
       flinkConfig: Configuration): (ApplicationId, YarnClusterDescriptor) = {
@@ -159,8 +161,10 @@ trait YarnClientTrait extends FlinkClientTrait {
   /**
    * Retrieves the ClusterSpecification and the YarnClusterDescriptor for deployment.
    *
-   * @param flinkConfig the Flink configuration
-   * @return a tuple containing the ClusterSpecification and the YarnClusterDescriptor
+   * @param flinkConfig
+   *   the Flink configuration
+   * @return
+   *   a tuple containing the ClusterSpecification and the YarnClusterDescriptor
    */
   private[client] def getYarnClusterDeployDescriptor(
       flinkConfig: Configuration): (ClusterSpecification, YarnClusterDescriptor) = {


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #3949

- Modify the relevant code for Flink on YARN and YARN client creation
- Add Kerberos authentication code before creating the YARN client.

 <!-- REMOVE this line if no issue to close -->

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (no)
