### PR TITLE
fix: Disable remote access and tracing for H2 console

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/config/SpringProperties.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/config/SpringProperties.java
@@ -117,8 +117,8 @@ public class SpringProperties {
         // h2
         springConfig.put("spring.h2.console.path", "/h2-console");
         springConfig.put("spring.h2.console.enabled", true);
-        springConfig.put("spring.h2.console.settings.web-allow-others", true);
-        springConfig.put("spring.h2.console.settings.trace", true);
+        springConfig.put("spring.h2.console.settings.web-allow-others", false);
+        springConfig.put("spring.h2.console.settings.trace", false);
         break;
       default:
         throw new UnsupportedOperationException("Unsupported datasource dialect: " + dialect);


### PR DESCRIPTION
Modify the H2 console to allow access only from the local machine.