### PR TITLE
[ISSUE-4354][Bug][Web UI] Fix invalid Prettier arguments in lint-staged config

### DIFF
--- a/streampark-console/streampark-console-webapp/package.json
+++ b/streampark-console/streampark-console-webapp/package.json
@@ -131,7 +131,7 @@
       "prettier --write"
     ],
     "{!(package)*.json,*.code-snippets,.!(browserslist)*rc}": [
-      "prettier --write--parser json"
+      "prettier --write --parser json"
     ],
     "package.json": [
       "prettier --write"


### PR DESCRIPTION
## What changed

Fix the Prettier command in the frontend lint-staged config. The missing space caused Prettier to treat `--write--parser=json` as an unknown option.

## Test

- `git diff --check`
- `prettier --parser json package.json`

Closes #4354
