### PR TITLE
[Bug] ApplicationBackUpCleanTask Runtime Error

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/ApplicationBackUpCleanTask.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/ApplicationBackUpCleanTask.java
@@ -43,7 +43,7 @@ public class ApplicationBackUpCleanTask {
         backUpService.lambdaQuery()
             .select(FlinkApplicationBackup::getAppId)
             .groupBy(FlinkApplicationBackup::getAppId)
-            .having("count(*) > " + maxBackupNum)
+            .having("COUNT(*) > {0}", maxBackupNum)
             .list()
             .stream()
             .map(FlinkApplicationBackup::getAppId)

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/ApplicationBackUpCleanTask.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/task/ApplicationBackUpCleanTask.java
@@ -40,15 +40,21 @@ public class ApplicationBackUpCleanTask {
     public void backUpClean() {
         log.info("Start to clean application backup");
         // select all application backup which count > maxBackupNum group by app_id
-        backUpService.lambdaQuery().groupBy(FlinkApplicationBackup::getAppId)
-            .having("count(*) > " + maxBackupNum).list().stream()
+        backUpService.lambdaQuery()
+            .select(FlinkApplicationBackup::getAppId)
+            .groupBy(FlinkApplicationBackup::getAppId)
+            .having("count(*) > " + maxBackupNum)
+            .list()
+            .stream()
             .map(FlinkApplicationBackup::getAppId)
             .forEach(
                 appId -> {
                     // order by create_time desc and skip first maxBackupNum records and delete
                     // others
-                    backUpService.lambdaQuery().eq(FlinkApplicationBackup::getAppId, appId)
-                        .orderByDesc(FlinkApplicationBackup::getCreateTime).list()
+                    backUpService.lambdaQuery()
+                        .eq(FlinkApplicationBackup::getAppId, appId)
+                        .orderByDesc(FlinkApplicationBackup::getCreateTime)
+                        .list()
                         .stream()
                         .skip(maxBackupNum)
                         .forEach(


### PR DESCRIPTION
## What changes were proposed in this pull request

In the current code, the table "t_flink_app_backup" will be cleaned at 01:00 everyday, and the sql is "SELECT id,app_id,sql_id,config_id,path,description,version,create_time FROM t_flink_app_backup GROUP BY app_id HAVING count(*) > 5"

###### But mysql8.0 sql_mode is  "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION", so this clean task is always error.

So I think we can just get "FlinkApplicationBackup::getAppId" column.

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
