### PR TITLE
[ISSUE-4203][Bug] Preserve quoted program args

### DIFF
--- a/streampark-common/src/main/scala/org/apache/streampark/common/util/FlinkConfigurationUtils.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/util/FlinkConfigurationUtils.scala
@@ -129,9 +129,44 @@ object FlinkConfigurationUtils extends Logger {
   @Nonnull def extractArguments(args: String): List[String] = {
     val programArgs = new ArrayBuffer[String]()
     if (StringUtils.isNotEmpty(args)) {
-      return extractArguments(args.split("\\s+"))
+      return extractArguments(splitQuotedArguments(args).toArray)
     }
     programArgs.toList
+  }
+
+  private[this] def splitQuotedArguments(args: String): List[String] = {
+    val arguments = new ArrayBuffer[String]()
+    val current = new StringBuilder
+    var quote = 0.toChar
+    var escaped = false
+
+    args.foreach {
+      case char if escaped =>
+        current.append(char)
+        escaped = false
+      case '\\' =>
+        current.append('\\')
+        escaped = true
+      case char if quote != 0 =>
+        current.append(char)
+        if (char == quote) {
+          quote = 0.toChar
+        }
+      case char @ ('\'' | '"') =>
+        current.append(char)
+        quote = char
+      case char if char.isWhitespace =>
+        if (current.nonEmpty) {
+          arguments += current.toString()
+          current.clear()
+        }
+      case char =>
+        current.append(char)
+    }
+    if (current.nonEmpty) {
+      arguments += current.toString()
+    }
+    arguments.toList
   }
 
   def extractArguments(array: Array[String]): List[String] = {

--- a/streampark-common/src/test/scala/org/apache/streampark/common/util/PropertiesUtilsTestCase.scala
+++ b/streampark-common/src/test/scala/org/apache/streampark/common/util/PropertiesUtilsTestCase.scala
@@ -43,6 +43,21 @@ class PropertiesUtilsTestCase {
     Assertions.assertTrue(programArgs.contains("username=root"))
   }
 
+  @Test def testExtractProgramArgsKeepsQuotedKeyValueWithSpaces(): Unit = {
+    val args =
+      "kafka_sync_database " +
+        "--kafka_conf properties.sasl.jaas.config='org.apache.flink.kafka.shaded.org.apache.kafka.common.security.plain.PlainLoginModule required username=\"user\" password=\"pass\";' " +
+        "--kafka_conf topic=zmn_bigdata_market_format"
+    val jaasConfig =
+      "properties.sasl.jaas.config=" +
+        "org.apache.flink.kafka.shaded.org.apache.kafka.common.security.plain.PlainLoginModule " +
+        "required username=\"user\" password=\"pass\";"
+
+    val programArgs = FlinkConfigurationUtils.extractArguments(args)
+
+    Assertions.assertTrue(programArgs.contains(jaasConfig))
+  }
+
   @Test def testDynamicProperties(): Unit = {
     val dynamicProperties =
       """


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #4203

This pull request updates `FlinkConfigurationUtils.extractArguments(String)` to split program arguments while preserving quoted segments. This prevents arguments such as Kafka `properties.sasl.jaas.config='... username="user" password="pass";'` from being split into multiple program arguments because of spaces inside the quoted value.

## Brief change log

- Add quote-aware splitting before delegating to the existing `extractArguments(Array[String])` logic.
- Keep existing array-based argument normalization unchanged.
- Add a regression test for Kafka JAAS config values with spaces and nested double quotes.

## Verifying this change

This change added tests and can be verified as follows:

- Added `PropertiesUtilsTestCase#testExtractProgramArgsKeepsQuotedKeyValueWithSpaces`.
- Verified the new test failed before the fix because the JAAS config value was split across multiple arguments.
- Ran locally:

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -s /tmp/codex-empty-maven-settings.xml -pl streampark-common -DskipITs -DskipRat -DfailIfNoTests=false -Dtest=PropertiesUtilsTestCase test
```

Result: `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`.

- Ran the full `streampark-common` test target locally:

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -s /tmp/codex-empty-maven-settings.xml -pl streampark-common -DskipITs -DskipRat -DfailIfNoTests=false test
```

Result: `Tests run: 12, Failures: 0, Errors: 0, Skipped: 0`.

## Does this pull request potentially affect one of the following parts
 - Dependencies (does it add or upgrade a dependency): no
