### PR TITLE
[Bug] Property or field 'appId' cannot be found on object of type 'org.apache.streampark.console.core.entity.FlinkApplication'

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/OpenAPIController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/OpenAPIController.java
@@ -50,14 +50,14 @@ public class OpenAPIController {
     @OpenAPI(name = "flinkStart", header = {
             @OpenAPI.Param(name = "Authorization", description = "Access authorization token", required = true, type = String.class)
     }, param = {
-            @OpenAPI.Param(name = "id", description = "current flink application id", required = true, type = Long.class, bindFor = "appId"),
+            @OpenAPI.Param(name = "id", description = "current flink application id", required = true, type = Long.class),
             @OpenAPI.Param(name = "teamId", description = "current user teamId", required = true, type = Long.class),
             @OpenAPI.Param(name = "argument", description = "flink program run arguments", required = false, type = String.class, bindFor = "args"),
             @OpenAPI.Param(name = "restoreFromSavepoint", description = "restored app from the savepoint or checkpoint", required = false, type = Boolean.class, defaultValue = "false", bindFor = "restoreOrTriggerSavepoint"),
             @OpenAPI.Param(name = "savepointPath", description = "savepoint or checkpoint path", required = false, type = String.class),
             @OpenAPI.Param(name = "allowNonRestored", description = "ignore savepoint if cannot be restored", required = false, type = Boolean.class, defaultValue = "false"),
     })
-    @Permission(app = "#app.appId", team = "#app.teamId")
+    @Permission(app = "#app.id", team = "#app.teamId")
     @PostMapping("app/start")
     @RequiresPermissions("app:start")
     public RestResponse flinkStart(FlinkApplication app) throws Exception {
@@ -68,13 +68,13 @@ public class OpenAPIController {
     @OpenAPI(name = "flinkCancel", header = {
             @OpenAPI.Param(name = "Authorization", description = "Access authorization token", required = true, type = String.class)
     }, param = {
-            @OpenAPI.Param(name = "id", description = "current flink application id", required = true, type = Long.class, bindFor = "appId"),
+            @OpenAPI.Param(name = "id", description = "current flink application id", required = true, type = Long.class),
             @OpenAPI.Param(name = "teamId", description = "current user teamId", required = true, type = Long.class),
             @OpenAPI.Param(name = "triggerSavepoint", description = "trigger savepoint before taking stopping", required = false, type = Boolean.class, defaultValue = "false", bindFor = "restoreOrTriggerSavepoint"),
             @OpenAPI.Param(name = "savepointPath", description = "savepoint path", required = false, type = String.class),
             @OpenAPI.Param(name = "drain", description = "send max watermark before canceling", required = false, type = Boolean.class, defaultValue = "false"),
     })
-    @Permission(app = "#app.appId", team = "#app.teamId")
+    @Permission(app = "#app.id", team = "#app.teamId")
     @PostMapping("app/cancel")
     @RequiresPermissions("app:cancel")
     public RestResponse flinkCancel(FlinkApplication app) throws Exception {


### PR DESCRIPTION
There are two errors in the annotation configuration of the flinkStart / flinkCancel method:
1. Error in @OpenAPI.Param(bindFor = "appId"):
This annotation binds the value of parameter id to the appId field of the FlinkApplication object. However, the FlinkApplication class does not have an appId field; the actual field name is id. This will result in ineffective data binding.
2. Error in SpEL expression @PermissionScope(app = "#app.appId"):
This expression attempts to access the appId property of the FlinkApplication object. Since the FlinkApplication class doesn't have an appId field, it will throw the exception: Property or field 'appId' cannot be found on object of type 'org.apache.streampark.console.core.entity.FlinkApplication'

<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #4121 <!-- REMOVE this line if no issue to close -->

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

 - Remove the bindFor = "appId" attribute from the @OpenAPI.
 - Change @PermissionScope(app = "#app.appId") to @PermissionScope(app = "#app.id")

 - Caused by location:
at org.apache.streampark.console.core.aspect.PermissionAspect.getId(PermissionAspect.java:118)

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
