### PR TITLE
e2e: fix dropdown options timeout by using anyMatch instead of visibi…

### DIFF
--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/resource/ProjectsPage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/resource/ProjectsPage.java
@@ -80,7 +80,7 @@ public class ProjectsPage extends NavBarPage implements ResourcePage.Tab {
         createProjectForm.selectCveDropdown.click();
 
         new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
-            .until(ExpectedConditions.visibilityOfAllElements(createProjectForm.selectCve));
+            .until(d -> createProjectForm.selectCve.stream().anyMatch(WebElement::isDisplayed));
 
         createProjectForm.selectCve.stream()
             .filter(e -> e.getText().equalsIgnoreCase("GitHub/GitLab"))
@@ -92,7 +92,7 @@ public class ProjectsPage extends NavBarPage implements ResourcePage.Tab {
         createProjectForm.selectBranchDropdown.click();
 
         new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
-            .until(ExpectedConditions.visibilityOfAllElements(createProjectForm.selectRefs));
+            .until(d -> createProjectForm.selectRefs.stream().anyMatch(WebElement::isDisplayed));
         createProjectForm.selectRefs.stream()
             .filter(e -> e.getText().equalsIgnoreCase(projectRefs))
             .findFirst()


### PR DESCRIPTION

<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request

Currently, the E2E testing workflow is failing. The failure is caused by a "ghost node" interfering with the Selenium locator when it tries to interact with the dropdown options (such as the branch/refs selection) in ProjectsPage.
Since StreamPark's frontend uses the Ant Design Vue `Select` component, its underlying engine (`rc-virtual-list`) renders a hidden dummy/measurement node in the DOM to calculate the dynamic height of options for virtual scrolling. This hidden node shares the exact same `.ant-select-item-option-content` class but inherently has empty text and remains invisible (`isDisplayed=false`). 
This PR fixes the workflow failure by introducing visibility filtering. By ignoring these hidden placeholder nodes generated by the frontend virtual scroll, the E2E script can accurately locate and interact with the target options.


<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

- Fixed the failing E2E workflow by optimizing the `Select` interaction logic in the test cases.
- Added `WebElement::isDisplayed` filtering when matching element collections such as `selectRefs`, safely bypassing the hidden measurement nodes generated by the frontend performance optimization.

## Verifying this change
[x] Re-run the StreamPark E2E tests via the GitHub Actions workflow or locally.

[x] Confirm that the previously failing ProjectsManagementTest— specifically the branch selection steps in Project creation — now passes stably. The fix has resolved the exceptions caused by invisible empty nodes.

**Important Note: The E2E Workflow Will Still Fail**

After merging this PR, the complete E2E test suite will still fail. This is expected, as other known issues remain. I will submit follow-up fixes immediately after this PR is merged​ to address these problems, until the entire workflow runs stably.
合并此PR后，E2E测试**仍然会失败**，但这是**预期内**的，因为还有其他已知问题存在，我已经找到了修复方法。我会在**此PR合并后立即提交后续修复**来解决这些问题，直到整个工作流能够成功运行。

<!--*(Please pick either of the following options)*-->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): (yes / no)
 no
