### PR TITLE
[ISSUE-4323][Bug] Fix flink conf path recovery

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/FlinkEnv.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/FlinkEnv.java
@@ -36,6 +36,8 @@ import lombok.Setter;
 import java.io.File;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
 import java.util.Date;
 import java.util.Map;
 import java.util.Properties;
@@ -117,7 +119,7 @@ public class FlinkEnv implements Serializable {
     }
 
     public Map<String, String> convertFlinkYamlAsMap() {
-        String flinkYamlString = DeflaterUtils.unzipString(flinkConf);
+        String flinkYamlString = getFlinkConfYaml();
         if (isLegacyFlinkConf()) {
             return FlinkConfigurationUtils.loadLegacyFlinkConf(flinkYamlString);
         }
@@ -133,7 +135,7 @@ public class FlinkEnv implements Serializable {
     }
 
     public void unzipFlinkConf() {
-        this.flinkConf = DeflaterUtils.unzipString(this.flinkConf);
+        this.flinkConf = getFlinkConfYaml();
     }
 
     public String getLargeVersion() {
@@ -166,11 +168,37 @@ public class FlinkEnv implements Serializable {
 
     @JsonIgnore
     public Properties getFlinkConfig() {
-        String flinkYamlString = DeflaterUtils.unzipString(flinkConf);
+        String flinkYamlString = getFlinkConfYaml();
         Properties flinkConfig = new Properties();
         Map<String, String> config = FlinkConfigurationUtils.loadLegacyFlinkConf(flinkYamlString);
         flinkConfig.putAll(config);
         return flinkConfig;
+    }
+
+    private String getFlinkConfYaml() {
+        try {
+            return DeflaterUtils.unzipString(flinkConf);
+        } catch (IllegalArgumentException e) {
+            if (isStoredFlinkHome()) {
+                doSetFlinkConf();
+                return DeflaterUtils.unzipString(flinkConf);
+            }
+            throw e;
+        }
+    }
+
+    private boolean isStoredFlinkHome() {
+        if (StringUtils.isBlank(flinkConf) || StringUtils.isBlank(flinkHome)) {
+            return false;
+        }
+        if (StringUtils.equals(flinkConf, flinkHome)) {
+            return true;
+        }
+        try {
+            return Paths.get(flinkConf).normalize().equals(Paths.get(flinkHome).normalize());
+        } catch (InvalidPathException e) {
+            return false;
+        }
     }
 
     private Float getVersionNumber() {

--- a/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/entity/FlinkEnvTest.java
+++ b/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/entity/FlinkEnvTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.console.core.entity;
+
+import org.apache.streampark.common.util.DeflaterUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FlinkEnvTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void unzipFlinkConfShouldRecoverWhenStoredValueIsFlinkHome() throws IOException {
+        FlinkEnv flinkEnv = flinkEnvWithStoredFlinkHome();
+
+        flinkEnv.unzipFlinkConf();
+
+        assertThat(flinkEnv.getFlinkConf())
+            .contains("execution.checkpointing.savepoint-dir: hdfs:///savepoints");
+    }
+
+    @Test
+    void getFlinkConfigShouldRecoverWhenStoredValueIsFlinkHome() throws IOException {
+        FlinkEnv flinkEnv = flinkEnvWithStoredFlinkHome();
+
+        Properties flinkConfig = flinkEnv.getFlinkConfig();
+
+        assertThat(flinkConfig)
+            .containsEntry("execution.checkpointing.savepoint-dir", "hdfs:///savepoints");
+        assertThat(DeflaterUtils.unzipString(flinkEnv.getFlinkConf()))
+            .contains("execution.checkpointing.savepoint-dir: hdfs:///savepoints");
+    }
+
+    @Test
+    void getFlinkConfigShouldRecoverWhenStoredValueHasTrailingSlash() throws IOException {
+        FlinkEnv flinkEnv = flinkEnvWithStoredFlinkHome();
+        flinkEnv.setFlinkConf(flinkEnv.getFlinkHome() + "/");
+
+        Properties flinkConfig = flinkEnv.getFlinkConfig();
+
+        assertThat(flinkConfig)
+            .containsEntry("execution.checkpointing.savepoint-dir", "hdfs:///savepoints");
+    }
+
+    private FlinkEnv flinkEnvWithStoredFlinkHome() throws IOException {
+        Path flinkHome = tempDir.resolve("flink-1.16.3");
+        Path confDir = flinkHome.resolve("conf");
+        Files.createDirectories(confDir);
+        Files.write(
+            confDir.resolve("flink-conf.yaml"),
+            "execution.checkpointing.savepoint-dir: hdfs:///savepoints\n"
+                .getBytes(StandardCharsets.UTF_8));
+
+        FlinkEnv flinkEnv = new FlinkEnv();
+        flinkEnv.setFlinkHome(flinkHome.toString());
+        flinkEnv.setFlinkConf(flinkHome.toString());
+        flinkEnv.setVersion("1.16.3");
+        return flinkEnv;
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #4323

Related #4316.

This pull request fixes the Flink Conf view path when `t_flink_env.flink_conf` contains the Flink home path instead of the compressed config content. In that case `DeflaterUtils.unzipString` fails before the page can render the config.

The recovery is intentionally conservative: it only reloads the config from `flinkHome` when the stored value equals, or normalizes to, the configured Flink home path. Other invalid compressed values still fail as before.

## Brief change log

- Reuse one Flink conf YAML resolver for `convertFlinkYamlAsMap`, `unzipFlinkConf`, and `getFlinkConfig`.
- Recover historical `flink_conf` values that were stored as the Flink home path by calling the existing `doSetFlinkConf` flow.
- Add `FlinkEnvTest` coverage for exact path recovery, trailing slash recovery, and `getFlinkConfig` usage.

## Verifying this change

This change added tests and can be verified as follows:

- Added `FlinkEnvTest` to cover the recovery behavior.
- Ran `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -Pfast -pl streampark-console/streampark-console-service -am -DskipTests=false -Dcheckstyle.skip=true -Dtest=FlinkEnvTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Ran `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -pl streampark-console/streampark-console-service -DskipTests spotless:check`
- Ran `git diff --check` and `git diff --cached --check`

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
