### PR TITLE
[ISSUE-4072][Bug] Use SSL when checking alert email

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/SettingServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/SettingServiceImpl.java
@@ -225,14 +225,7 @@ public class SettingServiceImpl extends ServiceImpl<SettingMapper, Setting>
     @Override
     public ResponseResult checkEmail(SenderEmail senderEmail) {
         ResponseResult result = new ResponseResult();
-        Properties props = new Properties();
-        props.put("mail.smtp.auth", "true");
-        if (senderEmail.isSsl()) {
-            props.put("mail.smtp.starttls.enable", "true");
-        }
-        props.put("mail.smtp.host", senderEmail.getHost());
-        props.put("mail.smtp.port", senderEmail.getPort());
-
+        Properties props = buildEmailProperties(senderEmail);
         Session session = Session.getInstance(props);
         try {
             Transport transport = session.getTransport("smtp");
@@ -245,6 +238,17 @@ public class SettingServiceImpl extends ServiceImpl<SettingMapper, Setting>
             result.setMsg("connect to target mail server failed: " + e.getMessage());
         }
         return result;
+    }
+
+    static Properties buildEmailProperties(SenderEmail senderEmail) {
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.host", senderEmail.getHost());
+        props.put("mail.smtp.port", senderEmail.getPort().toString());
+        if (senderEmail.isSsl()) {
+            props.put("mail.smtp.ssl.enable", "true");
+        }
+        return props;
     }
 
     @Override

--- a/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/impl/SettingServiceImplTest.java
+++ b/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/impl/SettingServiceImplTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.console.core.service.impl;
+
+import org.apache.streampark.console.core.bean.SenderEmail;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SettingServiceImplTest {
+
+    @Test
+    void buildEmailPropertiesUsesSslOnConnectWhenSslEnabled() {
+        SenderEmail senderEmail = senderEmail(true);
+
+        Properties properties = SettingServiceImpl.buildEmailProperties(senderEmail);
+
+        assertEquals("true", properties.getProperty("mail.smtp.auth"));
+        assertEquals("smtp.126.com", properties.getProperty("mail.smtp.host"));
+        assertEquals("994", properties.getProperty("mail.smtp.port"));
+        assertEquals("true", properties.getProperty("mail.smtp.ssl.enable"));
+        assertNull(properties.getProperty("mail.smtp.starttls.enable"));
+    }
+
+    @Test
+    void buildEmailPropertiesKeepsPlainSmtpWhenSslDisabled() {
+        SenderEmail senderEmail = senderEmail(false);
+
+        Properties properties = SettingServiceImpl.buildEmailProperties(senderEmail);
+
+        assertEquals("true", properties.getProperty("mail.smtp.auth"));
+        assertEquals("smtp.126.com", properties.getProperty("mail.smtp.host"));
+        assertEquals("994", properties.getProperty("mail.smtp.port"));
+        assertNull(properties.getProperty("mail.smtp.ssl.enable"));
+        assertNull(properties.getProperty("mail.smtp.starttls.enable"));
+    }
+
+    private static SenderEmail senderEmail(boolean ssl) {
+        SenderEmail senderEmail = new SenderEmail();
+        senderEmail.setHost("smtp.126.com");
+        senderEmail.setPort(994);
+        senderEmail.setSsl(ssl);
+        return senderEmail;
+    }
+}


### PR DESCRIPTION
## What changed

This fixes the alert email connection check for SSL SMTP settings.

The actual email sending path uses SSL-on-connect when `SenderEmail.ssl` is enabled, but `SettingServiceImpl.checkEmail` was enabling STARTTLS instead. That makes the check fail for SSL SMTP servers such as the case reported in #4072.

This patch extracts the JavaMail property building and makes `checkEmail` set `mail.smtp.ssl.enable=true` when SSL is selected. Plain SMTP keeps the existing behavior.

## Tests

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -s /tmp/codex-empty-maven-settings.xml \
  -pl streampark-console/streampark-console-service -am \
  -DskipITs -DskipRat -DskipWeb -DfailIfNoTests=false \
  -Dtest=SettingServiceImplTest test
```

Also checked:

```bash
git diff --check
```

I used OpenAI Codex to help inspect the issue and prepare the patch, then reviewed the diff and ran the tests above locally.
