### PR TITLE
[ISSUE-4322][Bug] Fix OpenAPI token authentication

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/authentication/ShiroRealm.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/authentication/ShiroRealm.java
@@ -107,8 +107,7 @@ public class ShiroRealm extends AuthorizingRealm {
                 // Check whether the token belongs to the api and whether the permission is valid
                 AccessToken accessToken = accessTokenService.getByUserId(userId);
                 try {
-                    String encryptToken = JWTUtil.encrypt(credential);
-                    if (accessToken == null || !accessToken.getToken().equals(encryptToken)) {
+                    if (accessToken == null || !credential.equals(JWTUtil.decrypt(accessToken.getToken()))) {
                         throw new AuthenticationException("the openapi authorization token is invalid");
                     }
                 } catch (Exception e) {

--- a/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/AccessTokenServiceTest.java
+++ b/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/AccessTokenServiceTest.java
@@ -31,6 +31,14 @@ import com.baomidou.mybatisplus.core.metadata.IPage;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
 
 public class AccessTokenServiceTest extends SpringUnitTestBase {
 
@@ -39,6 +47,31 @@ public class AccessTokenServiceTest extends SpringUnitTestBase {
 
     @Autowired
     private UserService userService;
+
+    @Test
+    void testOpenApiTokenCanAuthenticate() throws Exception {
+        Long mockUserId = 100001L;
+        RestResponse restResponse = accessTokenService.create(mockUserId, "");
+        AccessToken accessToken = (AccessToken) restResponse.get("data");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set(HttpHeaders.AUTHORIZATION, accessToken.getToken());
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("id", "100000");
+        body.add("teamId", "100000");
+
+        try {
+            ResponseEntity<String> response = new RestTemplate().postForEntity(
+                "http://localhost:10000/openapi/app/start",
+                new HttpEntity<>(body, headers),
+                String.class);
+            Assertions.assertNotEquals(401, response.getStatusCodeValue());
+        } catch (HttpStatusCodeException e) {
+            Assertions.assertNotEquals(401, e.getRawStatusCode());
+        }
+        Assertions.assertTrue(accessTokenService.removeById(accessToken.getId()));
+    }
 
     @Test
     void testCrudToken() throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes OpenAPI token authentication for generated access tokens.

The OpenAPI token is stored as an encrypted JWT. During authentication the request token is already decrypted by `JWTFilter`, so the realm should compare the decrypted stored token with the current credential instead of encrypting the credential again.

Because token encryption uses a random IV, encrypting the same JWT again does not produce the same stored token string, which caused valid OpenAPI requests to be rejected with 401.

## Brief change log

- Compare the decrypted stored OpenAPI token with the current credential in `ShiroRealm`.
- Add a regression test that creates an OpenAPI access token and requests `/openapi/app/start`, verifying the authentication layer no longer returns 401.

## Verifying this change

- Red check before the fix: `AccessTokenServiceTest#testOpenApiTokenCanAuthenticate` failed with `expected: not equal but was: <401>`.
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -pl streampark-console/streampark-console-service -am -Dtest=AccessTokenServiceTest,JWTTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

Closes #4322