### PR TITLE
[Bug] The getFinalSavepointDir did not receive the processPath return value, resulting in redundant calls and logical errors

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/SavepointServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/SavepointServiceImpl.java
@@ -353,9 +353,6 @@ public class SavepointServiceImpl extends ServiceImpl<SavepointMapper, Savepoint
 
     // infer savepoint
     String customSavepoint = this.getFinalSavepointDir(savepointPath, application);
-    if (StringUtils.isNotBlank(customSavepoint)) {
-      customSavepoint = processPath(customSavepoint, application.getJobName(), application.getId());
-    }
 
     FlinkCluster cluster = flinkClusterService.getById(application.getFlinkClusterId());
     String clusterId = getClusterId(application, cluster);
@@ -427,7 +424,7 @@ public class SavepointServiceImpl extends ServiceImpl<SavepointMapper, Savepoint
     }
 
     if (StringUtils.isNotBlank(result)) {
-      processPath(result, application.getJobName(), application.getId());
+      result = processPath(result, application.getJobName(), application.getId());
     } else {
       throw new IllegalArgumentException(
           String.format(


### PR DESCRIPTION
In the getFinalSavepointDir method, the processPath function is called but its return value is not assigned to any variable. This leads to the processed path being discarded, requiring the caller to call processPath again on the returned result. This causes:
1. Redundant computation (same path processing executed twice)
2. Inconsistent value handling (the method returns unprocessed value but expects it to be processed)
3. Logical fragility (if processPath has side effects, they would occur twice)

<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #4278  <!-- REMOVE this line if no issue to close -->

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

- *Use the result variable to receive the return value of the processPath method: result = processPath(result, application.getJobName(), application.getId());*
- *Delete redundant calculations*

## Verifying this change

- This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
