### PR TITLE
[ISSUE-4315][Bug] Fix multiline dynamic properties parsing

### DIFF
--- a/streampark-common/src/main/scala/org/apache/streampark/common/util/FlinkConfigurationUtils.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/util/FlinkConfigurationUtils.scala
@@ -99,8 +99,9 @@ object FlinkConfigurationUtils extends Logger {
   @Nonnull def extractDynamicProperties(properties: String): Map[String, String] = {
     if (StringUtils.isEmpty(properties)) Map.empty[String, String]
     else {
+      val normalizedProperties = normalizeDynamicProperties(properties)
       val map = mutable.Map[String, String]()
-      val simple = properties.replaceAll(MULTI_PROPERTY_REGEXP, "")
+      val simple = normalizedProperties.replaceAll(MULTI_PROPERTY_REGEXP, "")
       simple.split("\\s?-D") match {
         case d if Utils.isNotEmpty(d) =>
           d.foreach(x => {
@@ -113,7 +114,7 @@ object FlinkConfigurationUtils extends Logger {
           })
         case _ =>
       }
-      val matcher = MULTI_PROPERTY_PATTERN.matcher(properties)
+      val matcher = MULTI_PROPERTY_PATTERN.matcher(normalizedProperties)
       while (matcher.find()) {
         val opts = matcher.group()
         val index = opts.indexOf("=")
@@ -124,6 +125,24 @@ object FlinkConfigurationUtils extends Logger {
       }
       map.toMap
     }
+  }
+
+  private[this] def normalizeDynamicProperties(properties: String): String = {
+    val normalized = new StringBuilder
+    properties.split("\\r?\\n").foreach { line =>
+      val trimmed = line.trim
+      if (trimmed.nonEmpty) {
+        if (trimmed.startsWith("-D")) {
+          if (normalized.nonEmpty) {
+            normalized.append(System.lineSeparator())
+          }
+          normalized.append(trimmed)
+        } else {
+          normalized.append(trimmed)
+        }
+      }
+    }
+    normalized.toString()
   }
 
   @Nonnull def extractArguments(args: String): List[String] = {

--- a/streampark-common/src/test/scala/org/apache/streampark/common/util/PropertiesUtilsTestCase.scala
+++ b/streampark-common/src/test/scala/org/apache/streampark/common/util/PropertiesUtilsTestCase.scala
@@ -66,4 +66,26 @@ class PropertiesUtilsTestCase {
     Assertions.assertEquals(map("diy.param.name"), "apache streampark")
   }
 
+  @Test def testDynamicPropertiesWithMultilineValue(): Unit = {
+    val dynamicProperties =
+      """
+        |-Dexecution.target=yarn-application
+        |-Dyarn.ship-files=/data/module/flink-1.20.2;
+        |/opt/module/flink-cdc-3.5.0/test1.pgsql-to-starrocks.yaml;
+        |/data/module/hadoop/hadoop-3.3.6/etc/hadoop/core-site.xml;
+        |/data/module/hadoop/hadoop-3.3.6/etc/hadoop/hdfs-site.xml
+        |-Dyarn.application.queue=flink
+        |""".stripMargin
+
+    val map = FlinkConfigurationUtils.extractDynamicProperties(dynamicProperties)
+    Assertions.assertEquals(map("execution.target"), "yarn-application")
+    Assertions.assertEquals(
+      map("yarn.ship-files"),
+      "/data/module/flink-1.20.2;" +
+        "/opt/module/flink-cdc-3.5.0/test1.pgsql-to-starrocks.yaml;" +
+        "/data/module/hadoop/hadoop-3.3.6/etc/hadoop/core-site.xml;" +
+        "/data/module/hadoop/hadoop-3.3.6/etc/hadoop/hdfs-site.xml")
+    Assertions.assertEquals(map("yarn.application.queue"), "flink")
+  }
+
 }


### PR DESCRIPTION
## What's changed

Close #4315.

This fixes dynamic properties parsing when a long option value is split across multiple lines in the textarea, for example `yarn.ship-files`. Lines that do not start with `-D` are now treated as continuations of the previous dynamic property before the existing parser runs.

The existing single-line and quoted value cases continue to use the same parsing path.

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -pl streampark-common -Dtest=org.apache.streampark.common.util.PropertiesUtilsTestCase test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -pl streampark-common test`
- `git diff --check`

Note: the local default JDK is newer than the Scala 2.12 compiler bridge supports cleanly, so the verification commands above explicitly use JDK 17.