### PR TITLE
[Bug] fix duplicate application restarts and alerts.

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkAppHttpWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkAppHttpWatcher.java
@@ -67,6 +67,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -169,6 +170,8 @@ public class FlinkAppHttpWatcher {
 
     private static final Byte DEFAULT_FLAG_BYTE = Byte.valueOf("0");
 
+    private static final Set<Long> WATCHING_IN_PROGRESS = ConcurrentHashMap.newKeySet();
+
     @Qualifier("flinkRestAPIWatchingExecutor")
     @Autowired
     private Executor watchExecutor;
@@ -210,7 +213,17 @@ public class FlinkAppHttpWatcher {
             || timeMillis - lastOptionTime <= OPTION_INTERVAL.toMillis()
             || timeMillis - lastWatchTime >= WATCHING_INTERVAL.toMillis()) {
             lastWatchTime = timeMillis;
-            WATCHING_APPS.forEach(this::watch);
+            WATCHING_APPS.forEach((appId, application) -> {
+                if (WATCHING_IN_PROGRESS.add(appId)) {
+                    try {
+                        watch(appId, application);
+                    } finally {
+                        WATCHING_IN_PROGRESS.remove(appId);
+                    }
+                } else {
+                    log.info("App {} is already being watched, skipping", appId);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Issue Number: close #4301 <!-- REMOVE this line if no issue to close -->

Since the status of all applications is checked every 5 seconds, if the check cannot be completed within 5 seconds, it will cause the thread pool queue to accumulate. As a result, there may be multiple duplicate applications waiting in the thread pool queue, such as the same failed task that needs to be restarted appearing multiple times. This can lead to repeated application restarts and duplicate alerts.

Therefore, a WATCHING_IN_PROGRESS set is added here. If an application is already being watched, it will be skipped to ensure that there are no duplicate tasks in the thread pool queue.
<img width="1805" height="664" alt="image" src="https://github.com/user-attachments/assets/33c3b4aa-444e-49fe-8841-d6615bfc347b" />

## Brief change log
 fix duplicate application submissions and alerts when thread pool queue accumulates and failed task needs to be restarted

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
