### PR TITLE
[Improve] add streampark task id in external link

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/enums/PlaceholderTypeEnum.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/enums/PlaceholderTypeEnum.java
@@ -20,6 +20,8 @@ package org.apache.streampark.console.core.enums;
 /** configFile Type enum */
 public enum PlaceholderTypeEnum {
 
+    ID("id"),
+
     JOB_ID("job_id"),
 
     JOB_NAME("job_name"),

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ExternalLinkServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ExternalLinkServiceImpl.java
@@ -85,6 +85,7 @@ public class ExternalLinkServiceImpl extends ServiceImpl<ExternalLinkMapper, Ext
 
     private void renderLinkUrl(ExternalLink link, Application app) {
         Map<String, String> placeholderValueMap = new HashMap<>();
+        placeholderValueMap.put(PlaceholderTypeEnum.ID.get(), String.valueOf(app.getId()));
         placeholderValueMap.put(PlaceholderTypeEnum.JOB_ID.get(), app.getJobId());
         placeholderValueMap.put(PlaceholderTypeEnum.JOB_NAME.get(), app.getJobName());
         placeholderValueMap.put(PlaceholderTypeEnum.YARN_ID.get(), app.getClusterId());

--- a/streampark-console/streampark-console-webapp/src/views/setting/extlink/components/Modal.vue
+++ b/streampark-console/streampark-console-webapp/src/views/setting/extlink/components/Modal.vue
@@ -98,7 +98,7 @@
           h(
             'span',
             { class: 'tip-info' },
-            'Supported variables: {job_id}, {yarn_id}, {job_name},Example: https://grafana/flink-monitoring?var-JobId=var-JobId={job_id}',
+            'Supported variables: {id}, {job_id}, {yarn_id}, {job_name},Example: https://grafana/flink-monitoring?var-JobId=var-JobId={job_id}',
           ),
         rules: [
           {


### PR DESCRIPTION

## What changes were proposed in this pull request
When adding an external link, I found that the parameters only contained information about the remote task, but not the task ID of Streampark itself, which was inconvenient to use. Therefore, I added the ID to the external link.

## Brief change log

add ID in org/apache/streampark/console/core/enums/PlaceholderTypeEnum.java

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (no)
