### PR TITLE
[Bug]Fix FlinkJobStatusWatcher deadlock & NullPointerException

### DIFF
--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkJobStatusWatcher.scala
@@ -314,8 +314,8 @@ class FlinkJobStatusWatcher(conf: JobStatusWatcherConfig = JobStatusWatcherConfi
     )
     val jobState = trackId match {
       case id
-          if watchController.canceling.has(id) || latest.jobState.equals(
-            FlinkJobState.CANCELLING) =>
+          if watchController.canceling.has(id) || Option(latest).exists(
+            _.jobState == FlinkJobState.CANCELLING) =>
         logger.info(s"trackId ${trackId.toString} is canceling")
         if (deployExists) FlinkJobState.CANCELLING else FlinkJobState.CANCELED
       case _ =>

--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkWatcher.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/watcher/FlinkWatcher.scala
@@ -28,11 +28,11 @@ import scala.language.implicitConversions
 trait FlinkWatcher extends AutoCloseable {
 
   // see org.apache.flink.client.cli.ClientOptions.CLIENT_TIMEOUT}
-  lazy val FLINK_CLIENT_TIMEOUT_SEC: Timeout =
+  val FLINK_CLIENT_TIMEOUT_SEC: Timeout =
     Timeout.ofMilliseconds(Duration.ofSeconds(60).toMillis).toTimeout
 
   // see org.apache.flink.configuration.RestOptions.AWAIT_LEADER_TIMEOUT
-  lazy val FLINK_REST_AWAIT_TIMEOUT_SEC: Timeout = Timeout.ofMilliseconds(30000L)
+  val FLINK_REST_AWAIT_TIMEOUT_SEC: Timeout = Timeout.ofMilliseconds(30000L)
 
   private[this] val started: AtomicBoolean = new AtomicBoolean(false)
 


### PR DESCRIPTION
<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request


<!--(For example: This pull request proposed to add checkstyle plugin).-->

一、死锁问题
新创建一个streampark服务并启动后，添加一个新任务并启动，会一直starting，持续4分钟，原因是doWatch()方法线程A与appFuture异步执行线程B发生死锁，线程A持有当前对象实例（this）的锁，线程B中有两个lazy val懒加载需要等这个锁，导致死锁。
解决办法是把两个超时变量从lazy val改为val
```
死锁时间线：
T0: Thread-A (主线程) 进入 doWatch()
T1: Thread-A 获取 this.synchronized 锁
T2: Thread-A 创建 Future 任务提交到线程池
T3: Thread-B (Future线程) 从线程池取出任务开始执行
T4: Thread-B 执行 touchApplicationJob(id)
T5: Thread-B 访问 lazy val FLINK_CLIENT_TIMEOUT_SEC 和 FLINK_REST_AWAIT_TIMEOUT_SEC，尝试获取 this 对象的锁
    → 阻塞等待（因为Thread-A持有锁）
T6: Thread-A 执行 Await.ready(..., timeout)
    → 等待Thread-B完成
T7: timeout时间到达（2分钟，两个超时变量4分钟）
T8: Await.ready抛出TimeoutException
T9: Thread-A 捕获异常，记录日志，释放锁
T10: 锁释放后，Thread-B获得锁，继续执行
    → 但此时Future已经标记为失败/超时

```
二、空指针问题
当任务实际完成后，前端状态还是running，这是因为任务完成后deployment被flink删除了，jobs/overview接口不可用了，watcher还没来得及更新状态，于是会走inferStateFromK8sEvent方法去更新状态，但是这里的latest有大概率是null，因为watchController缓存时效是20秒，过期了就拿不到当前任务的最新状态了，导致` if watchController.canceling.has(id) || latest.jobState.equals(`里空指针，PS: 但是异常并没有抛出来
```
    val latest: JobStatusCV = watchController.jobStatuses.get(trackId)
    // whether deployment exists on kubernetes cluster
    val deployExists = KubernetesRetriever.isDeploymentExists(
      trackId.namespace,
      trackId.clusterId
    )
    val jobState = trackId match {
      case id
          if watchController.canceling.has(id) || latest.jobState.equals(
            FlinkJobState.CANCELLING) =>
```
**1. Deadlock bug**
After creating a new StreamPark service and starting it, when adding and launching a new task, it remains in the "starting" state continuously for 4 minutes. The reason is that a deadlock occurs between thread A of the `doWatch()` method and thread B executing `appFuture` asynchronously. Thread A holds the lock of the current object instance (`this`), while thread B contains two `lazy val` lazy-loaded variables that need to wait for this same lock, resulting in a deadlock.
```
Timeline of the Deadlock:

T0: Thread-A (main thread) enters doWatch()
T1: Thread-A acquires the this.synchronized lock
T2: Thread-A creates Future tasks and submits them to the thread pool
T3: Thread-B (Future thread) picks up a task from the thread pool and starts execution
T4: Thread-B executes touchApplicationJob(id)
T5: Thread-B accesses a lazy val FLINK_CLIENT_TIMEOUT_SEC and FLINK_REST_AWAIT_TIMEOUT_SEC, and attempts to acquire the lock on the 'this' object
    → Blocks waiting (because Thread-A holds the lock)
T6: Thread-A executes Await.ready(..., timeout)
    → Waits for Thread-B to complete
T7: Timeout is reached (2 minutes, with the two timeout variables totaling 4 minutes)
T8: Await.ready throws a TimeoutException
T9: Thread-A catches the exception, logs it, and releases the lock
T10: After the lock is released, Thread-B acquires the lock and continues execution
    → However, by this point, the Future is already marked as failed/timed out
```
Solution: Change the two timeout variables from lazy val to val

**2. NPE bug**
When a task is actually completed, the front-end status still shows "running". This is because after the task completes, the deployment is deleted by Flink, making the `jobs/overview` API unavailable. The watcher hasn't had time to update the status yet, so it falls back to the `inferStateFromK8sEvent` method to update the status. However, the `latest` variable here has a high probability of being `null` because the `watchController` cache has a 20-second expiration time. Once expired, it cannot retrieve the latest status of the current task, leading to a null pointer error in the condition:  
`if watchController.canceling.has(id) || latest.jobState.equals(...)`  

PS: However, the exception is not thrown (likely caught or suppressed somewhere).
```
    val latest: JobStatusCV = watchController.jobStatuses.get(trackId)
    // whether deployment exists on kubernetes cluster
    val deployExists = KubernetesRetriever.isDeploymentExists(
      trackId.namespace,
      trackId.clusterId
    )
    val jobState = trackId match {
      case id
          if watchController.canceling.has(id) || latest.jobState.equals(
            FlinkJobState.CANCELLING) =>
```

## Brief change log

<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->
1. change two timeout variables `FLINK_CLIENT_TIMEOUT_SEC` and `FLINK_REST_AWAIT_TIMEOUT_SEC` from `lazy val` to `val`
2. fix npe  

## Verifying this change

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
