### PR TITLE
[Bug] fix job silent status can't convert to lost status bugs

### DIFF
--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/K8sFlinkConfig.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/K8sFlinkConfig.scala
@@ -29,6 +29,13 @@ object K8sFlinkConfig {
     description = "run timeout seconds of single flink-k8s metrics tracking task")
 
   @deprecated
+  val jobStatusTrackCacheTimeoutSec: InternalOption = InternalOption(
+    key = "streampark.flink-k8s.tracking.cache-timeout-sec.job-status",
+    defaultValue = 300,
+    classType = classOf[java.lang.Integer],
+    description = "status cache timeout seconds of single flink-k8s job status tracking task")
+
+  @deprecated
   val metricTrackTaskTimeoutSec: InternalOption = InternalOption(
     key = "streampark.flink-k8s.tracking.polling-task-timeout-sec.cluster-metric",
     defaultValue = 120L,

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/DefaultFlinkK8sWatcher.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/DefaultFlinkK8sWatcher.scala
@@ -33,7 +33,7 @@ class DefaultFlinkK8sWatcher(conf: FlinkTrackConfig = FlinkTrackConfig.defaultCo
 
   // cache pool for storage tracking result
   implicit val watchController: FlinkK8sWatchController =
-    new FlinkK8sWatchController()
+    new FlinkK8sWatchController(conf.jobStatusWatcherConf)
 
   // eventBus for change event
   implicit lazy val eventBus: ChangeEventBus = {

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/FlinkK8sWatchController.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/FlinkK8sWatchController.scala
@@ -27,7 +27,7 @@ import java.util.Objects
 import java.util.concurrent.TimeUnit
 
 /** Tracking info cache pool on flink kubernetes mode. */
-class FlinkK8sWatchController extends Logger with AutoCloseable {
+class FlinkK8sWatchController(conf: JobStatusWatcherConfig = JobStatusWatcherConfig.defaultConf) extends Logger with AutoCloseable {
 
   // cache for tracking identifiers
   lazy val trackIds: TrackIdCache = TrackIdCache.build()
@@ -38,7 +38,7 @@ class FlinkK8sWatchController extends Logger with AutoCloseable {
   lazy val endpoints: EndpointCache = EndpointCache.build()
 
   // cache for tracking flink job status
-  lazy val jobStatuses: JobStatusCache = JobStatusCache.build()
+  lazy val jobStatuses: JobStatusCache = JobStatusCache.build(conf.jobStatusCacheTimeOutSec)
 
   // cache for tracking kubernetes events with Deployment kind
   lazy val k8sDeploymentEvents: K8sDeploymentEventCache =
@@ -156,10 +156,10 @@ object TrackIdCache {
   }
 }
 
-class JobStatusCache {
+class JobStatusCache(timeout: Int) {
 
   private[this] lazy val cache: Cache[CacheKey, JobStatusCV] =
-    Caffeine.newBuilder.expireAfterWrite(20, TimeUnit.SECONDS).build()
+    Caffeine.newBuilder.expireAfterWrite(timeout, TimeUnit.SECONDS).build()
 
   def putAll(kvs: Map[TrackId, JobStatusCV]): Unit =
     cache.putAll(kvs.map(t => (CacheKey(t._1.appId), t._2)))
@@ -183,7 +183,7 @@ class JobStatusCache {
 
 object JobStatusCache {
 
-  def build(): JobStatusCache = new JobStatusCache()
+  def build(timeout: Int): JobStatusCache = new JobStatusCache(timeout)
 
 }
 

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/TrackConfig.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/TrackConfig.scala
@@ -48,11 +48,14 @@ case class MetricWatcherConfig(requestTimeoutSec: Long, requestIntervalSec: Long
  *   interval seconds between two single tracking task
  * @param silentStateJobKeepTrackingSec
  *   retained tracking time for SILENT state flink tasks
+ * @param jobStatusCacheTimeOutSec
+ *   job status cache time out of single tracking task, must bigger than silentStateJobKeepTrackingSec
  */
 case class JobStatusWatcherConfig(
     requestTimeoutSec: Long,
     requestIntervalSec: Long,
-    silentStateJobKeepTrackingSec: Int)
+    silentStateJobKeepTrackingSec: Int,
+    jobStatusCacheTimeOutSec: Int)
 
 object FlinkTrackConfig {
   def defaultConf: FlinkTrackConfig =
@@ -66,7 +69,8 @@ object FlinkTrackConfig {
     JobStatusWatcherConfig(
       InternalConfigHolder.get(K8sFlinkConfig.jobStatusTrackTaskTimeoutSec),
       InternalConfigHolder.get(K8sFlinkConfig.jobStatueTrackTaskIntervalSec),
-      InternalConfigHolder.get(K8sFlinkConfig.silentStateJobKeepTrackingSec)),
+      InternalConfigHolder.get(K8sFlinkConfig.silentStateJobKeepTrackingSec),
+      InternalConfigHolder.get(K8sFlinkConfig.jobStatusTrackCacheTimeoutSec)),
     MetricWatcherConfig(
       InternalConfigHolder.get(K8sFlinkConfig.metricTrackTaskTimeoutSec),
       InternalConfigHolder.get(K8sFlinkConfig.metricTrackTaskIntervalSec)))
@@ -77,12 +81,14 @@ object JobStatusWatcherConfig {
   def defaultConf: JobStatusWatcherConfig = JobStatusWatcherConfig(
     requestTimeoutSec = 120,
     requestIntervalSec = 5,
-    silentStateJobKeepTrackingSec = 60)
+    silentStateJobKeepTrackingSec = 60,
+    jobStatusCacheTimeOutSec = 300)
 
   def debugConf: JobStatusWatcherConfig = JobStatusWatcherConfig(
     requestTimeoutSec = 120,
     requestIntervalSec = 2,
-    silentStateJobKeepTrackingSec = 5)
+    silentStateJobKeepTrackingSec = 5,
+    jobStatusCacheTimeOutSec = 30)
 }
 
 object MetricWatcherConfig {

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
@@ -128,11 +128,7 @@ class FlinkJobStatusWatcher(conf: JobStatusWatcherConfig = JobStatusWatcherConfi
                 case _ =>
                   touchSessionJob(trackId) match {
                     case Some(state) =>
-                      if (FlinkJobState.isEndState(state.jobState)) {
-                        // can't find that job in the k8s cluster.
-                        watchController.unWatching(trackId)
-                      }
-                      eventBus.postSync(FlinkJobStatusChangeEvent(trackId, state))
+                      updateState(trackId, state)
                     case _ =>
                   }
               }


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Bugs: The Silent Status Jobs  Can't Convert to Lost Status

Reason: The job status cache expiration time is too short, causing silent status jobs to fail to convert to lost status as expected
<img width="804" height="109" alt="image" src="https://github.com/user-attachments/assets/3570638d-8a29-4710-9fa0-185f63e0d716" />

the default `conf.silentStateJobKeepTrackingSec` value is 60s
<img width="1014" height="207" alt="image" src="https://github.com/user-attachments/assets/03c533e0-ff1e-47e7-b5d9-fa54032b4bea" />

the job status cache expiration time out is 20s
<img width="865" height="148" alt="image" src="https://github.com/user-attachments/assets/1ddcd0e7-85bd-439e-aece-ce36bd7abd90" />



Fix: 
1. Add the configuration parameter jobStatusTrackCacheTimeoutSec for job status cache with a default value of 300 seconds.
2. update session job status to status cache
<img width="921" height="317" alt="image" src="https://github.com/user-attachments/assets/d29da1ed-56ea-46d7-8b7a-db9789cc1fc1" />



## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
