### PR TITLE
[e2e]: Fix flaky ElementClickInterceptedException in System and Resource pages

### DIFF
--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/common/Constants.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/common/Constants.java
@@ -26,8 +26,6 @@ public class Constants {
 
     public static final Integer DEFAULT_SLEEP_MILLISECONDS = 2000;
 
-    public static final Integer DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS = 500;
-
     public static final Duration DEFAULT_WEBDRIVER_WAIT_DURATION = Duration.ofSeconds(10);
 
     public static final String LINE_SEPARATOR = "\n";

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/common/Constants.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/common/Constants.java
@@ -26,6 +26,8 @@ public class Constants {
 
     public static final Integer DEFAULT_SLEEP_MILLISECONDS = 2000;
 
+    public static final Integer DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS = 500;
+
     public static final Duration DEFAULT_WEBDRIVER_WAIT_DURATION = Duration.ofSeconds(10);
 
     public static final String LINE_SEPARATOR = "\n";

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/resource/ResourcePage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/resource/ResourcePage.java
@@ -22,6 +22,7 @@ import org.apache.streampark.e2e.pages.common.NavBarPage;
 import org.apache.streampark.e2e.pages.common.NavBarPage.NavBarItem;
 
 import lombok.Getter;
+import lombok.SneakyThrows;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.FindBy;
@@ -44,10 +45,12 @@ public final class ResourcePage extends NavBarPage implements NavBarItem {
         super(driver);
     }
 
+    @SneakyThrows
     public <T extends ResourcePage.Tab> T goToTab(Class<T> tab) {
         if (tab == VariablesPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuVariables));
+            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
             menuVariables.click();
             return tab.cast(new VariablesPage(driver));
         }
@@ -55,6 +58,7 @@ public final class ResourcePage extends NavBarPage implements NavBarItem {
         if (tab == ProjectsPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuProjects));
+            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
             menuProjects.click();
             return tab.cast(new ProjectsPage(driver));
         }
@@ -62,6 +66,7 @@ public final class ResourcePage extends NavBarPage implements NavBarItem {
         if (tab == UploadsPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuUploads));
+            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
             menuUploads.click();
             return tab.cast(new UploadsPage(driver));
         }

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/resource/ResourcePage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/resource/ResourcePage.java
@@ -50,7 +50,7 @@ public final class ResourcePage extends NavBarPage implements NavBarItem {
         if (tab == VariablesPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuVariables));
-            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
+            Thread.sleep(Constants.DEFAULT_SLEEP_MILLISECONDS);
             menuVariables.click();
             return tab.cast(new VariablesPage(driver));
         }
@@ -58,7 +58,7 @@ public final class ResourcePage extends NavBarPage implements NavBarItem {
         if (tab == ProjectsPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuProjects));
-            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
+            Thread.sleep(Constants.DEFAULT_SLEEP_MILLISECONDS);
             menuProjects.click();
             return tab.cast(new ProjectsPage(driver));
         }
@@ -66,7 +66,7 @@ public final class ResourcePage extends NavBarPage implements NavBarItem {
         if (tab == UploadsPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuUploads));
-            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
+            Thread.sleep(Constants.DEFAULT_SLEEP_MILLISECONDS);
             menuUploads.click();
             return tab.cast(new UploadsPage(driver));
         }

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/system/SystemPage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/system/SystemPage.java
@@ -22,6 +22,7 @@ import org.apache.streampark.e2e.pages.common.NavBarPage;
 import org.apache.streampark.e2e.pages.common.NavBarPage.NavBarItem;
 
 import lombok.Getter;
+import lombok.SneakyThrows;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.FindBy;
@@ -50,10 +51,12 @@ public final class SystemPage extends NavBarPage implements NavBarItem {
         super(driver);
     }
 
+    @SneakyThrows
     public <T extends SystemPage.Tab> T goToTab(Class<T> tab) {
         if (tab == UserManagementPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuUserManagement));
+            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
             menuUserManagement.click();
             return tab.cast(new UserManagementPage(driver));
         }
@@ -61,6 +64,7 @@ public final class SystemPage extends NavBarPage implements NavBarItem {
         if (tab == TeamManagementPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuTeamManagement));
+            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
             menuTeamManagement.click();
             return tab.cast(new TeamManagementPage(driver));
         }
