### PR TITLE
Add a jobId label to the pods deployed in k8s mode.

### DIFF
--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/FlinkClientTrait.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/FlinkClientTrait.scala
@@ -18,7 +18,7 @@
 package org.apache.streampark.flink.client.`trait`
 
 import org.apache.streampark.common.conf.ConfigConst._
-import org.apache.streampark.common.enums.{ApplicationType, DevelopmentMode, ExecutionMode}
+import org.apache.streampark.common.enums.{ApplicationType, DevelopmentMode}
 import org.apache.streampark.common.util.{DeflaterUtils, Logger, PropertiesUtils, Utils}
 import org.apache.streampark.flink.client.bean._
 import org.apache.streampark.flink.core.conf.FlinkRunOption
@@ -34,7 +34,6 @@ import org.apache.flink.client.cli.CliFrontend.loadCustomCommandLines
 import org.apache.flink.client.deployment.application.ApplicationConfiguration
 import org.apache.flink.client.program.{ClusterClient, PackagedProgram, PackagedProgramUtils}
 import org.apache.flink.configuration._
-import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions
 import org.apache.flink.runtime.jobgraph.{JobGraph, SavepointConfigOptions}
 import org.apache.flink.util.Preconditions.checkNotNull
 
@@ -151,27 +150,10 @@ trait FlinkClientTrait extends Logger {
           })
     }
 
-    // 5) add jobId Label To Kubernetes Pod, convenient for query in prometheus
-    if (ExecutionMode.isKubernetesMode(submitRequest.executionMode)) {
-      addPodJobIdLabels(flinkConfig, KubernetesConfigOptions.JOB_MANAGER_LABELS, submitRequest)
-      addPodJobIdLabels(flinkConfig, KubernetesConfigOptions.TASK_MANAGER_LABELS, submitRequest)
-    }
-
     flinkConfig
   }
 
   def setConfig(submitRequest: SubmitRequest, flinkConf: Configuration): Unit
-
-  private def addPodJobIdLabels(
-      flinkConfig: Configuration,
-      opt: ConfigOption[java.util.Map[String, String]],
-      submitRequest: SubmitRequest): Unit = {
-    val labels = flinkConfig
-      .getOptional[java.util.Map[String, String]](opt)
-      .orElse(new java.util.HashMap[String, String]())
-    labels.put("jobId", submitRequest.jobId)
-    flinkConfig.safeSet(opt, labels)
-  }
 
   @throws[Exception]
   def triggerSavepoint(savepointRequest: TriggerSavepointRequest): SavepointResponse = {

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/FlinkClientTrait.scala
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/scala/org/apache/streampark/flink/client/trait/FlinkClientTrait.scala
@@ -18,7 +18,7 @@
 package org.apache.streampark.flink.client.`trait`
 
 import org.apache.streampark.common.conf.ConfigConst._
-import org.apache.streampark.common.enums.{ApplicationType, DevelopmentMode}
+import org.apache.streampark.common.enums.{ApplicationType, DevelopmentMode, ExecutionMode}
 import org.apache.streampark.common.util.{DeflaterUtils, Logger, PropertiesUtils, Utils}
 import org.apache.streampark.flink.client.bean._
 import org.apache.streampark.flink.core.conf.FlinkRunOption
@@ -34,6 +34,7 @@ import org.apache.flink.client.cli.CliFrontend.loadCustomCommandLines
 import org.apache.flink.client.deployment.application.ApplicationConfiguration
 import org.apache.flink.client.program.{ClusterClient, PackagedProgram, PackagedProgramUtils}
 import org.apache.flink.configuration._
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions
 import org.apache.flink.runtime.jobgraph.{JobGraph, SavepointConfigOptions}
 import org.apache.flink.util.Preconditions.checkNotNull
 
@@ -150,10 +151,27 @@ trait FlinkClientTrait extends Logger {
           })
     }
 
+    // 5) add jobId Label To Kubernetes Pod, convenient for query in prometheus
+    if (ExecutionMode.isKubernetesMode(submitRequest.executionMode)) {
+      addPodJobIdLabels(flinkConfig, KubernetesConfigOptions.JOB_MANAGER_LABELS, submitRequest)
+      addPodJobIdLabels(flinkConfig, KubernetesConfigOptions.TASK_MANAGER_LABELS, submitRequest)
+    }
+
     flinkConfig
   }
 
   def setConfig(submitRequest: SubmitRequest, flinkConf: Configuration): Unit
+
+  private def addPodJobIdLabels(
+      flinkConfig: Configuration,
+      opt: ConfigOption[java.util.Map[String, String]],
+      submitRequest: SubmitRequest): Unit = {
+    val labels = flinkConfig
+      .getOptional[java.util.Map[String, String]](opt)
+      .orElse(new java.util.HashMap[String, String]())
+    labels.put("jobId", submitRequest.jobId)
+    flinkConfig.safeSet(opt, labels)
+  }
 
   @throws[Exception]
   def triggerSavepoint(savepointRequest: TriggerSavepointRequest): SavepointResponse = {


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/incubator-streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

Add a jobId label to the pods deployed on k8s to facilitate subsequent monitoring and task viewing.
<img width="1888" alt="image" src="https://github.com/user-attachments/assets/ffa6eb9d-096c-44d4-9545-15c8f561e367">


<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
