### PR TITLE
[Feature] Enable variable support for the savepoint path

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkSavepointServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkSavepointServiceImpl.java
@@ -140,24 +140,38 @@ public class FlinkSavepointServiceImpl extends ServiceImpl<FlinkSavepointMapper,
 
         // 1) properties have the highest priority, read the properties are set: -Dstate.savepoints.dir
         String savepointPath = getSavepointFromDynamicProps(application.getDynamicProperties());
-        if (StringUtils.isNotBlank(savepointPath)) {
-            return savepointPath;
-        }
 
         // Application conf configuration has the second priority. If it is a streampark|flinksql type
         // task, see if Application conf is configured when the task is defined, if checkpoints are
         // configured
         // and enabled, read `state.savepoints.dir`
-        savepointPath = getSavepointFromConfig(application);
-        if (StringUtils.isNotBlank(savepointPath)) {
-            return savepointPath;
+        if (StringUtils.isBlank(savepointPath)) {
+            savepointPath = getSavepointFromConfig(application);
         }
 
         // 3) If the savepoint is not obtained above, try to obtain the savepoint path according to the
         // deployment type (remote|on yarn)
         // 3.1) At the remote mode, request the flink webui interface to get the savepoint path
         // 3.2) At the yarn or k8s mode, then read the savepoint in flink-conf.yml in the bound flink
-        return getSavepointFromDeployLayer(application);
+        if (StringUtils.isBlank(savepointPath)) {
+            savepointPath = getSavepointFromDeployLayer(application);
+        }
+
+        // 4) Supporting variables
+        if (StringUtils.isNotBlank(savepointPath)) {
+            savepointPath =
+                processPath(
+                    savepointPath, application.getJobName(), application.getId());
+        }
+        return savepointPath;
+    }
+
+    private String processPath(String path, String jobName, Long jobId) {
+        if (StringUtils.isNotBlank(path)) {
+            return path.replaceAll("\\$\\{job(Name|name)}|\\$job(Name|name)", jobName)
+                .replaceAll("\\$\\{job(Id|id)}|\\$job(Id|id)", jobId.toString());
+        }
+        return path;
     }
 
     @Override


### PR DESCRIPTION
Enable variable support for saving point paths and resolve the bug in version 2.1.6 where getFinalSavepointDir did not receive a processPath return value, resulting in redundant calls and logical errors
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #4278 <!-- REMOVE this line if no issue to close -->

<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.


<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