@@ -68,12 +72,14 @@ public final class SystemPage extends NavBarPage implements NavBarItem {
         if (tab == RoleManagementPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuRoleManagement));
+            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
             menuRoleManagement.click();
             return tab.cast(new RoleManagementPage(driver));
         }
         if (tab == TokenManagementPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuTokenManagement));
+            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
             menuTokenManagement.click();
             return tab.cast(new TokenManagementPage(driver));
         }
@@ -81,6 +87,7 @@ public final class SystemPage extends NavBarPage implements NavBarItem {
         if (tab == MemberManagementPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuMemberManagement));
+            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
             menuMemberManagement.click();
             return tab.cast(new MemberManagementPage(driver));
         }

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/system/SystemPage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/system/SystemPage.java
@@ -56,7 +56,7 @@ public final class SystemPage extends NavBarPage implements NavBarItem {
         if (tab == UserManagementPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuUserManagement));
-            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
+            Thread.sleep(Constants.DEFAULT_SLEEP_MILLISECONDS);
             menuUserManagement.click();
             return tab.cast(new UserManagementPage(driver));
         }
@@ -64,7 +64,7 @@ public final class SystemPage extends NavBarPage implements NavBarItem {
         if (tab == TeamManagementPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuTeamManagement));
-            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
+            Thread.sleep(Constants.DEFAULT_SLEEP_MILLISECONDS);
             menuTeamManagement.click();
             return tab.cast(new TeamManagementPage(driver));
         }
@@ -72,14 +72,14 @@ public final class SystemPage extends NavBarPage implements NavBarItem {
         if (tab == RoleManagementPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuRoleManagement));
-            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
+            Thread.sleep(Constants.DEFAULT_SLEEP_MILLISECONDS);
             menuRoleManagement.click();
             return tab.cast(new RoleManagementPage(driver));
         }
         if (tab == TokenManagementPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuTokenManagement));
-            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
+            Thread.sleep(Constants.DEFAULT_SLEEP_MILLISECONDS);
             menuTokenManagement.click();
             return tab.cast(new TokenManagementPage(driver));
         }
@@ -87,7 +87,7 @@ public final class SystemPage extends NavBarPage implements NavBarItem {
         if (tab == MemberManagementPage.class) {
             new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
                 .until(ExpectedConditions.elementToBeClickable(menuMemberManagement));
-            Thread.sleep(Constants.DEFAULT_UI_ANIMATION_SLEEP_MILLISECONDS);
+            Thread.sleep(Constants.DEFAULT_SLEEP_MILLISECONDS);
             menuMemberManagement.click();
             return tab.cast(new MemberManagementPage(driver));
         }


### PR DESCRIPTION
…source pages

<!--
Thank you for contributing to StreamPark! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

## Contribution Checklist

  - If this is your first time, please read our contributor guidelines: [Submit Code](https://streampark.apache.org/community/submit_guide/submit_code).

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/streampark/issues).

  - Name the pull request in the form "[Feature] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - If the PR is unfinished, add `[WIP]` in your PR title, e.g., `[WIP][Feature] Title of the pull request`.

-->

## What changes were proposed in this pull request
This PR addresses a critical stability issue (flaky tests) in the E2E testing pipeline for StreamPark.
**Fix Flaky UI Tests (`ElementClickInterceptedException`)**: 
A race condition frequently occurred in `UserManagementTest` and `UploadManagementTest` where the Selenium webdriver clicked on child menu items while the parent menu's CSS expanding animation was still in progress. This caused clicks to be intercepted by the animated mask or parent container. 


<!--(For example: This pull request proposed to add checkstyle plugin).-->

## Brief change log

`SystemPage.java` & `ResourcePage.java`: Added `Thread.sleep()` before all `menu.click()` actions with `@SneakyThrows` to fix `ElementClickInterceptedException` caused by CSS animations.
<!--*(for example:)*
- *Add maven-checkstyle-plugin to root pom.xml*
-->

## Verifying this change
This is the last E2E issue I've found. From now on, the pipeline is highly likely to run successfully every time.

<!--*(example:)*
- *Added integration tests for end-to-end.*
- *Added *Test to verify the change.*
- *Manually verified the change by testing locally.* -->

## Does this pull request potentially affect one of the following parts
 no
