### PR TITLE
[Improve] default team member improvement

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/domain/Constant.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/domain/Constant.java
@@ -32,4 +32,6 @@ public class Constant {
     public static final String APP_DETAIL_MENU_ID = "100018";
 
     public static final Long DEFAULT_TEAM_ID = 100000L;
+
+    public static final Long DEFAULT_ROLE_ID = 100001L;
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/RoleService.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/RoleService.java
@@ -62,4 +62,10 @@ public interface RoleService extends IService<Role> {
      * @param role Role
      */
     void updateRole(Role role);
+
+    /**
+     * Get the Default Role
+     *
+     */
+    Role getSysDefaultRole();
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/RoleServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/RoleServiceImpl.java
@@ -123,4 +123,9 @@ public class RoleServiceImpl extends ServiceImpl<RoleMapper, Role> implements Ro
         }
         roleMenuService.saveBatch(roleMenus);
     }
+
+    @Override
+    public Role getSysDefaultRole() {
+        return baseMapper.selectOne(new LambdaQueryWrapper<Role>().eq(Role::getRoleId, Constant.DEFAULT_ROLE_ID));
+    }
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
@@ -31,10 +31,13 @@ import org.apache.streampark.console.core.service.application.ApplicationInfoSer
 import org.apache.streampark.console.core.service.application.ApplicationManageService;
 import org.apache.streampark.console.system.authentication.JWTToken;
 import org.apache.streampark.console.system.authentication.JWTUtil;
+import org.apache.streampark.console.system.entity.Member;
+import org.apache.streampark.console.system.entity.Role;
 import org.apache.streampark.console.system.entity.User;
 import org.apache.streampark.console.system.mapper.UserMapper;
 import org.apache.streampark.console.system.service.MemberService;
 import org.apache.streampark.console.system.service.MenuService;
+import org.apache.streampark.console.system.service.RoleService;
 import org.apache.streampark.console.system.service.TeamService;
 import org.apache.streampark.console.system.service.UserService;
 
@@ -85,6 +88,9 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
     @Autowired
     private TeamService teamService;
 
+    @Autowired
+    private RoleService roleService;
+
     @Override
     public User getByUsername(String username) {
         LambdaQueryWrapper<User> queryWrapper = new LambdaQueryWrapper<User>().eq(User::getUsername, username);
@@ -121,6 +127,14 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
             user.setPassword(password);
         }
         save(user);
+        // set team member
+        Member member = new Member();
+        member.setUserName(user.getUsername());
+        member.setTeamId(user.getLastTeamId());
+        Role role = roleService.getSysDefaultRole();
+        member.setRoleId(role.getRoleId());
+        member.setRoleName(role.getRoleName());
+        memberService.createMember(member);
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/service/impl/UserServiceImpl.java
@@ -130,7 +130,7 @@ public class UserServiceImpl extends ServiceImpl<UserMapper, User> implements Us
         // set team member
         Member member = new Member();
         member.setUserName(user.getUsername());
-        member.setTeamId(user.getLastTeamId());
+        member.setTeamId(teamService.getSysDefaultTeam().getId());
         Role role = roleService.getSysDefaultRole();
         member.setRoleId(role.getRoleId());
         member.setRoleName(role.getRoleName());


### PR DESCRIPTION
## What changes were proposed in this pull request

In #3922, set the default queue for new users as LastTeamId. However, since the user is not set as a member of the default team, login will fail. Therefore, we can set the user as a member of the default team after creating a new user.

## Brief change log

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (no)
