### PR TITLE
[Fix]: User-defined ingress causes job status error (apache#3792)

### DIFF
--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/ingress/IngressStrategyV1.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/ingress/IngressStrategyV1.scala
@@ -45,14 +45,7 @@ class IngressStrategyV1 extends IngressStrategy {
             Option(ingress)
               .map(ingress => ingress.getSpec.getRules.head)
               .map(rule => rule.getHost -> rule.getHttp.getPaths.head.getPath)
-              .map {
-                case (host, path) =>
-                  var new_path = path
-                  if (path.endsWith("/")) {
-                    new_path = path.substring(0, path.length - 1)
-                  }
-                  s"http://$host$new_path"
-              }
+              .map { case (host, path) => s"http://$host${path.replaceAll("\\/$", "")}" }
               .getOrElse {
                 Utils.using(clusterClient)(client => client.getWebInterfaceURL)
               }

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/ingress/IngressStrategyV1.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/ingress/IngressStrategyV1.scala
@@ -45,7 +45,14 @@ class IngressStrategyV1 extends IngressStrategy {
             Option(ingress)
               .map(ingress => ingress.getSpec.getRules.head)
               .map(rule => rule.getHost -> rule.getHttp.getPaths.head.getPath)
-              .map { case (host, path) => s"http://$host$path" }
+              .map {
+                case (host, path) =>
+                  var new_path = path
+                  if (path.endsWith("/")) {
+                    new_path = path.substring(0, path.length - 1)
+                  }
+                  s"http://$host$new_path"
+              }
               .getOrElse {
                 Utils.using(clusterClient)(client => client.getWebInterfaceURL)
               }


### PR DESCRIPTION
* [Fix]: User-defined ingress causes job status error

<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #3792 <!-- REMOVE this line if no issue to close -->

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log
Ingress address was build by 'host' and 'path', when use with default path '/' , the url will some like 'http://xxxx/", but when use this url within `org.apache.streampark.flink.kubernetes.watcher.FlinkJobStatusWatcher#callJobsOverviewsApi`, will cause error.
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.


<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): ( no)
