### PR TITLE
[Fix] Fix proxy URL authentication parameter

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ProxyServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ProxyServiceImpl.java
@@ -231,7 +231,10 @@ public class ProxyServiceImpl implements ProxyService {
                 (PrivilegedExceptionAction<ResponseEntity<?>>) () -> proxy(request, url, requestEntity));
         }
         if (YarnUtils.hasYarnHttpSimpleAuth()) {
-            return proxyRequest(request, String.format("%s?user.name=%s", url, HadoopConfigUtils.hadoopUserName()));
+            String urlTemplate =
+                StringUtils.isNotBlank(request.getQueryString()) ? "%s&user.name=%s" : "%s?user.name=%s";
+            return proxyRequest(
+                request, String.format(urlTemplate, url, HadoopConfigUtils.hadoopUserName()));
         }
         return proxyRequest(request, url);
     }


### PR DESCRIPTION
Fix proxy URL authentication parameter concatenation when URL already has query parameters. eg. flink exceptions, metrics.

## What changes were proposed in this pull request

Issue Number: close https://github.com/apache/streampark/issues/3930

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

before
![image](https://github.com/user-attachments/assets/9fad3300-4f14-44b7-97af-404671515c15)
![image](https://github.com/user-attachments/assets/494ab533-8f21-4be8-9e25-f90ac2744ac2)

after
![image](https://github.com/user-attachments/assets/87549138-0b90-4a3d-8046-4c09abef87ab)



<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
