### PR TITLE
[ISSUE-4339][Bug] Fix latest savepoint lookup

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkSavepointServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkSavepointServiceImpl.java
@@ -131,6 +131,9 @@ public class FlinkSavepointServiceImpl extends ServiceImpl<FlinkSavepointMapper,
         return this.lambdaQuery()
             .eq(FlinkSavepoint::getAppId, id)
             .eq(FlinkSavepoint::getLatest, true)
+            .orderByDesc(FlinkSavepoint::getTriggerTime)
+            .orderByDesc(FlinkSavepoint::getId)
+            .last("limit 1")
             .one();
     }
 

--- a/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/FlinkSavepointServiceTest.java
+++ b/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/FlinkSavepointServiceTest.java
@@ -26,8 +26,10 @@ import org.apache.streampark.console.core.entity.FlinkApplication;
 import org.apache.streampark.console.core.entity.FlinkApplicationConfig;
 import org.apache.streampark.console.core.entity.FlinkEffective;
 import org.apache.streampark.console.core.entity.FlinkEnv;
+import org.apache.streampark.console.core.entity.FlinkSavepoint;
 import org.apache.streampark.console.core.enums.ConfigFileTypeEnum;
 import org.apache.streampark.console.core.enums.EffectiveTypeEnum;
+import org.apache.streampark.console.core.mapper.FlinkSavepointMapper;
 import org.apache.streampark.console.core.service.application.FlinkApplicationConfigService;
 import org.apache.streampark.console.core.service.application.FlinkApplicationManageService;
 import org.apache.streampark.console.core.service.impl.FlinkSavepointServiceImpl;
@@ -37,6 +39,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
 
 import static org.apache.flink.configuration.CheckpointingOptions.SAVEPOINT_DIRECTORY;
 import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL;
@@ -66,6 +70,9 @@ class FlinkSavepointServiceTest extends SpringUnitTestBase {
     @Autowired
     FlinkApplicationManageService applicationManageService;
 
+    @Autowired
+    private FlinkSavepointMapper savepointMapper;
+
     @AfterEach
     void cleanTestRecordsInDatabase() {
         savepointService.remove(new QueryWrapper<>());
@@ -90,6 +97,19 @@ class FlinkSavepointServiceTest extends SpringUnitTestBase {
         assertThat(savepointServiceImpl.getSavepointFromDynamicProps(props)).isEqualTo("hdfs:///test");
         assertThat(savepointServiceImpl.getSavepointFromDynamicProps(propsWithEmptyTargetValue))
             .isEmpty();
+    }
+
+    @Test
+    void testGetLatestReturnsNewestSavepointWhenDuplicateLatestRecordsExist() {
+        Long appId = 1L;
+        FlinkSavepoint older = latestSavepoint(appId, "hdfs:///older", new Date(1000));
+        FlinkSavepoint newer = latestSavepoint(appId, "hdfs:///newer", new Date(2000));
+        savepointMapper.insert(older);
+        savepointMapper.insert(newer);
+
+        FlinkSavepoint latest = savepointService.getLatest(appId);
+
+        assertThat(latest.getPath()).isEqualTo("hdfs:///newer");
     }
 
     @Test
@@ -189,5 +209,14 @@ class FlinkSavepointServiceTest extends SpringUnitTestBase {
         // Test for it with the configured empty target value
         // Test for it with the configured non-empty target value
 
+    }
+
+    private FlinkSavepoint latestSavepoint(Long appId, String path, Date triggerTime) {
+        FlinkSavepoint savepoint = new FlinkSavepoint();
+        savepoint.setAppId(appId);
+        savepoint.setLatest(true);
+        savepoint.setPath(path);
+        savepoint.setTriggerTime(triggerTime);
+        return savepoint;
     }
 }

--- a/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/FlinkSavepointServiceTest.java
+++ b/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/FlinkSavepointServiceTest.java
@@ -204,11 +204,6 @@ class FlinkSavepointServiceTest extends SpringUnitTestBase {
         assertThatThrownBy(() -> savepointServiceImpl.getSavepointFromDeployLayer(application))
             .isInstanceOf(NullPointerException.class);
 
-        // Ignored.
-        // Test for it with empty config
-        // Test for it with the configured empty target value
-        // Test for it with the configured non-empty target value
-
     }
 
     private FlinkSavepoint latestSavepoint(Long appId, String path, Date triggerTime) {


### PR DESCRIPTION
## What changes were proposed in this pull request

This PR fixes `FlinkSavepointServiceImpl#getLatest` when duplicate `latest = true` savepoint records exist for the same application.

The previous query used `one()`, so MyBatis-Plus called `selectOne()` and threw `TooManyResultsException` if historical data contained more than one latest savepoint. This can make checkpoint polling repeatedly log errors, as reported in #4339.

The query now orders by `triggerTime` and `id` descending and limits the result to one row, so it returns the newest latest savepoint deterministically.

## Brief change log

- Order latest savepoint lookup by `triggerTime` and `id` descending.
- Limit the lookup to one row before calling `one()`.
- Add a regression test for duplicate `latest = true` savepoint records.

## Verifying this change

- Red test before the fix: `FlinkSavepointServiceTest#testGetLatestReturnsNewestSavepointWhenDuplicateLatestRecordsExist` failed with `TooManyResultsException: Expected one result (or null) to be returned by selectOne(), but found: 2`.
- After the fix: `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -pl streampark-console/streampark-console-service -am -Dtest=FlinkSavepointServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Result: `Tests run: 4, Failures: 0, Errors: 0, Skipped: 0`.

Closes #4339.
