### PR TITLE
Fix the issue where failure to start in k8s mode cannot be stopped.

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/enums/FlinkAppState.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/enums/FlinkAppState.java
@@ -141,11 +141,7 @@ public enum FlinkAppState implements Serializable {
   public static class Bridge {
     /** covert from org.apache.streampark.flink.k8s.enums.FlinkJobState */
     public static FlinkAppState fromK8sFlinkJobState(Enumeration.Value flinkJobState) {
-      if (FlinkJobState.K8S_INITIALIZING().equals(flinkJobState)) {
-        return INITIALIZING;
-      } else {
-        return of(flinkJobState.toString());
-      }
+      return of(flinkJobState.toString());
     }
 
     /** covert to org.apache.streampark.flink.k8s.enums.FlinkJobState */

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/enums/FlinkJobState.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/enums/FlinkJobState.scala
@@ -22,8 +22,6 @@ object FlinkJobState extends Enumeration {
 
   // flink job has been submit by the streampark.
   val STARTING,
-  // flink k8s resources are being initialized.
-  K8S_INITIALIZING,
   // lost track of flink job temporarily.
   SILENT,
   // flink job has terminated positively (maybe FINISHED or CANCELED)

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
@@ -323,20 +323,13 @@ class FlinkJobStatusWatcher(conf: JobStatusWatcherConfig = JobStatusWatcherConfi
         val isConnection = KubernetesDeploymentHelper.checkConnection()
 
         if (deployExists) {
-          val deployError = KubernetesDeploymentHelper.isDeploymentError(
-            trackId.namespace,
-            trackId.clusterId
-          )
-          if (!deployError) {
-            logger.info("Task Enter the initialization process.")
-            FlinkJobState.K8S_INITIALIZING
-          } else if (isConnection) {
-            logger.info("Enter the task failure deletion process.")
-            KubernetesDeploymentHelper.watchPodTerminatedLog(
+          if (isConnection) {
+            logger.info("Enter the task starting process.")
+            KubernetesDeploymentHelper.watchDeploymentLog(
               trackId.namespace,
               trackId.clusterId,
               trackId.jobId)
-            FlinkJobState.FAILED
+            FlinkJobState.STARTING
           } else {
             inferFromPreCache(latest)
           }


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

The existing k8s mode will change the status to FAILED after startup failure, which will cause the flink job to keep restarting on k8s, and there is no button on the front end of streampark to stop the flink job. This submission is to allow the flink job to be stopped via the abort button on the front end of streampark when the startup fails.

## Brief change log

1. Remove the "K8S_INITIALIZING" state specific to k8s mode.
2. When the rest interface of the flink job is not accessible and the job's deployment exists, the job should enter the Starting state instead of the failed state.
3. Change the abort implementation of k8s mode to delete the deployment.

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
