### PR TITLE
[Build] Add AGENTS.md for AI agent coding conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,239 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Apache StreamPark — Agent Instructions
+
+Project conventions, architecture, and coding patterns for the StreamPark codebase.
+
+## Architecture
+
+### Module Boundaries
+
+StreamPark is a Maven multi-module project with four top-level modules. Each has a clear responsibility boundary.
+
+- **`streampark-common`** (`streampark-common/`): Shared foundation layer. Contains configuration management (`ConfigKeys`, `ConfigOption`), utility classes (`Utils`, `HadoopUtils`, `JsonUtils`, `YarnUtils`), file system abstraction (`FsOperator`, `HdfsOperator`, `LfsOperator`), and shared enums (`FlinkDeployMode`, `ApplicationType`, etc.). Must be engine-agnostic — no Flink or Spark core API dependencies. All other modules depend on this module.
+
+- **`streampark-flink`** (`streampark-flink/`): Flink development framework and runtime integration. Contains the core development API (`FlinkStreaming`, `FlinkTable`, `FlinkSQL`), version-specific shims layers (`streampark-flink-shims_flink-1.xx`), job submission clients (`streampark-flink-client`), Kubernetes integration (`streampark-flink-kubernetes`), application packer (`streampark-flink-packer`), and connectors. The shims proxy (`FlinkShimsProxy`) is the central mechanism for multi-version Flink support.
+
+- **`streampark-spark`** (`streampark-spark/`): Spark development framework. Optional module, activated via `-Pspark` Maven profile. Contains `SparkStreaming`, `SparkBatch` core traits, Spark SQL client, and connectors. Follows the same lifecycle pattern as Flink modules.
+
+- **`streampark-console`** (`streampark-console/`): Web management platform. Contains two submodules:
+  - **`streampark-console-service`**: Spring Boot 2.7 backend, with `base/` (infrastructure), `core/` (business logic, controllers, services), and `system/` (authentication, user/role/team management) packages.
+  - **`streampark-console-webapp`**: Vue 3 + Vite frontend, with `api/` (API layer), `views/` (pages), `components/` (reusable UI), `store/` (Pinia state).
+
+The `streampark-common` module has the strongest stability guarantees — changes here affect all other modules. `streampark-flink/streampark-flink-core` public API (the `FlinkStreaming`, `FlinkTable` traits) should also be treated as stable — breaking changes require careful migration planning.
+
+### High-Sensitivity Areas
+
+- **`FlinkShimsProxy`**: The multi-version classloader isolation mechanism. Uses `ChildFirstClassLoader` to dynamically load version-specific shims JARs. Cached per Flink version. Changes here affect all Flink jobs across all versions. Never introduce static state that could leak across classloader boundaries.
+
+- **`FlinkStreaming` / `FlinkTable` lifecycle**: The `main` -> `init` -> `ready` -> `handle` -> `destroy` lifecycle is the contract all user applications depend on. Changes to the execution order or initialization behavior can break existing applications in production.
+
+- **`ConfigKeys` / `CommonConfig`**: Central configuration key definitions. Adding, removing, or renaming keys affects application configuration files, the console UI, and deployment scripts. Key names must remain backward-compatible.
+
+- **`FlinkApplicationController` / `FlinkApplicationManageService` / `FlinkApplicationActionService`**: The core application management flow. Operations (start, stop, cancel, deploy) must be idempotent and handle all Flink states correctly. The `AppChangeEvent` annotation triggers state synchronization.
+
+- **SQL parsing and validation** (`FlinkSql`, `FlinkSqlService`, `SqlConvertUtils`): SQL validation must be version-aware (Flink 1.12-1.20 have different SQL syntax). The `sql-rev.dict` file handles MySQL-to-PostgreSQL dialect conversion.
+
+- **Kubernetes integration** (`FlinkK8sWatchController`): Uses Caffeine caches (`TrackIdCache`, `JobStatusCache`, `MetricCache`) for tracking K8s-deployed Flink jobs. Cache invalidation and TTL must be correct to avoid stale state.
+
+- **Database schema changes**: All schema changes must have corresponding upgrade scripts in `streampark-console/.../script/upgrade/` for both MySQL and PostgreSQL. The `sql-rev.dict` file must be updated if new SQL dialect differences are introduced.
+
+- **Authentication & Authorization**: `ShiroConfig`, `JWTUtil`, `ShiroRealm` — changes here affect all user access. The `@Permission` annotation and `PermissionAspect` enforce team-level resource isolation. Never weaken RBAC checks.
+
+## Design Patterns
+
+- **Lifecycle trait pattern**: `FlinkStreaming`, `FlinkTable`, `SparkStreaming`, `SparkBatch` all follow the same trait-based lifecycle: `main` -> `init` -> `ready` -> `handle` -> `start` -> `destroy`. Users override `handle()` (required) and optionally `ready()`, `config()`, `destroy()`. Never add mandatory lifecycle methods to existing traits.
+
+- **Shims / Proxy pattern**: `FlinkShimsProxy.proxy(flinkVersion, func)` isolates version-specific Flink API calls behind a `ChildFirstClassLoader`. Each Flink version has its own shims module (`streampark-flink-shims_flink-1.xx`) with the same interface. New shims methods must be added to all version modules.
+
+- **Service layer separation**: Console services are split by responsibility — `FlinkApplicationManageService` (CRUD), `FlinkApplicationActionService` (start/stop/cancel), `FlinkApplicationInfoService` (query/info). Follow this pattern when adding new application operations.
+
+- **Implicit enrichment**: Scala `implicit` conversions are used to extend Flink/Spark APIs (e.g., `DataStreamExt` adds methods to `DataStream`). New implicit conversions must be scoped to avoid polluting the global namespace.
+
+- **MyBatis-Plus entity pattern**: Entities extend `BaseEntity` (auto-fill `createTime`/`modifyTime`). Mappers extend MyBatis-Plus `BaseMapper`. Pagination uses `MybatisPager` + `PaginationInterceptor`. Follow existing patterns rather than introducing new ORM approaches.
+
+- **Enum-based configuration**: Both Java enums (`FlinkDeployMode`, `ApplicationType`) and Scala enumeratum enums (`ApiType`, `PlannerType`) are used. Prefer Scala `enumeratum` for new Scala-side enums — it provides better type safety and serialization.
+
+- **REST response pattern**: All controller methods return `RestResponse.success(data)` or `RestResponse.fail(...)`. Never return raw objects. Use `@Permission` annotation for access control, `@AppChangeEvent` for state-change auditing.
+
+- **File system abstraction**: Use `FsOperator` (with `HdfsOperator` / `LfsOperator` implementations) for file operations. Never use raw `java.io.File` or Hadoop `FileSystem` directly in business logic.
+
+## Coding Conventions
+
+### Java (Backend)
+
+- **Formatting**: Eclipse formatter via Spotless (`tools/checkstyle/spotless_streampark_formatter.xml`). Run `./mvnw spotless:apply` before committing.
+- **Import order**: `org.apache.streampark`, `org.apache.streampark.shaded`, `org.apache`, `javax`, `java`, `scala`, `\#` (all others).
+- **Static checks**: Checkstyle (`tools/checkstyle/checkstyle.xml`) + Spotless. No wildcard imports. No `@author` tags. No JUnit 4 imports.
+- **Lombok**: Use `@Slf4j`, `@Data`, `@Builder` where appropriate. Do not use `@EqualsAndHashCode` on JPA/Hibernate entities.
+- **Testing**: JUnit 5 (`org.junit.jupiter`) + AssertJ. Use `@Test` (not `@Test` from JUnit 4). Use `assertThat(...).isEqualTo(...)` style. Test classes should be in the same package as the code under test.
+- **Package structure**: Controllers in `controller/`, service interfaces in `service/`, implementations in `service/impl/`, entities in `entity/`, mappers in `mapper/`, enums in `enums/`.
+
+### Scala (Framework / Common)
+
+- **Formatting**: Scalafmt 3.7.5 (`tools/checkstyle/.scalafmt.conf`). Max column 160. Run `./mvnw spotless:apply` to format.
+- **Import ordering**: `org.apache.streampark.*` first, then other third-party, then `javax.*`, `java.*`, `scala.*`.
+- **Static checks**: Scalastyle (`tools/checkstyle/scalastyle-config.xml`). No wildcard imports. No `println` statements (use `Logger` trait).
+- **Testing**: ScalaTest 3.2.9. Use `FlatSpec` or `FunSuite` style consistent with existing tests.
+- **Style**: Use `val` over `var`. Prefer `Option` over `null` in public APIs. Use `lazy val` for expensive initialization. Use pattern matching instead of `isInstanceOf`/`asInstanceOf`.
+
+### TypeScript / Vue (Frontend)
+
+- **Formatting**: ESLint + Prettier. Run `pnpm lint:eslint` and `pnpm lint:prettier`.
+- **Vue 3 Composition API**: Use `<script setup lang="ts">` for new components. Use Pinia for state management (not Vuex).
+- **API layer**: All HTTP calls go through `src/api/` modules using `defHttp`. API URLs are defined as enum constants. Never use `axios` or `fetch` directly in components.
+- **Component naming**: PascalCase for component files and names. Use `index.ts` barrel exports in component directories.
+- **Unused variables**: Prefix with `_` to suppress ESLint warnings (`argsIgnorePattern: '^_'`).
+
+### General
+
+- **Apache License header**: Required on all new files. Use the copyright header from `tools/checkstyle/copyright.txt`. Enforced by Spotless and Apache RAT.
+- **No wildcard imports**: Prohibited in both Java and Scala (enforced by Spotless).
+- **No personal pronouns in comments**: Use descriptive, impersonal documentation.
+- **Database**: Support both MySQL and PostgreSQL. All new SQL must be tested against both. Use `sql-rev.dict` for dialect differences.
+- **Logging**: Use Lombok `@Slf4j` (Java) or `Logger` trait (Scala). Use `log.info`/`log.error` with parameterized messages. Never log credentials or sensitive data.
+
+## Commands
+
+- **Full build (backend + frontend, skip tests):**
+  ```shell
+  ./build.sh
+  ```
+  Equivalent to: `./mvnw -Pshaded,webapp,dist -DskipTests clean install`
+
+- **Fast build (backend only, skip all checks):**
+  ```shell
+  ./mvnw -Pfast clean install -DskipTests
+  ```
+
+- **Build with Spark module:**
+  ```shell
+  ./mvnw -Pspark,shaded clean install -DskipTests
+  ```
+
+- **Build backend only:**
+  ```shell
+  ./mvnw clean install -DskipTests -pl '!streampark-console/streampark-console-webapp'
+  ```
+
+- **Run single test class (Java):**
+  ```shell
+  ./mvnw test -pl streampark-console/streampark-console-service -Dtest=FlinkApplicationControllerTest
+  ```
+
+- **Run single test class (Scala):**
+  ```shell
+  ./mvnw test -pl streampark-common -Dtest=org.apache.streampark.common.util.CommandUtilsTest
+  ```
+
+- **Format code (Java + Scala):**
+  ```shell
+  ./mvnw spotless:apply
+  ```
+
+- **Check formatting:**
+  ```shell
+  ./mvnw spotless:check
+  ```
+
+- **Run Checkstyle:**
+  ```shell
+  ./mvnw checkstyle:check
+  ```
+
+- **Frontend development server:**
+  ```shell
+  cd streampark-console/streampark-console-webapp && pnpm dev
+  ```
+
+- **Frontend lint:**
+  ```shell
+  cd streampark-console/streampark-console-webapp && pnpm lint:eslint && pnpm lint:prettier
+  ```
+
+- **Frontend build:**
+  ```shell
+  cd streampark-console/streampark-console-webapp && pnpm build
+  ```
+
+- **Run Docker Compose (local):**
+  ```shell
+  docker compose -f docker/docker-compose.yaml up -d
+  ```
+
+## PR & Commit Conventions
+
+- **PR title format**: `[Module] Description` (e.g., `[Flink] Fix shims classloader isolation`, `[Console] Add team-level resource filtering`, `[Common] Support Hadoop 3.x configuration`).
+- **Module prefixes**: `[Common]`, `[Flink]`, `[Spark]`, `[Console]`, `[K8s]`, `[Docs]`, `[CI]`, `[Build]`.
+- **One concern per PR**: Unrelated whitespace, import, or formatting changes go in separate PRs. Do not mix refactoring with feature work.
+- **Commit messages**: Describe the *what* and *why*, not implementation details. Reference related GitHub issues with `#xxx`.
+- **Apache License header**: Required on all new files (enforced by Spotless and Apache RAT). The `spotless:check` and `apache-rat:check` goals run in CI.
+- **Schema changes**: Must include upgrade scripts for both MySQL and PostgreSQL in `streampark-console/.../script/upgrade/`.
+- **New shims methods**: When adding a new method to the shims interface, add implementations to all version-specific shims modules (`streampark-flink-shims_flink-1.12` through `streampark-flink-shims_flink-1.20`).
+
+## AI-Generated PR Disclosure
+
+Pull requests that are authored or substantially generated by AI agents **must** disclose that in the PR description. When creating a PR description, always include an AI Disclosure block at the bottom. Use the template below and fill in the fields you know. For fields you cannot determine, use `[unknown - human to fill in]`.
+
+See the [ASF generative tooling guidelines](https://www.apache.org/legal/generative-tooling.html) for additional policy on AI-generated contributions. Generated files must still follow StreamPark's Apache License header and license check requirements unless explicitly excluded by project policy. For commits authored using generative AI tooling, include a `Generated-by: <tool>` token in the commit message.
+
+AI-generated review comments **must** be reviewed for accuracy before posting. Auto-posting unreviewed AI comments is discouraged.
+
+### Required Fields
+
+- **Model**: Set this to your model identifier and version (e.g., `Claude Opus 4.6`, `GPT-4o`, `Gemini 2.5 Pro`).
+- **Platform/Tool**: Set this to the tool or platform that orchestrated the generation (e.g., `GitHub Copilot`, `Cursor`, `Aider`, `Claude Code`, `custom script`).
+- **Human Oversight**: Set this to `fully reviewed`, `partially reviewed`, or `unreviewed`. If unknown, use `[unknown - human to fill in]`.
+- **Prompt Summary**: A brief description of the prompt or task given to the agent.
+
+### PR Description Template
+
+Add the following block at the bottom of PR descriptions:
+
+```
+---
+**AI Disclosure**
+- Model: [model name and version]
+- Platform/Tool: [tool or platform name]
+- Human Oversight: [fully reviewed | partially reviewed | unreviewed]
+- Prompt Summary: [brief description of the task]
+```
+
+## Boundaries
+
+### Never Without Explicit Discussion
+
+- **Never** modify `.asf.yaml`, `LICENSE`, `NOTICE`, or `.gitignore` without explicit discussion.
+- **Never** upgrade Flink, Spark, Scala, Spring Boot, or other major dependency versions without discussion — these changes have broad impact across the entire project.
+- **Never** remove or rename keys in `ConfigKeys` or `CommonConfig` — these are user-facing configuration contracts.
+- **Never** change the `FlinkStreaming` / `FlinkTable` lifecycle method signatures — this breaks all user applications.
+- **Never** add new required lifecycle methods to the `FlinkStreaming` / `FlinkTable` traits.
+- **Never** commit secrets, credentials, API keys, or cloud-specific tokens.
+- **Never** introduce a new Flink version shims module without adding the corresponding CI build configuration.
+- **Never** add a new database migration without providing both MySQL and PostgreSQL upgrade scripts.
+- **Never** change the `SqlConvertUtils` dialect conversion logic without testing against both MySQL and PostgreSQL.
+
+### Ask First
+
+- **Ask first** before adding new third-party dependencies — license compatibility with Apache 2.0 matters.
+- **Ask first** before promoting package-private classes/methods to public.
+- **Ask first** before adding new Maven modules or restructuring the module hierarchy.
+- **Ask first** before introducing new Scala implicits in the `common` module — they affect all downstream code.
+- **Ask first** before changing the authentication model (Shiro/JWT/Pac4j configuration).

--- a/streampark-common/src/main/scala/org/apache/streampark/common/conf/FlinkVersion.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/conf/FlinkVersion.scala
@@ -127,6 +127,7 @@ class FlinkVersion(val flinkHome: String) extends Serializable with Logger {
   def checkVersion(throwException: Boolean = true): Boolean = {
     version.split("\\.").map(_.trim.toInt) match {
       case Array(1, v, _) if v >= 12 && v <= 20 => true
+      case Array(2, v, _) if v >= 0 => true
       case _ =>
         if (throwException) {
           throw new UnsupportedOperationException(s"Unsupported flink version: $version")
@@ -139,6 +140,7 @@ class FlinkVersion(val flinkHome: String) extends Serializable with Logger {
   def checkVersion(sinceVersion: Int): Boolean = {
     version.split("\\.").map(_.trim.toInt) match {
       case Array(1, v, _) if v >= sinceVersion => true
+      case Array(2, v, _) if v >= sinceVersion => true
       case _ => false
     }
   }

--- a/streampark-console/streampark-console-service/pom.xml
+++ b/streampark-console/streampark-console-service/pom.xml
@@ -587,6 +587,27 @@
                             <version>${project.version}</version>
                             <outputDirectory>${project.build.directory}/shims</outputDirectory>
                         </dependency>
+                        <!-- flink 2.0 support-->
+                        <dependency>
+                            <groupId>org.apache.streampark</groupId>
+                            <artifactId>streampark-flink-shims_flink-2.0_${scala.binary.version}</artifactId>
+                            <version>${project.version}</version>
+                            <outputDirectory>${project.build.directory}/shims</outputDirectory>
+                        </dependency>
+                        <!-- flink 2.1 support-->
+                        <dependency>
+                            <groupId>org.apache.streampark</groupId>
+                            <artifactId>streampark-flink-shims_flink-2.1_${scala.binary.version}</artifactId>
+                            <version>${project.version}</version>
+                            <outputDirectory>${project.build.directory}/shims</outputDirectory>
+                        </dependency>
+                        <!-- flink 2.2 support-->
+                        <dependency>
+                            <groupId>org.apache.streampark</groupId>
+                            <artifactId>streampark-flink-shims_flink-2.2_${scala.binary.version}</artifactId>
+                            <version>${project.version}</version>
+                            <outputDirectory>${project.build.directory}/shims</outputDirectory>
+                        </dependency>
                         <!-- flink-submit-core -->
                         <dependency>
                             <groupId>org.apache.streampark</groupId>

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvInitializer.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvInitializer.java
@@ -71,7 +71,7 @@ public class EnvInitializer implements ApplicationRunner {
     private final FileFilter fileFilter = p -> !".gitkeep".equals(p.getName());
 
     private static final Pattern PATTERN_FLINK_SHIMS_JAR = Pattern.compile(
-        "^streampark-flink-shims_flink-(1.1[2-9]|1\\.2[0-9])_(2.12)-(.*).jar$",
+        "^streampark-flink-shims_flink-(1\\.1[2-9]|1\\.2[0-9]|2\\.[0-9])_(2\\.12)-(.*).jar$",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     @SneakyThrows

--- a/streampark-flink/streampark-flink-shims/pom.xml
+++ b/streampark-flink/streampark-flink-shims/pom.xml
@@ -41,6 +41,9 @@
         <module>streampark-flink-shims_flink-1.18</module>
         <module>streampark-flink-shims_flink-1.19</module>
         <module>streampark-flink-shims_flink-1.20</module>
+        <module>streampark-flink-shims_flink-2.0</module>
+        <module>streampark-flink-shims_flink-2.1</module>
+        <module>streampark-flink-shims_flink-2.2</module>
     </modules>
 
 </project>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.streampark</groupId>
+        <artifactId>streampark-flink-shims</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>streampark-flink-shims_flink-2.0_${scala.binary.version}</artifactId>
+    <name>StreamPark : Flink Shims 2.0</name>
+
+    <properties>
+        <flink.version>2.0.2</flink.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.streampark</groupId>
+            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Flink 2.x removed Scala DataStream API, use Java API only -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-kubernetes</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-yarn</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-statebackend-rocksdb</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/java/org/apache/streampark/flink/core/StreamEnvConfigFunction.java
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/java/org/apache/streampark/flink/core/StreamEnvConfigFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.ParameterTool;
+
+@FunctionalInterface
+public interface StreamEnvConfigFunction {
+
+    /**
+     * When used to initialize StreamExecutionEnvironment, it can be used to implement this function
+     * and customize the parameters to be set...
+     *
+     * @param environment
+     * @param parameterTool
+     */
+    void configuration(StreamExecutionEnvironment environment, ParameterTool parameterTool);
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/java/org/apache/streampark/flink/core/TableEnvConfigFunction.java
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/java/org/apache/streampark/flink/core/TableEnvConfigFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.util.ParameterTool;
+
+@FunctionalInterface
+public interface TableEnvConfigFunction {
+
+    /**
+     * When used to initialize the TableEnvironment, it can be used to implement this function and
+     * customize the parameters to be set...
+     *
+     * @param tableConfig
+     * @param parameterTool
+     */
+    void configuration(TableConfig tableConfig, ParameterTool parameterTool);
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/EnhancerImplicit.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/EnhancerImplicit.scala
@@ -20,11 +20,10 @@ package org.apache.streampark.flink.core
 import org.apache.streampark.common.conf.ConfigKeys.{KEY_APP_NAME, KEY_FLINK_APP_NAME}
 import org.apache.streampark.common.util.DeflaterUtils
 
-import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.configuration.PipelineOptions
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
-import org.apache.flink.table.api.bridge.scala.{StreamTableEnvironment => ScalaStreamTableEnvironment}
+import org.apache.flink.util.ParameterTool
 
 import scala.util.Try
 
@@ -52,30 +51,19 @@ object EnhancerImplicit {
     private[flink] def setAppName(implicit parameter: ParameterTool): TableEnvironment = {
       val appName = parameter.getAppName()
       if (appName != null) {
-        env.getConfig.getConfiguration.setString(PipelineOptions.NAME, appName)
+        env.getConfig.getConfiguration.setString(PipelineOptions.NAME.key, appName)
       }
       env
     }
 
   }
 
-  implicit class EnhanceStreamExecutionEnvironment(env: ScalaStreamTableEnvironment) {
-
-    private[flink] def setAppName(implicit parameter: ParameterTool): ScalaStreamTableEnvironment = {
-      val appName = parameter.getAppName()
-      if (appName != null) {
-        env.getConfig.getConfiguration.setString(PipelineOptions.NAME, appName)
-      }
-      env
-    }
-  }
-
-  implicit class EnhanceJavaStreamTableEnvironment(env: StreamTableEnvironment) {
+  implicit class EnhanceStreamTableEnvironment(env: StreamTableEnvironment) {
 
     private[flink] def setAppName(implicit parameter: ParameterTool): StreamTableEnvironment = {
       val appName = parameter.getAppName()
       if (appName != null) {
-        env.getConfig.getConfiguration.setString(PipelineOptions.NAME, appName)
+        env.getConfig.getConfiguration.setString(PipelineOptions.NAME.key, appName)
       }
       env
     }

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkClientTrait.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkClientTrait.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.api.common.JobID
+import org.apache.flink.client.program.ClusterClient
+import org.apache.flink.core.execution.SavepointFormatType
+
+import java.util.concurrent.CompletableFuture
+
+abstract class FlinkClientTrait[T](clusterClient: ClusterClient[T]) {
+
+  def triggerSavepoint(
+      jobID: JobID,
+      savepointDir: String,
+      nativeFormat: Boolean = false): CompletableFuture[String] = {
+    clusterClient.triggerSavepoint(jobID, savepointDir, SavepointFormatType.DEFAULT)
+  }
+
+  def cancelWithSavepoint(
+      jobID: JobID,
+      savepointDir: String,
+      nativeFormat: Boolean = false): CompletableFuture[String] = {
+    clusterClient.cancelWithSavepoint(jobID, savepointDir, SavepointFormatType.DEFAULT)
+  }
+
+  def stopWithSavepoint(
+      jobID: JobID,
+      advanceToEndOfEventTime: Boolean,
+      savepointDir: String,
+      nativeFormat: Boolean = false): CompletableFuture[String] =
+    clusterClient.stopWithSavepoint(jobID, advanceToEndOfEventTime, savepointDir, SavepointFormatType.DEFAULT)
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkClusterClient.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkClusterClient.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.api.common.JobID
+import org.apache.flink.client.program.ClusterClient
+import org.apache.flink.core.execution.SavepointFormatType
+
+import java.util.concurrent.CompletableFuture
+
+class FlinkClusterClient[T](clusterClient: ClusterClient[T])
+  extends FlinkClientTrait[T](clusterClient) {
+
+  override def triggerSavepoint(
+      jobID: JobID,
+      savepointDir: String,
+      nativeFormat: Boolean): CompletableFuture[String] = {
+    clusterClient.triggerSavepoint(
+      jobID,
+      savepointDir,
+      if (nativeFormat) SavepointFormatType.NATIVE
+      else SavepointFormatType.CANONICAL)
+  }
+
+  override def cancelWithSavepoint(
+      jobID: JobID,
+      savepointDirectory: String,
+      nativeFormat: Boolean): CompletableFuture[String] = {
+    clusterClient.cancelWithSavepoint(
+      jobID,
+      savepointDirectory,
+      if (nativeFormat) SavepointFormatType.NATIVE
+      else SavepointFormatType.CANONICAL)
+  }
+
+  override def stopWithSavepoint(
+      jobID: JobID,
+      advanceToEndOfEventTime: Boolean,
+      savepointDirectory: String,
+      nativeFormat: Boolean): CompletableFuture[String] = {
+    clusterClient.stopWithSavepoint(
+      jobID,
+      advanceToEndOfEventTime,
+      savepointDirectory,
+      if (nativeFormat) SavepointFormatType.NATIVE
+      else SavepointFormatType.CANONICAL)
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClient.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClient.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService
+
+import java.util.Optional
+
+class FlinkKubernetesClient(kubeClient: FlinkKubeClient)
+  extends FlinkKubernetesClientTrait(kubeClient) {
+
+  override def getService(serviceName: String): Optional[KubernetesService] = {
+    kubeClient.getService(serviceName)
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClientTrait.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClientTrait.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService
+
+import java.util.Optional
+
+abstract class FlinkKubernetesClientTrait(kubeClient: FlinkKubeClient) {
+
+  /**
+   * Get the kubernetes service of the given flink clusterId.
+   *
+   * @param serviceName
+   *   the name of the service
+   * @return
+   *   Return the optional kubernetes service of the specified name.
+   */
+  def getService(serviceName: String): Optional[KubernetesService] =
+    kubeClient.getService(serviceName)
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkSqlExecutor.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkSqlExecutor.scala
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys.KEY_FLINK_SQL
+import org.apache.streampark.common.util.{AssertUtils, Logger}
+import org.apache.streampark.flink.core.SqlCommand._
+
+import org.apache.commons.lang3.StringUtils
+import org.apache.flink.configuration.{Configuration, ExecutionOptions}
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.util.ParameterTool
+
+import java.util
+import java.util.concurrent.locks.ReentrantReadWriteLock
+
+import scala.collection.mutable
+import scala.util.Try
+
+object FlinkSqlExecutor extends Logger {
+
+  private[this] val lock = new ReentrantReadWriteLock().writeLock
+
+  private[streampark] def executeSql(
+      sql: String,
+      parameter: ParameterTool,
+      context: TableEnvironment)(implicit callbackFunc: String => Unit = null): Unit = {
+
+    val flinkSql: String =
+      if (StringUtils.isBlank(sql)) parameter.get(KEY_FLINK_SQL())
+      else parameter.get(sql)
+    require(StringUtils.isNotBlank(flinkSql), "verify failed: flink sql cannot be empty")
+
+    def callback(r: String): Unit = {
+      callbackFunc match {
+        case null => logInfo(r)
+        case x => x(r)
+      }
+    }
+
+    val runMode = parameter.get(ExecutionOptions.RUNTIME_MODE.key())
+
+    var hasInsert = false
+    val statementSet = context.createStatementSet()
+    SqlCommandParser
+      .parseSQL(flinkSql)
+      .foreach(x => {
+        val args = if (x.operands.isEmpty) null else x.operands.head
+        val command = x.command.name
+        x.command match {
+          // For display sql statement result information
+          case SHOW_CATALOGS =>
+            val catalogs = context.listCatalogs
+            callback(s"$command: ${catalogs.mkString("\n")}")
+          case SHOW_CURRENT_CATALOG =>
+            val catalog = context.getCurrentCatalog
+            callback(s"$command: $catalog")
+          case SHOW_DATABASES =>
+            val databases = context.listDatabases
+            callback(s"$command: ${databases.mkString("\n")}")
+          case SHOW_CURRENT_DATABASE =>
+            val database = context.getCurrentDatabase
+            callback(s"$command: $database")
+          case SHOW_TABLES =>
+            val tables =
+              context.listTables().filter(!_.startsWith("UnnamedTable"))
+            callback(s"$command: ${tables.mkString("\n")}")
+          case SHOW_FUNCTIONS =>
+            val functions = context.listUserDefinedFunctions()
+            callback(s"$command: ${functions.mkString("\n")}")
+          case SHOW_MODULES =>
+            val modules = context.listModules()
+            callback(s"$command: ${modules.mkString("\n")}")
+          case DESC | DESCRIBE =>
+            val schema = context.scan(args).getSchema
+            val builder = new mutable.StringBuilder()
+            builder.append("Column\tType\n")
+            for (i <- 0 to schema.getFieldCount) {
+              builder.append(
+                schema.getFieldName(i).get() + "\t" + schema
+                  .getFieldDataType(i)
+                  .get() + "\n")
+            }
+            callback(builder.toString())
+          case EXPLAIN =>
+            val tableResult = context.executeSql(x.originSql)
+            val r = tableResult.collect().next().getField(0).toString
+            callback(r)
+          // For specific statement, such as: SET/RESET/INSERT/SELECT
+          case SET =>
+            val operand = x.operands(1)
+            logInfo(s"$command: $args --> $operand")
+            context.getConfig.getConfiguration.setString(args, operand)
+          case RESET | RESET_ALL =>
+            val confDataField =
+              classOf[Configuration].getDeclaredField("confData")
+            confDataField.setAccessible(true)
+            val confData = confDataField
+              .get(context.getConfig.getConfiguration)
+              .asInstanceOf[util.HashMap[String, AnyRef]]
+            confData.synchronized {
+              if (x.command == RESET) {
+                confData.remove(args)
+              } else {
+                confData.clear()
+              }
+            }
+            logInfo(s"$command: $args")
+          case BEGIN_STATEMENT_SET | END_STATEMENT_SET =>
+            logWarn(s"SQL Client Syntax: ${x.command.name} ")
+          case INSERT =>
+            statementSet.addInsertSql(x.originSql)
+            hasInsert = true
+          case SELECT =>
+            logError("StreamPark dose not support 'SELECT' statement now!")
+            throw new RuntimeException("StreamPark dose not support 'select' statement now!")
+          case DELETE | UPDATE =>
+            AssertUtils.required(
+              runMode != "STREAMING",
+              s"Currently, ${command.toUpperCase()} statement only supports in batch mode, " +
+                s"and it requires the target table connector implements the SupportsRowLevelDelete, " +
+                s"For more details please refer to: https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/dev/table/sql/$command")
+          case _ =>
+            try {
+              lock.lock()
+              val result = context.executeSql(x.originSql)
+              logInfo(s"$command:$args")
+            } finally {
+              if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+              }
+            }
+        }
+      })
+
+    if (hasInsert) {
+      statementSet.execute() match {
+        case t if t != null =>
+          Try(t.getJobClient.get.getJobID).getOrElse(null) match {
+            case x if x != null => logInfo(s"jobId:$x")
+            case _ =>
+          }
+        case _ =>
+      }
+    } else {
+      logError("No 'INSERT' statement to trigger the execution of the Flink job.")
+      throw new RuntimeException("No 'INSERT' statement to trigger the execution of the Flink job.")
+    }
+
+    logInfo(
+      s"\n\n\n==============flinkSql==============\n\n $flinkSql\n\n============================\n\n\n")
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkSqlValidator.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkSqlValidator.scala
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.enums.FlinkSqlValidationFailedType
+import org.apache.streampark.common.util.{ExceptionUtils, Logger}
+import org.apache.streampark.flink.core.SqlCommand._
+
+import org.apache.calcite.config.Lex
+import org.apache.calcite.sql.parser.SqlParser
+import org.apache.calcite.sql.parser.SqlParser.Config
+import org.apache.flink.sql.parser.validate.FlinkSqlConformance
+import org.apache.flink.table.api.SqlDialect
+import org.apache.flink.table.api.SqlDialect.{DEFAULT, HIVE}
+import org.apache.flink.table.api.config.TableConfigOptions
+import org.apache.flink.table.planner.delegation.FlinkSqlParserFactories
+
+import scala.language.existentials
+import scala.util.{Failure, Try}
+
+object FlinkSqlValidator extends Logger {
+
+  private[this] val FLINK112_CALCITE_PARSER_CLASS =
+    "org.apache.flink.table.planner.calcite.CalciteParser"
+
+  private[this] val FLINK113_PLUS_CALCITE_PARSER_CLASS =
+    "org.apache.flink.table.planner.parse.CalciteParser"
+
+  private[this] val SYNTAX_ERROR_REGEXP =
+    ".*at\\sline\\s(\\d+),\\scolumn\\s(\\d+).*".r
+
+  private[this] lazy val sqlParserConfigMap: Map[String, SqlParser.Config] = {
+    def getConfig(sqlDialect: SqlDialect): Config = {
+      val conformance = sqlDialect match {
+        case HIVE =>
+          try {
+            FlinkSqlConformance.DEFAULT
+          } catch {
+            // for flink 1.18+
+            case _: NoSuchFieldError => FlinkSqlConformance.DEFAULT
+            case e: Throwable =>
+              throw new IllegalArgumentException("Init Flink sql Dialect error: ", e)
+          }
+        case DEFAULT => FlinkSqlConformance.DEFAULT
+        case _ =>
+          throw new UnsupportedOperationException(s"Unsupported sqlDialect: $sqlDialect")
+      }
+      SqlParser.config
+        .withParserFactory(FlinkSqlParserFactories.create(conformance))
+        .withConformance(conformance)
+        .withLex(Lex.JAVA)
+        .withIdentifierMaxLength(256)
+    }
+
+    Map(
+      SqlDialect.DEFAULT.name() -> getConfig(SqlDialect.DEFAULT),
+      SqlDialect.HIVE.name() -> getConfig(SqlDialect.HIVE))
+  }
+
+  def verifySql(sql: String): FlinkSqlValidationResult = {
+    val sqlCommands = SqlCommandParser.parseSQL(sql, r => return r)
+    var sqlDialect = SqlDialect.DEFAULT.name().toLowerCase()
+    var hasInsert = false
+    for (call <- sqlCommands) {
+      val args = call.operands.head
+      val command = call.command
+      command match {
+        case SET | RESET =>
+          if (command == SET && args == TableConfigOptions.TABLE_SQL_DIALECT.key()) {
+            sqlDialect = call.operands.last
+          }
+        case BEGIN_STATEMENT_SET | END_STATEMENT_SET =>
+          logWarn(s"SQL Client Syntax: ${call.command.name} ")
+        case _ =>
+          if (command == INSERT) {
+            hasInsert = true
+          }
+          Try {
+            val calciteClass = Try(Class.forName(FLINK112_CALCITE_PARSER_CLASS))
+              .getOrElse(Class.forName(FLINK113_PLUS_CALCITE_PARSER_CLASS))
+            sqlDialect.toUpperCase() match {
+              case "HIVE" =>
+              case "DEFAULT" =>
+                val parser = calciteClass
+                  .getConstructor(Array(classOf[Config]): _*)
+                  .newInstance(sqlParserConfigMap(sqlDialect.toUpperCase()))
+                val method =
+                  parser.getClass.getDeclaredMethod("parse", classOf[String])
+                method.setAccessible(true)
+                method.invoke(parser, call.originSql)
+              case _ =>
+                throw new UnsupportedOperationException(s"unsupported dialect: $sqlDialect")
+            }
+          } match {
+            case Failure(e) =>
+              val exception = ExceptionUtils.stringifyException(e)
+              val causedBy = exception.drop(exception.indexOf("Caused by:"))
+              val cleanUpError = exception.replaceAll("[\r\n]", "")
+              if (SYNTAX_ERROR_REGEXP.findAllMatchIn(cleanUpError).nonEmpty) {
+                val SYNTAX_ERROR_REGEXP(line, column) = cleanUpError
+                val errorLine = call.lineStart + line.toInt - 1
+                return FlinkSqlValidationResult(
+                  success = false,
+                  failedType = FlinkSqlValidationFailedType.SYNTAX_ERROR,
+                  lineStart = call.lineStart,
+                  lineEnd = call.lineEnd,
+                  errorLine = errorLine,
+                  errorColumn = column.toInt,
+                  sql = call.originSql,
+                  exception = causedBy.replaceAll(s"at\\sline\\s$line", s"at line $errorLine"))
+              } else {
+                return FlinkSqlValidationResult(
+                  success = false,
+                  failedType = FlinkSqlValidationFailedType.SYNTAX_ERROR,
+                  lineStart = call.lineStart,
+                  lineEnd = call.lineEnd,
+                  sql = call.originSql,
+                  exception = causedBy)
+              }
+            case _ =>
+          }
+      }
+    }
+
+    if (hasInsert) {
+      FlinkSqlValidationResult()
+    } else {
+      FlinkSqlValidationResult(
+        success = false,
+        failedType = FlinkSqlValidationFailedType.SYNTAX_ERROR,
+        lineStart = sqlCommands.head.lineStart,
+        lineEnd = sqlCommands.last.lineEnd,
+        exception = "No 'INSERT' statement to trigger the execution of the Flink job.")
+    }
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkStreamTableTraitV2.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkStreamTableTraitV2.scala
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Implicits.JavaList
+import org.apache.streampark.common.util.Utils
+import org.apache.streampark.flink.core.EnhancerImplicit._
+
+import org.apache.flink.api.common.{JobExecutionResult, RuntimeExecutionMode}
+import org.apache.flink.api.common.cache.DistributedCache
+import org.apache.flink.api.common.eventtime.WatermarkStrategy
+import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFormat}
+import org.apache.flink.api.connector.source.{Source, SourceSplit}
+import org.apache.flink.api.java.tuple
+import org.apache.flink.configuration.ReadableConfig
+import org.apache.flink.core.execution.{JobClient, JobListener}
+import org.apache.flink.streaming.api.CheckpointingMode
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.{CheckpointConfig, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.functions.source.FileProcessingMode
+import org.apache.flink.streaming.api.graph.StreamGraph
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.table.catalog.Catalog
+import org.apache.flink.table.functions._
+import org.apache.flink.table.module.Module
+import org.apache.flink.types.Row
+import org.apache.flink.util.{ParameterTool, SplittableIterator}
+
+import java.util.Optional
+
+/**
+ * Integration api of stream and table for Flink 2.x (using Java DataStream API instead of removed Scala API).
+ *
+ * @param parameter
+ *   parameter
+ * @param streamEnv
+ *   streamEnv
+ * @param tableEnv
+ *   tableEnv
+ */
+abstract class FlinkStreamTableTraitV2(
+    val parameter: ParameterTool,
+    private val streamEnv: StreamExecutionEnvironment,
+    private val tableEnv: StreamTableEnvironment)
+  extends StreamTableEnvironment {
+
+  /**
+   * Once a Table has been converted to a DataStream, the DataStream job must be executed using the
+   * execute method of the StreamExecutionEnvironment.
+   */
+  var isConvertedToDataStream: Boolean = false
+
+  /** Recommended to use this Api to start tasks */
+  def start(name: String = null): JobExecutionResult = {
+    val appName = parameter.getAppName(name, true)
+    execute(appName)
+  }
+
+  @deprecated def execute(jobName: String): JobExecutionResult = {
+    Utils.printLogo(s"FlinkStreamTable $jobName Starting...")
+    if (isConvertedToDataStream) {
+      streamEnv.execute(jobName)
+    } else null
+  }
+
+  def sql(sql: String = null)(implicit callback: String => Unit = null): Unit =
+    FlinkSqlExecutor.executeSql(sql, parameter, this)
+
+  // ...streamEnv api start...
+
+  def $getCachedFiles: JavaList[tuple.Tuple2[String, DistributedCache.DistributedCacheEntry]] =
+    this.streamEnv.getCachedFiles
+
+  def $getJobListeners: JavaList[JobListener] = this.streamEnv.getJobListeners
+
+  def $setParallelism(parallelism: Int): Unit =
+    this.streamEnv.setParallelism(parallelism)
+
+  def $setRuntimeMode(deployMode: RuntimeExecutionMode): StreamExecutionEnvironment =
+    this.streamEnv.setRuntimeMode(deployMode)
+
+  def $setMaxParallelism(maxParallelism: Int): Unit =
+    this.streamEnv.setMaxParallelism(maxParallelism)
+
+  def $getParallelism: Int = this.streamEnv.getParallelism
+
+  def $getMaxParallelism: Int = this.streamEnv.getMaxParallelism
+
+  def $setBufferTimeout(timeoutMillis: Long): StreamExecutionEnvironment =
+    this.streamEnv.setBufferTimeout(timeoutMillis)
+
+  def $getBufferTimeout: Long = this.streamEnv.getBufferTimeout
+
+  def $disableOperatorChaining(): StreamExecutionEnvironment =
+    this.streamEnv.disableOperatorChaining()
+
+  def $getCheckpointConfig: CheckpointConfig =
+    this.streamEnv.getCheckpointConfig
+
+  def $enableCheckpointing(interval: Long, mode: CheckpointingMode): StreamExecutionEnvironment =
+    this.streamEnv.enableCheckpointing(interval, mode)
+
+  def $enableCheckpointing(interval: Long): StreamExecutionEnvironment =
+    this.streamEnv.enableCheckpointing(interval)
+
+  def $getCheckpointingMode: CheckpointingMode =
+    this.streamEnv.getCheckpointingMode
+
+  def $configure(configuration: ReadableConfig, classLoader: ClassLoader): Unit =
+    this.streamEnv.configure(configuration, classLoader)
+
+  def $fromSequence(from: Long, to: Long): DataStream[java.lang.Long] =
+    this.streamEnv.fromSequence(from, to)
+
+  // fromData with varargs removed in Flink 2.0
+  def $fromData[T](data: T): DataStream[T] =
+    this.streamEnv.fromData(data)
+
+  def $fromCollection[T](data: java.util.Collection[T]): DataStream[T] =
+    this.streamEnv.fromCollection(data)
+
+  def $fromParallelCollection[T](data: SplittableIterator[T], clazz: Class[T]): DataStream[T] =
+    this.streamEnv.fromParallelCollection(data, clazz)
+
+  def $readFile[T](inputFormat: FileInputFormat[T], filePath: String): DataStream[T] =
+    this.streamEnv.readFile(inputFormat, filePath)
+
+  def $readFile[T](
+      inputFormat: FileInputFormat[T],
+      filePath: String,
+      watchType: FileProcessingMode,
+      interval: Long): DataStream[T] =
+    this.streamEnv.readFile(inputFormat, filePath, watchType, interval)
+
+  def $socketTextStream(
+      hostname: String,
+      port: Int,
+      delimiter: Char,
+      maxRetry: Long): DataStream[String] =
+    this.streamEnv.socketTextStream(hostname, port, delimiter, maxRetry)
+
+  def $createInput[T](inputFormat: InputFormat[T, _]): DataStream[T] =
+    this.streamEnv.createInput(inputFormat)
+
+  def $fromSource[T](
+      source: Source[T, _ <: SourceSplit, _],
+      watermarkStrategy: WatermarkStrategy[T],
+      sourceName: String): DataStream[T] =
+    this.streamEnv.fromSource(source, watermarkStrategy, sourceName)
+
+  def $registerJobListener(jobListener: JobListener): Unit =
+    this.streamEnv.registerJobListener(jobListener)
+
+  def $clearJobListeners(): Unit = this.streamEnv.clearJobListeners()
+
+  def $executeAsync(): JobClient = this.streamEnv.executeAsync()
+
+  def $executeAsync(jobName: String): JobClient =
+    this.streamEnv.executeAsync(jobName)
+
+  def $getExecutionPlan: String = this.streamEnv.getExecutionPlan
+
+  def $getStreamGraph: StreamGraph = this.streamEnv.getStreamGraph
+
+  def $registerCachedFile(filePath: String, name: String): Unit =
+    this.streamEnv.registerCachedFile(filePath, name)
+
+  def $registerCachedFile(filePath: String, name: String, executable: Boolean): Unit =
+    this.streamEnv.registerCachedFile(filePath, name, executable)
+
+  def $isUnalignedCheckpointsEnabled: Boolean =
+    this.streamEnv.isUnalignedCheckpointsEnabled
+
+  def $isForceUnalignedCheckpoints: Boolean =
+    this.streamEnv.isForceUnalignedCheckpoints
+
+  @deprecated def $readFile[T](
+      inputFormat: FileInputFormat[T],
+      filePath: String,
+      watchType: FileProcessingMode,
+      interval: Long,
+      filter: FilePathFilter): DataStream[T] =
+    this.streamEnv.readFile(inputFormat, filePath, watchType, interval, filter)
+
+  // ...streamEnv api end...
+
+  override def fromDataStream[T](dataStream: DataStream[T]): Table =
+    tableEnv.fromDataStream(dataStream)
+
+  override def fromDataStream[T](dataStream: DataStream[T], schema: Schema): Table =
+    tableEnv.fromDataStream(dataStream, schema)
+
+  override def fromChangelogStream(dataStream: DataStream[Row]): Table =
+    tableEnv.fromChangelogStream(dataStream)
+
+  override def fromChangelogStream(dataStream: DataStream[Row], schema: Schema): Table =
+    tableEnv.fromChangelogStream(dataStream, schema)
+
+  override def fromChangelogStream(
+      dataStream: DataStream[Row],
+      schema: Schema,
+      changelogMode: org.apache.flink.table.connector.ChangelogMode): Table =
+    tableEnv.fromChangelogStream(dataStream, schema, changelogMode)
+
+  override def createTemporaryView[T](path: String, dataStream: DataStream[T]): Unit =
+    tableEnv.createTemporaryView(path, dataStream)
+
+  override def createTemporaryView[T](
+      path: String,
+      dataStream: DataStream[T],
+      schema: Schema): Unit =
+    tableEnv.createTemporaryView(path, dataStream, schema)
+
+  override def toDataStream(table: Table): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table)
+  }
+
+  override def toDataStream[T](table: Table, targetClass: Class[T]): DataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table, targetClass)
+  }
+
+  override def toDataStream[T](
+      table: Table,
+      targetDataType: org.apache.flink.table.types.AbstractDataType[_]): DataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table, targetDataType)
+  }
+
+  override def toChangelogStream(table: Table): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table)
+  }
+
+  override def toChangelogStream(table: Table, targetSchema: Schema): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema)
+  }
+
+  override def toChangelogStream(
+      table: Table,
+      targetSchema: Schema,
+      changelogMode: org.apache.flink.table.connector.ChangelogMode): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema, changelogMode)
+  }
+
+  override def createStatementSet(): org.apache.flink.table.api.bridge.java.StreamStatementSet =
+    tableEnv.createStatementSet()
+
+  // ...table env delegation...
+
+  override def fromValues(values: org.apache.flink.table.expressions.Expression*): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(
+      rowType: org.apache.flink.table.types.AbstractDataType[_],
+      values: org.apache.flink.table.expressions.Expression*): Table =
+    tableEnv.fromValues(rowType, values: _*)
+
+  override def fromValues(values: java.lang.Iterable[_]): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(
+      rowType: org.apache.flink.table.types.AbstractDataType[_],
+      values: java.lang.Iterable[_]): Table =
+    tableEnv.fromValues(rowType, values)
+
+  override def registerCatalog(catalogName: String, catalog: Catalog): Unit =
+    tableEnv.registerCatalog(catalogName, catalog)
+
+  override def getCatalog(catalogName: String): Optional[Catalog] =
+    tableEnv.getCatalog(catalogName)
+
+  override def loadModule(moduleName: String, module: Module): Unit =
+    tableEnv.loadModule(moduleName, module)
+
+  override def unloadModule(moduleName: String): Unit =
+    tableEnv.unloadModule(moduleName)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionClass)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionInstance)
+
+  override def dropTemporarySystemFunction(name: String): Boolean =
+    tableEnv.dropTemporarySystemFunction(name)
+
+  override def createFunction(path: String, functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def createFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def dropFunction(path: String): Boolean = tableEnv.dropFunction(path)
+
+  override def createTemporaryFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporaryFunction(path, functionClass)
+
+  override def createTemporaryFunction(path: String, functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporaryFunction(path, functionInstance)
+
+  override def dropTemporaryFunction(path: String): Boolean =
+    tableEnv.dropTemporaryFunction(path)
+
+  override def createTemporaryView(path: String, view: Table): Unit =
+    tableEnv.createTemporaryView(path, view)
+
+  override def from(path: String): Table = tableEnv.from(path)
+
+  override def listCatalogs(): Array[String] = tableEnv.listCatalogs()
+
+  override def listModules(): Array[String] = tableEnv.listModules()
+
+  override def listDatabases(): Array[String] = tableEnv.listDatabases()
+
+  override def listTables(): Array[String] = tableEnv.listTables()
+
+  override def listViews(): Array[String] = tableEnv.listViews()
+
+  override def listTemporaryTables(): Array[String] =
+    tableEnv.listTemporaryTables
+
+  override def listTemporaryViews(): Array[String] =
+    tableEnv.listTemporaryViews()
+
+  override def listUserDefinedFunctions(): Array[String] =
+    tableEnv.listUserDefinedFunctions()
+
+  override def listFunctions(): Array[String] = tableEnv.listFunctions()
+
+  override def dropTemporaryTable(path: String): Boolean =
+    tableEnv.dropTemporaryTable(path)
+
+  override def dropTemporaryView(path: String): Boolean =
+    tableEnv.dropTemporaryView(path)
+
+  override def explainSql(statement: String, extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, extraDetails: _*)
+
+  override def sqlQuery(query: String): Table = tableEnv.sqlQuery(query)
+
+  override def executeSql(statement: String): TableResult =
+    tableEnv.executeSql(statement)
+
+  override def getCurrentCatalog: String = tableEnv.getCurrentCatalog
+
+  override def useCatalog(catalogName: String): Unit =
+    tableEnv.useCatalog(catalogName)
+
+  override def getCurrentDatabase: String = tableEnv.getCurrentDatabase
+
+  override def useDatabase(databaseName: String): Unit =
+    tableEnv.useDatabase(databaseName)
+
+  override def getConfig: TableConfig = tableEnv.getConfig
+
+  @deprecated override def registerFunction(name: String, function: ScalarFunction): Unit =
+    tableEnv.registerFunction(name, function)
+
+  @deprecated override def registerTable(name: String, table: Table): Unit =
+    tableEnv.registerTable(name, table)
+
+  @deprecated override def scan(tablePath: String*): Table =
+    tableEnv.scan(tablePath: _*)
+
+  @deprecated override def getCompletionHints(statement: String, position: Int): Array[String] =
+    tableEnv.getCompletionHints(statement, position)
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializerV2.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializerV2.scala
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys._
+import org.apache.streampark.common.enums.ApiType
+import org.apache.streampark.common.enums.ApiType.ApiType
+import org.apache.streampark.common.util._
+import org.apache.streampark.common.util.Implicits._
+import org.apache.streampark.flink.core.conf.FlinkConfiguration
+
+import collection.{mutable, Map}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.util.ParameterTool
+
+import java.io.File
+
+private[flink] object FlinkStreamingInitializerV2 {
+
+  def initialize(
+      args: Array[String],
+      config: (StreamExecutionEnvironment, ParameterTool) => Unit): (ParameterTool, StreamExecutionEnvironment) = {
+    val flinkInitializer = new FlinkStreamingInitializerV2(args, ApiType.SCALA)
+    flinkInitializer.streamEnvConfFunc = config
+    (flinkInitializer.configuration.parameter, flinkInitializer.streamEnv)
+  }
+
+  def initialize(args: StreamEnvConfig): (ParameterTool, StreamExecutionEnvironment) = {
+    val flinkInitializer =
+      new FlinkStreamingInitializerV2(args.args, ApiType.JAVA)
+    flinkInitializer.javaStreamEnvConfFunc = args.conf
+    (flinkInitializer.configuration.parameter, flinkInitializer.streamEnv)
+  }
+}
+
+private[flink] class FlinkStreamingInitializerV2(args: Array[String], apiType: ApiType)
+  extends Logger {
+
+  var streamEnvConfFunc: (StreamExecutionEnvironment, ParameterTool) => Unit = _
+
+  var tableConfFunc: (TableConfig, ParameterTool) => Unit = _
+
+  var javaStreamEnvConfFunc: StreamEnvConfigFunction = _
+
+  var javaTableEnvConfFunc: TableEnvConfigFunction = _
+
+  implicit private[flink] val parameter: ParameterTool = configuration.parameter
+
+  lazy val streamEnv: StreamExecutionEnvironment = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment(configuration.envConfig)
+
+    apiType match {
+      case ApiType.JAVA if javaStreamEnvConfFunc != null =>
+        javaStreamEnvConfFunc.configuration(env, configuration.parameter)
+      case ApiType.SCALA if streamEnvConfFunc != null =>
+        streamEnvConfFunc(env, configuration.parameter)
+      case _ =>
+    }
+    env.getConfig.setGlobalJobParameters(configuration.parameter)
+    env
+  }
+
+  lazy val configuration: FlinkConfiguration = initParameter()
+
+  def initParameter(): FlinkConfiguration = {
+    val argsMap = ParameterTool.fromArgs(args)
+    val config = argsMap.get(KEY_APP_CONF(), null) match {
+      case null | "" =>
+        throw new ExceptionInInitializerError(
+          "[StreamPark] Usage:can't find config,please set \"--conf $path \" in main arguments")
+      case file => file
+    }
+    val configMap = parseConfig(config)
+    val properConf = extractConfigByPrefix(configMap, KEY_FLINK_PROPERTY_PREFIX)
+    val appConf = extractConfigByPrefix(configMap, KEY_APP_PREFIX)
+
+    // config priority: explicitly specified priority > project profiles > system profiles
+    val parameter = ParameterTool
+      .fromSystemProperties()
+      .mergeWith(ParameterTool.fromMap(properConf))
+      .mergeWith(ParameterTool.fromMap(appConf))
+      .mergeWith(argsMap)
+
+    val envConfig = Configuration.fromMap(properConf)
+    FlinkConfiguration(parameter, envConfig, null)
+  }
+
+  def parseConfig(config: String): Map[String, String] = {
+
+    lazy val content = DeflaterUtils.unzipString(config.drop(7))
+
+    def readConfig(text: String): Map[String, String] = {
+      val format = config.split("\\.").last.toLowerCase
+      format match {
+        case "yml" | "yaml" => PropertiesUtils.fromYamlText(text)
+        case "conf" => PropertiesUtils.fromHoconText(text)
+        case "properties" => PropertiesUtils.fromPropertiesText(text)
+        case _ =>
+          throw new IllegalArgumentException(
+            "[StreamPark] Usage: application config file error,must be [yaml|conf|properties]")
+      }
+    }
+
+    val map = config match {
+      case x if x.startsWith("yaml://") => PropertiesUtils.fromYamlText(content)
+      case x if x.startsWith("conf://") =>
+        PropertiesUtils.fromHoconText(content)
+      case x if x.startsWith("prop://") =>
+        PropertiesUtils.fromPropertiesText(content)
+      case x if x.startsWith("hdfs://") =>
+        // If the configuration file with the hdfs, user will need to copy the hdfs-related configuration files under the resources dir
+        val text = HdfsUtils.read(x)
+        readConfig(text)
+      case _ =>
+        val configFile = new File(config)
+        require(
+          configFile.exists(),
+          s"[StreamPark] Usage: application config file: $configFile is not found!!!")
+        val text = FileUtils.readFile(configFile)
+        readConfig(text)
+    }
+    map.filter(_._2.nonEmpty)
+  }
+
+  def extractConfigByPrefix(configMap: Map[String, String], prefix: String): Map[String, String] = {
+    val map = mutable.Map[String, String]()
+    configMap.foreach(x =>
+      if (x._1.startsWith(prefix)) {
+        map += x._1.drop(prefix.length) -> x._2
+      })
+    map
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkTableInitializerV2.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkTableInitializerV2.scala
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys._
+import org.apache.streampark.common.enums.{ApiType, PlannerType}
+import org.apache.streampark.common.enums.ApiType.ApiType
+import org.apache.streampark.common.util.{DeflaterUtils, PropertiesUtils}
+import org.apache.streampark.common.util.Implicits._
+import org.apache.streampark.flink.core.EnhancerImplicit._
+import org.apache.streampark.flink.core.conf.FlinkConfiguration
+
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.{EnvironmentSettings, TableConfig, TableEnvironment}
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.util.ParameterTool
+
+import java.io.File
+
+import scala.collection.{mutable, Map}
+import scala.util.{Failure, Success, Try}
+
+private[flink] object FlinkTableInitializerV2 {
+
+  def initialize(
+      args: Array[String],
+      config: (TableConfig, ParameterTool) => Unit): (ParameterTool, TableEnvironment) = {
+    val flinkInitializer = new FlinkTableInitializerV2(args, ApiType.SCALA)
+    flinkInitializer.tableConfFunc = config
+    (flinkInitializer.configuration.parameter, flinkInitializer.tableEnv)
+  }
+
+  def initialize(args: TableEnvConfig): (ParameterTool, TableEnvironment) = {
+    val flinkInitializer = new FlinkTableInitializerV2(args.args, ApiType.JAVA)
+    flinkInitializer.javaTableEnvConfFunc = args.conf
+    (flinkInitializer.configuration.parameter, flinkInitializer.tableEnv)
+  }
+
+  def initialize(
+      args: Array[String],
+      configStream: (StreamExecutionEnvironment, ParameterTool) => Unit,
+      configTable: (TableConfig, ParameterTool) => Unit): (ParameterTool, StreamExecutionEnvironment, StreamTableEnvironment) = {
+
+    val flinkInitializer = new FlinkTableInitializerV2(args, ApiType.SCALA)
+    flinkInitializer.streamEnvConfFunc = configStream
+    flinkInitializer.tableConfFunc = configTable
+    (
+      flinkInitializer.configuration.parameter,
+      flinkInitializer.streamEnv,
+      flinkInitializer.streamTableEnv)
+  }
+
+  def initialize(
+      args: StreamTableEnvConfig): (ParameterTool, StreamExecutionEnvironment, StreamTableEnvironment) = {
+    val flinkInitializer = new FlinkTableInitializerV2(args.args, ApiType.JAVA)
+    flinkInitializer.javaStreamEnvConfFunc = args.streamConfig
+    flinkInitializer.javaTableEnvConfFunc = args.tableConfig
+    (
+      flinkInitializer.configuration.parameter,
+      flinkInitializer.streamEnv,
+      flinkInitializer.streamTableEnv)
+  }
+
+}
+
+private[flink] class FlinkTableInitializerV2(args: Array[String], apiType: ApiType)
+  extends FlinkStreamingInitializerV2(args, apiType) {
+
+  private[this] lazy val envSettings = {
+
+    val builder = EnvironmentSettings.newInstance()
+
+    Try(PlannerType.withName(parameter.get(KEY_FLINK_TABLE_PLANNER)))
+      .getOrElse(PlannerType.BLINK) match {
+      case PlannerType.BLINK =>
+        val useBlinkPlanner =
+          Try(builder.getClass.getDeclaredMethod("useBlinkPlanner"))
+            .getOrElse(null)
+        if (useBlinkPlanner == null) {
+          logWarn("useBlinkPlanner deprecated")
+        } else {
+          useBlinkPlanner.setAccessible(true)
+          useBlinkPlanner.invoke(builder)
+          logInfo("blinkPlanner will be used.")
+        }
+      case PlannerType.OLD =>
+        val useOldPlanner = Try(builder.getClass.getDeclaredMethod("useOldPlanner")).getOrElse(null)
+        if (useOldPlanner == null) {
+          logWarn("useOldPlanner deprecated")
+        } else {
+          useOldPlanner.setAccessible(true)
+          useOldPlanner.invoke(builder)
+          logInfo("useOldPlanner will be used.")
+        }
+      case PlannerType.ANY =>
+        val useAnyPlanner = Try(builder.getClass.getDeclaredMethod("useAnyPlanner")).getOrElse(null)
+        if (useAnyPlanner == null) {
+          logWarn("useAnyPlanner deprecated")
+        } else {
+          logInfo("useAnyPlanner will be used.")
+          useAnyPlanner.setAccessible(true)
+          useAnyPlanner.invoke(builder)
+        }
+    }
+
+    parameter.get(KEY_FLINK_CONF(), null) match {
+      case null | "" =>
+        throw new ExceptionInInitializerError(
+          "[StreamPark] Usage:can't find config,please set \"--flink.conf $conf \" in main arguments")
+      case conf => builder.withConfiguration(
+          Configuration.fromMap(PropertiesUtils.fromYamlText(DeflaterUtils.unzipString(conf))))
+    }
+    val buildWith =
+      (parameter.get(KEY_FLINK_TABLE_CATALOG), parameter.get(KEY_FLINK_TABLE_DATABASE))
+    buildWith match {
+      case (x: String, y: String) if x != null && y != null =>
+        logInfo(s"with built in catalog: $x")
+        logInfo(s"with built in database: $y")
+        builder.withBuiltInCatalogName(x)
+        builder.withBuiltInDatabaseName(y)
+      case (x: String, _) if x != null =>
+        logInfo(s"with built in catalog: $x")
+        builder.withBuiltInCatalogName(x)
+      case (_, y: String) if y != null =>
+        logInfo(s"with built in database: $y")
+        builder.withBuiltInDatabaseName(y)
+      case _ =>
+    }
+    builder
+  }
+
+  lazy val tableEnv: TableEnvironment = {
+    logInfo(s"job working in batch mode")
+    envSettings.inBatchMode()
+    val tableEnv = TableEnvironment.create(envSettings.build()).setAppName
+    apiType match {
+      case ApiType.JAVA if javaTableEnvConfFunc != null =>
+        javaTableEnvConfFunc.configuration(tableEnv.getConfig, parameter)
+      case ApiType.SCALA if tableConfFunc != null =>
+        tableConfFunc(tableEnv.getConfig, parameter)
+      case _ =>
+    }
+    tableEnv
+  }
+
+  lazy val streamTableEnv: StreamTableEnvironment = {
+    logInfo(s"components should work in streaming mode")
+    envSettings.inStreamingMode()
+    val setting = envSettings.build()
+
+    if (streamEnvConfFunc != null) {
+      streamEnvConfFunc(streamEnv, parameter)
+    }
+    if (javaStreamEnvConfFunc != null) {
+      javaStreamEnvConfFunc.configuration(streamEnv, parameter)
+    }
+    val streamTableEnv =
+      StreamTableEnvironment.create(streamEnv, setting).setAppName
+    apiType match {
+      case ApiType.JAVA if javaTableEnvConfFunc != null =>
+        javaTableEnvConfFunc.configuration(streamTableEnv.getConfig, parameter)
+      case ApiType.SCALA if tableConfFunc != null =>
+        tableConfFunc(streamTableEnv.getConfig, parameter)
+      case _ =>
+    }
+    streamTableEnv
+  }
+
+  /** In case of table SQL, the parameter conf is not required, it depends on the developer. */
+
+  override def initParameter(): FlinkConfiguration = {
+    val configuration = {
+      val argsMap = ParameterTool.fromArgs(args)
+      argsMap.get(KEY_APP_CONF(), null) match {
+        case null | "" =>
+          logWarn("Usage:can't find config,you can set \"--conf $path \" in main arguments")
+          val parameter =
+            ParameterTool.fromSystemProperties().mergeWith(argsMap)
+          FlinkConfiguration(parameter, new Configuration(), new Configuration())
+        case file =>
+          val configMap = parseConfig(file)
+          // set sql..
+          val sqlConf = mutable.Map[String, String]()
+          configMap.foreach(x => {
+            if (x._1.startsWith(KEY_SQL_PREFIX)) {
+              sqlConf += x._1.drop(KEY_SQL_PREFIX.length) -> x._2
+            }
+          })
+
+          // config priority: explicitly specified priority > project profiles > system profiles
+          val properConf =
+            extractConfigByPrefix(configMap, KEY_FLINK_PROPERTY_PREFIX)
+          val appConf = extractConfigByPrefix(configMap, KEY_APP_PREFIX)
+          val tableConf =
+            extractConfigByPrefix(configMap, KEY_FLINK_TABLE_PREFIX)
+
+          val tableConfig = Configuration.fromMap(tableConf)
+          val envConfig = Configuration.fromMap(properConf)
+
+          val parameter = ParameterTool
+            .fromSystemProperties()
+            .mergeWith(ParameterTool.fromMap(properConf))
+            .mergeWith(ParameterTool.fromMap(tableConf))
+            .mergeWith(ParameterTool.fromMap(appConf))
+            .mergeWith(ParameterTool.fromMap(sqlConf))
+            .mergeWith(argsMap)
+
+          FlinkConfiguration(parameter, envConfig, tableConfig)
+      }
+    }
+
+    configuration.parameter.get(KEY_FLINK_SQL()) match {
+      case null => configuration
+      case param =>
+        // for streampark-console
+        Try(DeflaterUtils.unzipString(param)) match {
+          case Success(value) =>
+            configuration.copy(parameter = configuration.parameter.mergeWith(
+              ParameterTool.fromMap(Map(KEY_FLINK_SQL() -> value))))
+          case Failure(_) =>
+            val sqlFile = new File(param)
+            Try(PropertiesUtils.fromYamlFile(sqlFile.getAbsolutePath)) match {
+              case Success(value) =>
+                configuration.copy(parameter =
+                  configuration.parameter.mergeWith(ParameterTool.fromMap(value)))
+              case Failure(e) =>
+                new IllegalArgumentException(s"[StreamPark] init sql error.$e")
+                configuration
+            }
+        }
+    }
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkTableTrait.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/FlinkTableTrait.scala
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Utils
+import org.apache.streampark.flink.core.EnhancerImplicit._
+
+import org.apache.flink.api.common.JobExecutionResult
+import org.apache.flink.table.api._
+import org.apache.flink.table.catalog.Catalog
+import org.apache.flink.table.expressions.Expression
+import org.apache.flink.table.functions._
+import org.apache.flink.table.module.Module
+import org.apache.flink.table.types.AbstractDataType
+import org.apache.flink.util.ParameterTool
+
+import java.lang
+import java.util.Optional
+
+abstract class FlinkTableTrait(val parameter: ParameterTool, private val tableEnv: TableEnvironment)
+  extends TableEnvironment {
+
+  def start(): JobExecutionResult = {
+    val appName = parameter.getAppName(required = true)
+    execute(appName)
+  }
+
+  def execute(jobName: String): JobExecutionResult = {
+    Utils.printLogo(s"FlinkTable $jobName Starting...")
+    null
+  }
+
+  def sql(sql: String = null): Unit =
+    FlinkSqlExecutor.executeSql(sql, parameter, this)
+
+  override def fromValues(values: Expression*): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(rowType: AbstractDataType[_], values: Expression*): Table =
+    tableEnv.fromValues(rowType, values: _*)
+
+  override def fromValues(values: lang.Iterable[_]): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(rowType: AbstractDataType[_], values: lang.Iterable[_]): Table =
+    tableEnv.fromValues(rowType, values)
+
+  override def registerCatalog(catalogName: String, catalog: Catalog): Unit =
+    tableEnv.registerCatalog(catalogName, catalog)
+
+  override def getCatalog(catalogName: String): Optional[Catalog] =
+    tableEnv.getCatalog(catalogName)
+
+  override def loadModule(moduleName: String, module: Module): Unit =
+    tableEnv.loadModule(moduleName, module)
+
+  override def unloadModule(moduleName: String): Unit =
+    tableEnv.unloadModule(moduleName)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionClass)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionInstance)
+
+  override def dropTemporarySystemFunction(name: String): Boolean =
+    tableEnv.dropTemporarySystemFunction(name)
+
+  override def createFunction(path: String, functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def createFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def dropFunction(path: String): Boolean = tableEnv.dropFunction(path)
+
+  override def createTemporaryFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporaryFunction(path, functionClass)
+
+  override def createTemporaryFunction(path: String, functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporaryFunction(path, functionInstance)
+
+  override def dropTemporaryFunction(path: String): Boolean =
+    tableEnv.dropTemporaryFunction(path)
+
+  override def createTemporaryView(path: String, view: Table): Unit =
+    tableEnv.createTemporaryView(path, view)
+
+  override def from(path: String): Table = tableEnv.from(path)
+
+  override def listCatalogs(): Array[String] = tableEnv.listCatalogs()
+
+  override def listModules(): Array[String] = tableEnv.listModules()
+
+  override def listDatabases(): Array[String] = tableEnv.listDatabases()
+
+  override def listTables(): Array[String] = tableEnv.listTables()
+
+  override def listViews(): Array[String] = tableEnv.listViews()
+
+  override def listTemporaryTables(): Array[String] =
+    tableEnv.listTemporaryTables
+
+  override def listTemporaryViews(): Array[String] =
+    tableEnv.listTemporaryViews()
+
+  override def listUserDefinedFunctions(): Array[String] =
+    tableEnv.listUserDefinedFunctions()
+
+  override def listFunctions(): Array[String] = tableEnv.listFunctions()
+
+  override def dropTemporaryTable(path: String): Boolean =
+    tableEnv.dropTemporaryTable(path)
+
+  override def dropTemporaryView(path: String): Boolean =
+    tableEnv.dropTemporaryView(path)
+
+  override def explainSql(statement: String, extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, extraDetails: _*)
+
+  override def sqlQuery(query: String): Table = tableEnv.sqlQuery(query)
+
+  override def executeSql(statement: String): TableResult =
+    tableEnv.executeSql(statement)
+
+  override def getCurrentCatalog: String = tableEnv.getCurrentCatalog
+
+  override def useCatalog(catalogName: String): Unit =
+    tableEnv.useCatalog(catalogName)
+
+  override def getCurrentDatabase: String = tableEnv.getCurrentDatabase
+
+  override def useDatabase(databaseName: String): Unit =
+    tableEnv.useDatabase(databaseName)
+
+  override def getConfig: TableConfig = tableEnv.getConfig
+
+  override def createStatementSet(): StatementSet =
+    tableEnv.createStatementSet()
+
+  @deprecated override def registerFunction(name: String, function: ScalarFunction): Unit =
+    tableEnv.registerFunction(name, function)
+
+  @deprecated override def registerTable(name: String, table: Table): Unit =
+    tableEnv.registerTable(name, table)
+
+  @deprecated override def scan(tablePath: String*): Table =
+    tableEnv.scan(tablePath: _*)
+
+  @deprecated override def getCompletionHints(statement: String, position: Int): Array[String] =
+    tableEnv.getCompletionHints(statement, position)
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/SqlCommandParser.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/SqlCommandParser.scala
@@ -1,0 +1,651 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys.PARAM_PREFIX
+import org.apache.streampark.common.enums.FlinkSqlValidationFailedType
+import org.apache.streampark.common.util.Logger
+
+import enumeratum.EnumEntry
+import org.apache.commons.lang3.StringUtils
+
+import java.lang.{Boolean => JavaBool}
+import java.util.Scanner
+import java.util.regex.{Matcher, Pattern}
+
+import scala.annotation.tailrec
+import scala.collection.{immutable, mutable}
+import scala.collection.mutable.ListBuffer
+import scala.util.control.Breaks.{break, breakable}
+
+object SqlCommandParser extends Logger {
+
+  def parseSQL(
+      sql: String,
+      validationCallback: FlinkSqlValidationResult => Unit = null): List[SqlCommandCall] = {
+    val sqlEmptyError = "verify failed: flink sql cannot be empty."
+    require(StringUtils.isNotBlank(sql), sqlEmptyError)
+    val sqlSegments = SqlSplitter.splitSql(sql)
+    sqlSegments match {
+      case s if s.isEmpty =>
+        if (validationCallback != null) {
+          validationCallback(
+            FlinkSqlValidationResult(
+              success = false,
+              failedType = FlinkSqlValidationFailedType.VERIFY_FAILED,
+              exception = sqlEmptyError))
+          null
+        } else {
+          throw new IllegalArgumentException(sqlEmptyError)
+        }
+      case segments =>
+        val calls = new ListBuffer[SqlCommandCall]
+        for (segment <- segments) {
+          parseLine(segment) match {
+            case Some(x) => calls += x
+            case _ =>
+              if (validationCallback != null) {
+                validationCallback(
+                  FlinkSqlValidationResult(
+                    success = false,
+                    failedType = FlinkSqlValidationFailedType.UNSUPPORTED_SQL,
+                    lineStart = segment.start,
+                    lineEnd = segment.end,
+                    exception = s"unsupported sql",
+                    sql = segment.sql))
+              } else {
+                throw new UnsupportedOperationException(s"unsupported sql: ${segment.sql}")
+              }
+          }
+        }
+
+        calls.toList match {
+          case c if c.isEmpty =>
+            if (validationCallback != null) {
+              validationCallback(
+                FlinkSqlValidationResult(
+                  success = false,
+                  failedType = FlinkSqlValidationFailedType.VERIFY_FAILED,
+                  exception = "flink sql syntax error, no executable sql"))
+              null
+            } else {
+              throw new UnsupportedOperationException("flink sql syntax error, no executable sql")
+            }
+          case r => r
+        }
+    }
+  }
+
+  private[this] def parseLine(sqlSegment: SqlSegment): Option[SqlCommandCall] = {
+    val sqlCommand = SqlCommand.get(sqlSegment.sql.trim)
+    if (sqlCommand == null) None
+    else {
+      val matcher = sqlCommand.matcher
+      val groups = new Array[String](matcher.groupCount)
+      for (i <- groups.indices) {
+        groups(i) = matcher.group(i + 1)
+      }
+      sqlCommand
+        .converter(groups)
+        .map(x =>
+          SqlCommandCall(sqlSegment.start, sqlSegment.end, sqlCommand, x, sqlSegment.sql.trim))
+    }
+  }
+
+}
+
+object Converters {
+  val NO_OPERANDS = (_: Array[String]) => Some(Array.empty[String])
+}
+
+sealed abstract class SqlCommand(
+    val name: String,
+    private val regex: String,
+    val converter: Array[String] => Option[Array[String]] = (x: Array[String]) =>
+      Some(Array[String](x.head)))
+  extends EnumEntry {
+  var matcher: Matcher = _
+
+  def matches(input: String): Boolean = {
+    if (StringUtils.isBlank(regex)) false
+    else {
+      val pattern =
+        Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL)
+      matcher = pattern.matcher(input)
+      matcher.matches()
+    }
+  }
+}
+
+object SqlCommand extends enumeratum.Enum[SqlCommand] {
+
+  def get(stmt: String): SqlCommand = {
+    var cmd: SqlCommand = null
+    breakable {
+      this.values.foreach(x => {
+        if (x.matches(stmt)) {
+          cmd = x
+          break()
+        }
+      })
+    }
+    cmd
+  }
+
+  val values: immutable.IndexedSeq[SqlCommand] = findValues
+
+  // ---- SELECT Statements--------------------------------------------------------------------------------------------------------------------------------
+  case object SELECT extends SqlCommand("select", "(SELECT\\s+.+)")
+
+  // ----CREATE Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * <pre> CREATE [TEMPORARY] TABLE [IF NOT EXISTS] [catalog_name.][db_name.]table_name ( {
+   * <physical_column_definition> | <metadata_column_definition> | <computed_column_definition> }[ ,
+   * ...n] [ <watermark_definition> ] [ <table_constraint> ][ , ...n] ) [COMMENT table_comment]
+   * [PARTITIONED BY (partition_column_name1, partition_column_name2, ...)] WITH (key1=val1,
+   * key2=val2, ...) [ LIKE source_table [( <like_options> )] ] </pre
+   */
+  case object CREATE_TABLE
+    extends SqlCommand("create table", "(CREATE\\s+(TEMPORARY\\s+|)TABLE\\s+.+)")
+
+  /** <pre> CREATE CATALOG catalog_name WITH (key1=val1, key2=val2, ...) </pre> */
+  case object CREATE_CATALOG extends SqlCommand("create catalog", "(CREATE\\s+CATALOG\\s+.+)")
+
+  /**
+   * <pre> CREATE DATABASE [IF NOT EXISTS] [catalog_name.]db_name<br> [COMMENT database_comment]<br>
+   * WITH (key1=val1, key2=val2, ...)<br> </pre>
+   */
+  case object CREATE_DATABASE extends SqlCommand("create database", "(CREATE\\s+DATABASE\\s+.+)")
+
+  /**
+   * <pre> CREATE [TEMPORARY] VIEW [IF NOT EXISTS] [catalog_name.][db_name.]view_name [( columnName
+   * [, columnName ]* )] [COMMENT view_comment] AS query_expression< </pre
+   */
+  case object CREATE_VIEW
+    extends SqlCommand(
+      "create view",
+      "(CREATE\\s+(TEMPORARY\\s+|)VIEW\\s+(IF\\s+NOT\\s+EXISTS\\s+|)(\\S+)\\s+AS\\s+SELECT\\s+.+)")
+
+  /**
+   * <pre> CREATE [TEMPORARY|TEMPORARY SYSTEM] FUNCTION [IF NOT EXISTS]
+   * [catalog_name.][db_name.]function_name AS identifier [LANGUAGE JAVA|SCALA|PYTHON] </pre
+   */
+  case object CREATE_FUNCTION
+    extends SqlCommand(
+      "create function",
+      "(CREATE\\s+(TEMPORARY\\s+|TEMPORARY\\s+SYSTEM\\s+|)FUNCTION\\s+(IF\\s+NOT\\s+EXISTS\\s+|)(\\S+)\\s+AS\\s+.*)")
+
+  // ----DROP Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * <pre> DROP statements are used to remove a catalog with the given catalog name or to remove a
+   * registered table/view/function from the current or specified Catalog.
+   *
+   * Flink SQL supports the following DROP statements for now: * DROP CATALOG * DROP TABLE * DROP
+   * DATABASE * DROP VIEW * DROP FUNCTION </pre>
+   */
+
+  /** <strong>DROP CATALOG [IF EXISTS] catalog_name</strong> */
+  case object DROP_CATALOG extends SqlCommand("drop catalog", "(DROP\\s+CATALOG\\s+.+)")
+
+  /** <strong>DROP [TEMPORARY] TABLE [IF EXISTS] [catalog_name.][db_name.]table_name</strong> */
+  case object DROP_TABLE extends SqlCommand("drop table", "(DROP\\s+(TEMPORARY\\s+|)TABLE\\s+.+)")
+
+  /** <strong>DROP DATABASE [IF EXISTS] [catalog_name.]db_name [ (RESTRICT | CASCADE) ]</strong> */
+  case object DROP_DATABASE extends SqlCommand("drop database", "(DROP\\s+DATABASE\\s+.+)")
+
+  /** <strong>DROP [TEMPORARY] VIEW [IF EXISTS] [catalog_name.][db_name.]view_name</strong> */
+  case object DROP_VIEW extends SqlCommand("drop view", "(DROP\\s+(TEMPORARY\\s+|)VIEW\\s+.+)")
+
+  /**
+   * <strong>DROP [TEMPORARY|TEMPORARY SYSTEM] FUNCTION [IF EXISTS]
+   * [catalog_name.][db_name.]function_name</strong>
+   */
+  case object DROP_FUNCTION
+    extends SqlCommand(
+      "drop function",
+      "(DROP\\s+(TEMPORARY\\s+|TEMPORARY\\s+SYSTEM\\s+|)FUNCTION\\s+.+)")
+
+  // ----ALTER Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * <strong>ALTER TABLE [catalog_name.][db_name.]table_name RENAME TO new_table_name</strong>
+   *
+   * <strong>ALTER TABLE [catalog_name.][db_name.]table_name SET (key1=val1, key2=val2,
+   * ...)</strong>
+   */
+  case object ALTER_TABLE extends SqlCommand("alter table", "(ALTER\\s+TABLE\\s+.+)")
+
+  /**
+   * <strong>ALTER VIEW [catalog_name.][db_name.]view_name RENAME TO new_view_name</strong>
+   *
+   * <strong>ALTER VIEW [catalog_name.][db_name.]view_name AS new_query_expression</strong>
+   */
+  case object ALTER_VIEW extends SqlCommand("alter view", "(ALTER\\s+VIEW\\s+.+)")
+
+  /** <strong>ALTER DATABASE [catalog_name.]db_name SET (key1=val1, key2=val2, ...)</strong> */
+  case object ALTER_DATABASE extends SqlCommand("alter database", "(ALTER\\s+DATABASE\\s+.+)")
+
+  /**
+   * <strong> ALTER [TEMPORARY|TEMPORARY SYSTEM] FUNCTION [IF EXISTS]
+   * [catalog_name.][db_name.]function_name AS identifier [LANGUAGE JAVA|SCALA|PYTHON] </strong>
+   */
+  case object ALTER_FUNCTION
+    extends SqlCommand(
+      "alter function",
+      "(ALTER\\s+(TEMPORARY\\s+|TEMPORARY\\s+SYSTEM\\s+|)FUNCTION\\s+.+)")
+
+  // ---- INSERT Statement--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * INSERT { INTO | OVERWRITE } [catalog_name.][db_name.]table_name [PARTITION part_spec]
+   * [column_list] select_statement INSERT { INTO | OVERWRITE } [catalog_name.][db_name.]table_name
+   * VALUES values_row [, values_row ...]
+   */
+  case object INSERT extends SqlCommand("insert", "(INSERT\\s+(INTO|OVERWRITE)\\s+.+)")
+
+  // ---- DESCRIBE Statement--------------------------------------------------------------------------------------------------------------------------------
+
+  /** { DESCRIBE | DESC } [catalog_name.][db_name.]table_name */
+  case object DESC extends SqlCommand("desc", "(DESC\\s+.+)")
+
+  /** { DESCRIBE | DESC } [catalog_name.][db_name.]table_name */
+  case object DESCRIBE extends SqlCommand("describe", "(DESCRIBE\\s+.+)")
+
+  // ---- EXPLAIN Statement--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * For flink-1.13.x: EXPLAIN PLAN FOR `<query_statement_or_insert_statement>` <br> For
+   * flink-1.14.x: EXPLAIN ESTIMATED_COST, CHANGELOG_MODE, JSON_EXECUTION_PLAN
+   * `<query_statement_or_insert_statement>`<br> For flink-1.15.x: <br> <pre> EXPLAIN
+   * [([ExplainDetail[, ExplainDetail]*]) | PLAN FOR]
+   * <query_statement_or_insert_statement_or_statement_set>
+   *
+   * statement_set: EXECUTE STATEMENT SET BEGIN insert_statement; ... insert_statement; END; </pre>
+   * Recommended not to use the form of flink-1.15.x
+   */
+  case object EXPLAIN extends SqlCommand("explain", "(EXPLAIN\\s+.+)")
+
+  // ---- USE Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** USE CATALOG catalog_name */
+  case object USE_CATALOG extends SqlCommand("use catalog", "(USE\\s+CATALOG\\s+.+)")
+
+  /** USE MODULES module_name1[, module_name2, ...] */
+  case object USE_MODULES extends SqlCommand("use modules", "(USE\\s+MODULES\\s+.+)")
+
+  /** USE [catalog_name.]database_name */
+  case object USE_DATABASE extends SqlCommand("use database", "(USE\\s+(?!(CATALOG|MODULES)).+)")
+
+  // ----SHOW Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** SHOW CATALOGS */
+  case object SHOW_CATALOGS extends SqlCommand("show catalogs", "(SHOW\\s+CATALOGS\\s*)")
+
+  /** SHOW CURRENT CATALOG */
+  case object SHOW_CURRENT_CATALOG
+    extends SqlCommand("show current catalog", "(SHOW\\s+CURRENT\\s+CATALOG\\s*)")
+
+  /** SHOW DATABASES */
+  case object SHOW_DATABASES extends SqlCommand("show databases", "(SHOW\\s+DATABASES\\s*)")
+
+  /** SHOW CURRENT DATABASE */
+  case object SHOW_CURRENT_DATABASE
+    extends SqlCommand("show current database", "(SHOW\\s+CURRENT\\s+DATABASE\\s*)")
+
+  /**
+   * SHOW TABLES,support from flink-1.13.x<br> SHOW TABLES [ ( FROM | IN )
+   * [catalog_name.]database_name ] [ [NOT] LIKE `<sql_like_pattern`> ], support from flink-1.15.x
+   */
+  case object SHOW_TABLES extends SqlCommand("show tables", "(SHOW\\s+TABLES.*)")
+
+  /** SHOW CREATE TABLE, flink-1.14.x support. */
+  case object SHOW_CREATE_TABLE
+    extends SqlCommand("show create table", "(SHOW\\s+CREATE\\s+TABLE\\s+.+)")
+
+  /**
+   * SHOW COLUMNS ( FROM | IN ) [`[`catalog_name.]database.]`<table_name>` [ [NOT] LIKE
+   * `<sql_like_pattern>`],flink-1.15.x support.
+   */
+  case object SHOW_COLUMNS extends SqlCommand("show columns", "(SHOW\\s+COLUMNS\\s+.+)")
+
+  /** SHOW VIEWS */
+  case object SHOW_VIEWS extends SqlCommand("show views", "(SHOW\\s+VIEWS\\s*)")
+
+  /** SHOW CREATE VIEW */
+  case object SHOW_CREATE_VIEW
+    extends SqlCommand("show create view", "(SHOW\\s+CREATE\\s+VIEW\\s+.+)")
+
+  /** SHOW [USER] FUNCTIONS */
+  case object SHOW_FUNCTIONS
+    extends SqlCommand("show functions", "(SHOW\\s+(USER\\s+|)FUNCTIONS\\s*)")
+
+  /** SHOW [FULL] MODULES */
+  case object SHOW_MODULES extends SqlCommand("show modules", "(SHOW\\s+(FULL\\s+|)MODULES\\s*)")
+
+  // ----LOAD Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** LOAD MODULE module_name [WITH ('key1' = 'val1', 'key2' = 'val2', ...)] */
+  case object LOAD_MODULE extends SqlCommand("load module", "(LOAD\\s+MODULE\\s+.+)")
+
+  // ----UNLOAD Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** UNLOAD MODULE module_name */
+  case object UNLOAD_MODULE extends SqlCommand("unload module", "(UNLOAD\\s+MODULE\\s+.+)")
+
+  // ----SET Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** SET ('key' = 'value') */
+  case object SET
+    extends SqlCommand(
+      "set",
+      "SET(\\s+(\\S+)\\s*=(.*))?",
+      {
+        case a if a.length < 3 => None
+        case a if a.head == null => Some(Array[String](cleanUp(a.head)))
+        case a => Some(Array[String](cleanUp(a(1)), cleanUp(a(2))))
+      })
+
+  // ----RESET Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** RESET ('key') */
+  case object RESET extends SqlCommand("reset", "RESET\\s+'(.*)'")
+
+  /** RESET */
+  case object RESET_ALL extends SqlCommand("reset all", "RESET", _ => Some(Array[String]("ALL")))
+
+  // ----INSERT SET Statements--------------------------------------------------------------------------------------------------------------------------------
+  /*
+   * <pre>
+   * SQL Client execute each INSERT INTO statement as a single Flink job. However,
+   * this is sometimes not optimal because some part of the pipeline can be reused.
+   * SQL Client supports STATEMENT SET syntax to execute a set of SQL statements.
+   * This is an equivalent feature with StatementSet in Table API.
+   * The STATEMENT SET syntax encloses one or more INSERT INTO statements.
+   * All statements in a STATEMENT SET block are holistically optimized and executed as a single Flink job.
+   * Joint optimization and execution allows for reusing common intermediate results and can therefore significantly
+   * improve the efficiency of executing multiple queries.
+   * </pre>
+   */
+  /** This is SQL Client's syntax, don't use in our platform. */
+  @deprecated
+  case object BEGIN_STATEMENT_SET
+    extends SqlCommand("begin statement set", "BEGIN\\s+STATEMENT\\s+SET", Converters.NO_OPERANDS)
+
+  /** This is SQL Client's syntax, don't use in our platform. */
+  @deprecated
+  case object END_STATEMENT_SET
+    extends SqlCommand("end statement set", "END", Converters.NO_OPERANDS)
+
+  // Since: 2.1.2 for flink 1.18
+  case object DELETE extends SqlCommand("delete", "(DELETE\\s+FROM\\s+.+)")
+
+  // Since: 2.1.2 for flink 1.18
+  case object UPDATE extends SqlCommand("update", "(UPDATE\\s+.+)")
+
+  private[this] def cleanUp(sql: String): String =
+    sql.trim.replaceAll("^(['\"])|(['\"])$", "")
+
+}
+
+/** Call of SQL command with operands and command type. */
+case class SqlCommandCall(
+    lineStart: Int,
+    lineEnd: Int,
+    command: SqlCommand,
+    operands: Array[String],
+    originSql: String) {}
+
+case class FlinkSqlValidationResult(
+    success: JavaBool = true,
+    failedType: FlinkSqlValidationFailedType = null,
+    lineStart: Int = 0,
+    lineEnd: Int = 0,
+    errorLine: Int = 0,
+    errorColumn: Int = 0,
+    sql: String = null,
+    exception: String = null)
+
+case class SqlSegment(start: Int, end: Int, sql: String)
+
+object SqlSplitter {
+
+  private lazy val singleLineCommentPrefixList = Set[String](PARAM_PREFIX)
+
+  /**
+   * Split whole text into multiple sql statements. Two Steps: Step 1, split the whole text into
+   * multiple sql statements. Step 2, refine the results. Replace the preceding sql statements with
+   * empty lines, so that we can get the correct line number in the parsing error message. e.g:
+   * select a from table_1; select a from table_2; select a from table_3; The above text will be
+   * splitted into: sql_1: select a from table_1 sql_2: \nselect a from table_2 sql_3: \n\nselect a
+   * from table_3
+   *
+   * @param sql
+   * @return
+   */
+  def splitSql(sql: String): List[SqlSegment] = {
+    val queries = ListBuffer[String]()
+    val lastIndex = if (StringUtils.isNotBlank(sql)) sql.length - 1 else 0
+    var query = new mutable.StringBuilder
+
+    var multiLineComment = false
+    var singleLineComment = false
+    var singleQuoteString = false
+    var doubleQuoteString = false
+    var lineNum: Int = 0
+    val lineNumMap = new collection.mutable.HashMap[Int, (Int, Int)]()
+
+    // Whether each line of the record is empty. If it is empty, it is false. If it is not empty, it is true
+    val lineDescriptor = {
+      val scanner = new Scanner(sql)
+      val descriptor = new collection.mutable.HashMap[Int, Boolean]
+      var lineNumber = 0
+      var startComment = false
+      var hasComment = false
+
+      while (scanner.hasNextLine) {
+        lineNumber += 1
+        val line = scanner.nextLine().trim
+        val nonEmpty =
+          StringUtils.isNotBlank(line) && !line.startsWith(PARAM_PREFIX)
+        if (line.startsWith("/*")) {
+          startComment = true
+          hasComment = true
+        }
+
+        descriptor += lineNumber -> (nonEmpty && !hasComment)
+
+        if (startComment && line.endsWith("*/")) {
+          startComment = false
+          hasComment = false
+        }
+      }
+      descriptor
+    }
+
+    @tailrec
+    def findStartLine(num: Int): Int =
+      if (num >= lineDescriptor.size || lineDescriptor(num)) num
+      else findStartLine(num + 1)
+
+    def markLineNumber(): Unit = {
+      val line = lineNum + 1
+      if (lineNumMap.isEmpty) {
+        lineNumMap += (0 -> (findStartLine(1) -> line))
+      } else {
+        val index = lineNumMap.size
+        val start = lineNumMap(lineNumMap.size - 1)._2 + 1
+        lineNumMap += (index -> (findStartLine(start) -> line))
+      }
+    }
+
+    for (idx <- 0 until sql.length) {
+
+      if (sql.charAt(idx) == '\n') lineNum += 1
+
+      breakable {
+        val ch = sql.charAt(idx)
+
+        // end of single line comment
+        if (singleLineComment && (ch == '\n')) {
+          singleLineComment = false
+          query += ch
+          if (idx == lastIndex && query.toString.trim.nonEmpty) {
+            // add query when it is the end of sql.
+            queries += query.toString
+          }
+          break()
+        }
+
+        // end of multiple line comment
+        if (multiLineComment && (idx - 1) >= 0 && sql.charAt(idx - 1) == '/'
+          && (idx - 2) >= 0 && sql.charAt(idx - 2) == '*') {
+          multiLineComment = false
+        }
+
+        // single quote start or end mark
+        if (ch == '\'' && !(singleLineComment || multiLineComment)) {
+          if (singleQuoteString) {
+            singleQuoteString = false
+          } else if (!doubleQuoteString) {
+            singleQuoteString = true
+          }
+        }
+
+        // double quote start or end mark
+        if (ch == '"' && !(singleLineComment || multiLineComment)) {
+          if (doubleQuoteString && idx > 0) {
+            doubleQuoteString = false
+          } else if (!singleQuoteString) {
+            doubleQuoteString = true
+          }
+        }
+
+        // single line comment or multiple line comment start mark
+        if (!singleQuoteString && !doubleQuoteString && !multiLineComment && !singleLineComment && idx < lastIndex) {
+          if (isSingleLineComment(sql.charAt(idx), sql.charAt(idx + 1))) {
+            singleLineComment = true
+          } else if (sql.charAt(idx) == '/' && sql.length > (idx + 2)
+            && sql.charAt(idx + 1) == '*' && sql.charAt(idx + 2) != '+') {
+            multiLineComment = true
+          }
+        }
+
+        if (ch == ';' && !singleQuoteString && !doubleQuoteString && !multiLineComment && !singleLineComment) {
+          markLineNumber()
+          // meet the end of semicolon
+          if (query.toString.trim.nonEmpty) {
+            queries += query.toString
+            query = new mutable.StringBuilder
+          }
+        } else if (idx == lastIndex) {
+          markLineNumber()
+
+          // meet the last character
+          if (!singleLineComment && !multiLineComment) {
+            query += ch
+          }
+
+          if (query.toString.trim.nonEmpty) {
+            queries += query.toString
+            query = new mutable.StringBuilder
+          }
+        } else if (!singleLineComment && !multiLineComment) {
+          // normal case, not in single line comment and not in multiple line comment
+          query += ch
+        } else if (ch == '\n') {
+          query += ch
+        }
+      }
+    }
+
+    val refinedQueries = new collection.mutable.HashMap[Int, String]()
+    for (i <- queries.indices) {
+      val currStatement = queries(i)
+      if (isSingleLineComment(currStatement) || isMultipleLineComment(currStatement)) {
+        // transform comment line as blank lines
+        if (refinedQueries.nonEmpty) {
+          val lastRefinedQuery = refinedQueries.last
+          refinedQueries(refinedQueries.size - 1) =
+            lastRefinedQuery + extractLineBreaks(currStatement)
+        }
+      } else {
+        var linesPlaceholder = ""
+        if (i > 0) {
+          linesPlaceholder = extractLineBreaks(refinedQueries(i - 1))
+        }
+        // add some blank lines before the statement to keep the original line number
+        val refinedQuery = linesPlaceholder + currStatement
+        refinedQueries += refinedQueries.size -> refinedQuery
+      }
+    }
+
+    val set = new ListBuffer[SqlSegment]
+    refinedQueries.foreach(x => {
+      val line = lineNumMap(x._1)
+      set += SqlSegment(line._1, line._2, x._2)
+    })
+    set.toList.sortWith((a, b) => a.start < b.start)
+  }
+
+  /**
+   * extract line breaks
+   *
+   * @param text
+   * @return
+   */
+  private[this] def extractLineBreaks(text: String): String = {
+    val builder = new mutable.StringBuilder
+    for (i <- 0 until text.length) {
+      if (text.charAt(i) == '\n') {
+        builder.append('\n')
+      }
+    }
+    builder.toString
+  }
+
+  private[this] def isSingleLineComment(text: String) =
+    text.trim.startsWith(PARAM_PREFIX)
+
+  private[this] def isMultipleLineComment(text: String) =
+    text.trim.startsWith("/*") && text.trim.endsWith("*/")
+
+  /**
+   * check single-line comment
+   *
+   * @param curChar
+   * @param nextChar
+   * @return
+   */
+  private[this] def isSingleLineComment(curChar: Char, nextChar: Char): Boolean = {
+    var flag = false
+    for (singleCommentPrefix <- singleLineCommentPrefixList) {
+      singleCommentPrefix.length match {
+        case 1 if curChar == singleCommentPrefix.charAt(0) => flag = true
+        case 2
+            if curChar == singleCommentPrefix.charAt(0) && nextChar == singleCommentPrefix.charAt(
+              1) =>
+          flag = true
+        case _ =>
+      }
+    }
+    flag
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/StreamEnvConfig.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/StreamEnvConfig.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+class StreamEnvConfig(val args: Array[String], val conf: StreamEnvConfigFunction)
+
+class StreamTableEnvConfig(
+    val args: Array[String],
+    val streamConfig: StreamEnvConfigFunction,
+    val tableConfig: TableEnvConfigFunction)
+
+class TableEnvConfig(val args: Array[String], val conf: TableEnvConfigFunction)

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/StreamTableContext.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/StreamTableContext.scala
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Implicits.JavaList
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.tuple
+import org.apache.flink.streaming.api.datastream.{DataStream => JavaDataStream}
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.table.catalog.CatalogDescriptor
+import org.apache.flink.table.connector.ChangelogMode
+import org.apache.flink.table.expressions.Expression
+import org.apache.flink.table.module.ModuleEntry
+import org.apache.flink.table.resource.ResourceUri
+import org.apache.flink.table.types.AbstractDataType
+import org.apache.flink.types.Row
+import org.apache.flink.util.ParameterTool
+
+class StreamTableContext(
+    override val parameter: ParameterTool,
+    private val streamEnv: StreamExecutionEnvironment,
+    private val tableEnv: StreamTableEnvironment)
+  extends FlinkStreamTableTraitV2(parameter, streamEnv, tableEnv) {
+
+  def this(args: (ParameterTool, StreamExecutionEnvironment, StreamTableEnvironment)) =
+    this(args._1, args._2, args._3)
+
+  def this(args: StreamTableEnvConfig) =
+    this(FlinkTableInitializerV2.initialize(args))
+
+  override def fromDataStream[T](dataStream: JavaDataStream[T], schema: Schema): Table =
+    tableEnv.fromDataStream[T](dataStream, schema)
+
+  /** @deprecated old API */
+  override def fromDataStream[T](dataStream: JavaDataStream[T], expressions: Expression*): Table =
+    tableEnv.fromDataStream(dataStream, expressions: _*)
+
+  override def fromChangelogStream(dataStream: JavaDataStream[Row]): Table =
+    tableEnv.fromChangelogStream(dataStream)
+
+  override def fromChangelogStream(dataStream: JavaDataStream[Row], schema: Schema): Table =
+    tableEnv.fromChangelogStream(dataStream, schema)
+
+  override def fromChangelogStream(
+      dataStream: JavaDataStream[Row],
+      schema: Schema,
+      changelogMode: ChangelogMode): Table =
+    tableEnv.fromChangelogStream(dataStream, schema, changelogMode)
+
+  override def createTemporaryView[T](
+      path: String,
+      dataStream: JavaDataStream[T],
+      schema: Schema): Unit =
+    tableEnv.createTemporaryView[T](path, dataStream, schema)
+
+  /** @deprecated old API */
+  @deprecated override def createTemporaryView[T](
+      path: String,
+      dataStream: JavaDataStream[T],
+      expressions: Expression*): Unit =
+    tableEnv.createTemporaryView(path, dataStream, expressions: _*)
+
+  override def toDataStream(table: Table): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table)
+  }
+
+  override def toDataStream[T](table: Table, targetClass: Class[T]): JavaDataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream[T](table, targetClass)
+  }
+
+  override def toDataStream[T](table: Table, targetDataType: AbstractDataType[_]): JavaDataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream[T](table, targetDataType)
+  }
+
+  override def toChangelogStream(table: Table): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table)
+  }
+
+  override def toChangelogStream(table: Table, targetSchema: Schema): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema)
+  }
+
+  override def toChangelogStream(
+      table: Table,
+      targetSchema: Schema,
+      changelogMode: ChangelogMode): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema, changelogMode)
+  }
+
+  override def createStatementSet(): org.apache.flink.table.api.bridge.java.StreamStatementSet =
+    tableEnv.createStatementSet()
+
+  override def useModules(strings: String*): Unit =
+    tableEnv.useModules(strings: _*)
+
+  override def createTemporaryTable(path: String, descriptor: TableDescriptor): Unit =
+    tableEnv.createTemporaryTable(path, descriptor)
+
+  override def createTable(path: String, descriptor: TableDescriptor): Unit =
+    tableEnv.createTable(path, descriptor)
+
+  override def from(descriptor: TableDescriptor): Table =
+    tableEnv.from(descriptor)
+
+  override def listFullModules(): Array[ModuleEntry] =
+    tableEnv.listFullModules()
+
+  /** @since 1.15 */
+  override def listTables(s: String, s1: String): Array[String] =
+    tableEnv.listTables(s, s1)
+
+  /** @since 1.15 */
+  override def loadPlan(planReference: PlanReference): CompiledPlan =
+    tableEnv.loadPlan(planReference)
+
+  /** @since 1.15 */
+  override def compilePlanSql(s: String): CompiledPlan =
+    tableEnv.compilePlanSql(s)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, className, resourceUris, ignoreIfExists)
+
+  /** @since 1.17 */
+  override def createTemporaryFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporaryFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createTemporarySystemFunction(
+      name: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporarySystemFunction(name, className, resourceUris)
+
+  /** @since 1.17 */
+  override def explainSql(
+      statement: String,
+      format: ExplainFormat,
+      extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, format, extraDetails: _*)
+
+  /** @since 1.18 */
+  override def createCatalog(catalog: String, catalogDescriptor: CatalogDescriptor): Unit = {
+    tableEnv.createCatalog(catalog, catalogDescriptor)
+  }
+
+  /** @deprecated old API */
+  @deprecated override def toAppendStream[T](
+      table: Table,
+      typeInformation: TypeInformation[T]): JavaDataStream[T] =
+    tableEnv.toAppendStream(table, typeInformation)
+
+  /** @deprecated old API */
+  @deprecated override def toRetractStream[T](
+      table: Table,
+      typeInformation: TypeInformation[T]): JavaDataStream[tuple.Tuple2[java.lang.Boolean, T]] =
+    tableEnv.toRetractStream(table, typeInformation)
+
+  /** since Flink 2.0 */
+  override def toAppendStream[T](table: Table, clazz: Class[T]): JavaDataStream[T] =
+    tableEnv.toAppendStream(table, clazz)
+
+  /** since Flink 2.0 */
+  override def toRetractStream[T](table: Table, clazz: Class[T]): JavaDataStream[tuple.Tuple2[java.lang.Boolean, T]] =
+    tableEnv.toRetractStream(table, clazz)
+
+  /** since Flink 2.0 */
+  override def createTable(path: String, descriptor: TableDescriptor, ignoreIfExists: Boolean): Boolean =
+    tableEnv.createTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createTemporaryTable(
+      path: String,
+      descriptor: TableDescriptor,
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createTemporaryTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table, ignoreIfExists: Boolean): Boolean =
+    tableEnv.createView(path, view, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table): Unit =
+    tableEnv.createView(path, view)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropTable(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String): Boolean =
+    tableEnv.dropTable(path)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropView(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String): Boolean =
+    tableEnv.dropView(path)
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/TableContext.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/TableContext.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Implicits.JavaList
+
+import org.apache.flink.table.api._
+import org.apache.flink.table.catalog.CatalogDescriptor
+import org.apache.flink.table.module.ModuleEntry
+import org.apache.flink.table.resource.ResourceUri
+import org.apache.flink.util.ParameterTool
+
+class TableContext(override val parameter: ParameterTool, private val tableEnv: TableEnvironment)
+  extends FlinkTableTrait(parameter, tableEnv) {
+
+  def this(args: (ParameterTool, TableEnvironment)) = this(args._1, args._2)
+
+  def this(args: TableEnvConfig) = this(FlinkTableInitializerV2.initialize(args))
+
+  override def useModules(strings: String*): Unit =
+    tableEnv.useModules(strings: _*)
+
+  override def createTemporaryTable(path: String, descriptor: TableDescriptor): Unit = {
+    tableEnv.createTemporaryTable(path, descriptor)
+  }
+
+  override def createTable(path: String, descriptor: TableDescriptor): Unit = {
+    tableEnv.createTable(path, descriptor)
+  }
+
+  override def from(tableDescriptor: TableDescriptor): Table = {
+    tableEnv.from(tableDescriptor)
+  }
+
+  override def listFullModules(): Array[ModuleEntry] =
+    tableEnv.listFullModules()
+
+  /** @since 1.15 */
+  override def listTables(catalogName: String, databaseName: String): Array[String] =
+    tableEnv.listTables(catalogName, databaseName)
+
+  /** @since 1.15 */
+  override def loadPlan(planReference: PlanReference): CompiledPlan =
+    tableEnv.loadPlan(planReference)
+
+  /** @since 1.15 */
+  override def compilePlanSql(stmt: String): CompiledPlan =
+    tableEnv.compilePlanSql(stmt)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, className, resourceUris, ignoreIfExists)
+
+  /** @since 1.17 */
+  override def createTemporaryFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporaryFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createTemporarySystemFunction(
+      name: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporarySystemFunction(name, className, resourceUris)
+
+  /** @since 1.17 */
+  override def explainSql(
+      statement: String,
+      format: ExplainFormat,
+      extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, format, extraDetails: _*)
+
+  /** @since 1.18 */
+  override def createCatalog(catalog: String, catalogDescriptor: CatalogDescriptor): Unit = {
+    tableEnv.createCatalog(catalog, catalogDescriptor)
+  }
+
+  /** since Flink 2.0 */
+  override def createTable(
+      path: String,
+      descriptor: TableDescriptor,
+      ignoreIfExists: Boolean): Boolean =
+    tableEnv.createTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createTemporaryTable(
+      path: String,
+      descriptor: TableDescriptor,
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createTemporaryTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table, ignoreIfExists: Boolean): Boolean =
+    tableEnv.createView(path, view, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table): Unit =
+    tableEnv.createView(path, view)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropTable(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String): Boolean =
+    tableEnv.dropTable(path)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropView(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String): Boolean =
+    tableEnv.dropView(path)
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/TableExt.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/TableExt.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.api.{Table => FlinkTable}
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.types.Row
+
+object TableExt {
+
+  class Table(val table: FlinkTable) {
+    def ->(field: String, fields: String*): FlinkTable =
+      table.as(field, fields: _*)
+  }
+
+  class TableConversions(
+      table: FlinkTable,
+      streamTableEnv: StreamTableEnvironment) {
+
+    def \\ : DataStream[Row] = streamTableEnv.toDataStream(table)
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/conf/FlinkConfiguration.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.0/src/main/scala/org/apache/streampark/flink/core/conf/FlinkConfiguration.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core.conf
+
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.util.ParameterTool
+
+case class FlinkConfiguration(
+    parameter: ParameterTool,
+    envConfig: Configuration,
+    tableConfig: Configuration)

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.streampark</groupId>
+        <artifactId>streampark-flink-shims</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>streampark-flink-shims_flink-2.1_${scala.binary.version}</artifactId>
+    <name>StreamPark : Flink Shims 2.1</name>
+
+    <properties>
+        <flink.version>2.1.2</flink.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.streampark</groupId>
+            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Flink 2.x removed Scala DataStream API, use Java API only -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-kubernetes</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-yarn</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-statebackend-rocksdb</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/java/org/apache/streampark/flink/core/StreamEnvConfigFunction.java
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/java/org/apache/streampark/flink/core/StreamEnvConfigFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.ParameterTool;
+
+@FunctionalInterface
+public interface StreamEnvConfigFunction {
+
+    /**
+     * When used to initialize StreamExecutionEnvironment, it can be used to implement this function
+     * and customize the parameters to be set...
+     *
+     * @param environment
+     * @param parameterTool
+     */
+    void configuration(StreamExecutionEnvironment environment, ParameterTool parameterTool);
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/java/org/apache/streampark/flink/core/TableEnvConfigFunction.java
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/java/org/apache/streampark/flink/core/TableEnvConfigFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.util.ParameterTool;
+
+@FunctionalInterface
+public interface TableEnvConfigFunction {
+
+    /**
+     * When used to initialize the TableEnvironment, it can be used to implement this function and
+     * customize the parameters to be set...
+     *
+     * @param tableConfig
+     * @param parameterTool
+     */
+    void configuration(TableConfig tableConfig, ParameterTool parameterTool);
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/EnhancerImplicit.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/EnhancerImplicit.scala
@@ -20,11 +20,10 @@ package org.apache.streampark.flink.core
 import org.apache.streampark.common.conf.ConfigKeys.{KEY_APP_NAME, KEY_FLINK_APP_NAME}
 import org.apache.streampark.common.util.DeflaterUtils
 
-import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.configuration.PipelineOptions
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
-import org.apache.flink.table.api.bridge.scala.{StreamTableEnvironment => ScalaStreamTableEnvironment}
+import org.apache.flink.util.ParameterTool
 
 import scala.util.Try
 
@@ -52,30 +51,19 @@ object EnhancerImplicit {
     private[flink] def setAppName(implicit parameter: ParameterTool): TableEnvironment = {
       val appName = parameter.getAppName()
       if (appName != null) {
-        env.getConfig.getConfiguration.setString(PipelineOptions.NAME, appName)
+        env.getConfig.getConfiguration.setString(PipelineOptions.NAME.key, appName)
       }
       env
     }
 
   }
 
-  implicit class EnhanceStreamExecutionEnvironment(env: ScalaStreamTableEnvironment) {
-
-    private[flink] def setAppName(implicit parameter: ParameterTool): ScalaStreamTableEnvironment = {
-      val appName = parameter.getAppName()
-      if (appName != null) {
-        env.getConfig.getConfiguration.setString(PipelineOptions.NAME, appName)
-      }
-      env
-    }
-  }
-
-  implicit class EnhanceJavaStreamTableEnvironment(env: StreamTableEnvironment) {
+  implicit class EnhanceStreamTableEnvironment(env: StreamTableEnvironment) {
 
     private[flink] def setAppName(implicit parameter: ParameterTool): StreamTableEnvironment = {
       val appName = parameter.getAppName()
       if (appName != null) {
-        env.getConfig.getConfiguration.setString(PipelineOptions.NAME, appName)
+        env.getConfig.getConfiguration.setString(PipelineOptions.NAME.key, appName)
       }
       env
     }

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkClientTrait.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkClientTrait.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.api.common.JobID
+import org.apache.flink.client.program.ClusterClient
+import org.apache.flink.core.execution.SavepointFormatType
+
+import java.util.concurrent.CompletableFuture
+
+abstract class FlinkClientTrait[T](clusterClient: ClusterClient[T]) {
+
+  def triggerSavepoint(
+      jobID: JobID,
+      savepointDir: String,
+      nativeFormat: Boolean = false): CompletableFuture[String] = {
+    clusterClient.triggerSavepoint(jobID, savepointDir, SavepointFormatType.DEFAULT)
+  }
+
+  def cancelWithSavepoint(
+      jobID: JobID,
+      savepointDir: String,
+      nativeFormat: Boolean = false): CompletableFuture[String] = {
+    clusterClient.cancelWithSavepoint(jobID, savepointDir, SavepointFormatType.DEFAULT)
+  }
+
+  def stopWithSavepoint(
+      jobID: JobID,
+      advanceToEndOfEventTime: Boolean,
+      savepointDir: String,
+      nativeFormat: Boolean = false): CompletableFuture[String] =
+    clusterClient.stopWithSavepoint(jobID, advanceToEndOfEventTime, savepointDir, SavepointFormatType.DEFAULT)
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkClusterClient.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkClusterClient.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.api.common.JobID
+import org.apache.flink.client.program.ClusterClient
+import org.apache.flink.core.execution.SavepointFormatType
+
+import java.util.concurrent.CompletableFuture
+
+class FlinkClusterClient[T](clusterClient: ClusterClient[T])
+  extends FlinkClientTrait[T](clusterClient) {
+
+  override def triggerSavepoint(
+      jobID: JobID,
+      savepointDir: String,
+      nativeFormat: Boolean): CompletableFuture[String] = {
+    clusterClient.triggerSavepoint(
+      jobID,
+      savepointDir,
+      if (nativeFormat) SavepointFormatType.NATIVE
+      else SavepointFormatType.CANONICAL)
+  }
+
+  override def cancelWithSavepoint(
+      jobID: JobID,
+      savepointDirectory: String,
+      nativeFormat: Boolean): CompletableFuture[String] = {
+    clusterClient.cancelWithSavepoint(
+      jobID,
+      savepointDirectory,
+      if (nativeFormat) SavepointFormatType.NATIVE
+      else SavepointFormatType.CANONICAL)
+  }
+
+  override def stopWithSavepoint(
+      jobID: JobID,
+      advanceToEndOfEventTime: Boolean,
+      savepointDirectory: String,
+      nativeFormat: Boolean): CompletableFuture[String] = {
+    clusterClient.stopWithSavepoint(
+      jobID,
+      advanceToEndOfEventTime,
+      savepointDirectory,
+      if (nativeFormat) SavepointFormatType.NATIVE
+      else SavepointFormatType.CANONICAL)
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClient.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClient.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService
+
+import java.util.Optional
+
+class FlinkKubernetesClient(kubeClient: FlinkKubeClient)
+  extends FlinkKubernetesClientTrait(kubeClient) {
+
+  override def getService(serviceName: String): Optional[KubernetesService] = {
+    kubeClient.getService(serviceName)
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClientTrait.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClientTrait.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService
+
+import java.util.Optional
+
+abstract class FlinkKubernetesClientTrait(kubeClient: FlinkKubeClient) {
+
+  /**
+   * Get the kubernetes service of the given flink clusterId.
+   *
+   * @param serviceName
+   *   the name of the service
+   * @return
+   *   Return the optional kubernetes service of the specified name.
+   */
+  def getService(serviceName: String): Optional[KubernetesService] =
+    kubeClient.getService(serviceName)
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkSqlExecutor.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkSqlExecutor.scala
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys.KEY_FLINK_SQL
+import org.apache.streampark.common.util.{AssertUtils, Logger}
+import org.apache.streampark.flink.core.SqlCommand._
+
+import org.apache.commons.lang3.StringUtils
+import org.apache.flink.configuration.{Configuration, ExecutionOptions}
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.util.ParameterTool
+
+import java.util
+import java.util.concurrent.locks.ReentrantReadWriteLock
+
+import scala.collection.mutable
+import scala.util.Try
+
+object FlinkSqlExecutor extends Logger {
+
+  private[this] val lock = new ReentrantReadWriteLock().writeLock
+
+  private[streampark] def executeSql(
+      sql: String,
+      parameter: ParameterTool,
+      context: TableEnvironment)(implicit callbackFunc: String => Unit = null): Unit = {
+
+    val flinkSql: String =
+      if (StringUtils.isBlank(sql)) parameter.get(KEY_FLINK_SQL())
+      else parameter.get(sql)
+    require(StringUtils.isNotBlank(flinkSql), "verify failed: flink sql cannot be empty")
+
+    def callback(r: String): Unit = {
+      callbackFunc match {
+        case null => logInfo(r)
+        case x => x(r)
+      }
+    }
+
+    val runMode = parameter.get(ExecutionOptions.RUNTIME_MODE.key())
+
+    var hasInsert = false
+    val statementSet = context.createStatementSet()
+    SqlCommandParser
+      .parseSQL(flinkSql)
+      .foreach(x => {
+        val args = if (x.operands.isEmpty) null else x.operands.head
+        val command = x.command.name
+        x.command match {
+          // For display sql statement result information
+          case SHOW_CATALOGS =>
+            val catalogs = context.listCatalogs
+            callback(s"$command: ${catalogs.mkString("\n")}")
+          case SHOW_CURRENT_CATALOG =>
+            val catalog = context.getCurrentCatalog
+            callback(s"$command: $catalog")
+          case SHOW_DATABASES =>
+            val databases = context.listDatabases
+            callback(s"$command: ${databases.mkString("\n")}")
+          case SHOW_CURRENT_DATABASE =>
+            val database = context.getCurrentDatabase
+            callback(s"$command: $database")
+          case SHOW_TABLES =>
+            val tables =
+              context.listTables().filter(!_.startsWith("UnnamedTable"))
+            callback(s"$command: ${tables.mkString("\n")}")
+          case SHOW_FUNCTIONS =>
+            val functions = context.listUserDefinedFunctions()
+            callback(s"$command: ${functions.mkString("\n")}")
+          case SHOW_MODULES =>
+            val modules = context.listModules()
+            callback(s"$command: ${modules.mkString("\n")}")
+          case DESC | DESCRIBE =>
+            val schema = context.scan(args).getSchema
+            val builder = new mutable.StringBuilder()
+            builder.append("Column\tType\n")
+            for (i <- 0 to schema.getFieldCount) {
+              builder.append(
+                schema.getFieldName(i).get() + "\t" + schema
+                  .getFieldDataType(i)
+                  .get() + "\n")
+            }
+            callback(builder.toString())
+          case EXPLAIN =>
+            val tableResult = context.executeSql(x.originSql)
+            val r = tableResult.collect().next().getField(0).toString
+            callback(r)
+          // For specific statement, such as: SET/RESET/INSERT/SELECT
+          case SET =>
+            val operand = x.operands(1)
+            logInfo(s"$command: $args --> $operand")
+            context.getConfig.getConfiguration.setString(args, operand)
+          case RESET | RESET_ALL =>
+            val confDataField =
+              classOf[Configuration].getDeclaredField("confData")
+            confDataField.setAccessible(true)
+            val confData = confDataField
+              .get(context.getConfig.getConfiguration)
+              .asInstanceOf[util.HashMap[String, AnyRef]]
+            confData.synchronized {
+              if (x.command == RESET) {
+                confData.remove(args)
+              } else {
+                confData.clear()
+              }
+            }
+            logInfo(s"$command: $args")
+          case BEGIN_STATEMENT_SET | END_STATEMENT_SET =>
+            logWarn(s"SQL Client Syntax: ${x.command.name} ")
+          case INSERT =>
+            statementSet.addInsertSql(x.originSql)
+            hasInsert = true
+          case SELECT =>
+            logError("StreamPark dose not support 'SELECT' statement now!")
+            throw new RuntimeException("StreamPark dose not support 'select' statement now!")
+          case DELETE | UPDATE =>
+            AssertUtils.required(
+              runMode != "STREAMING",
+              s"Currently, ${command.toUpperCase()} statement only supports in batch mode, " +
+                s"and it requires the target table connector implements the SupportsRowLevelDelete, " +
+                s"For more details please refer to: https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/dev/table/sql/$command")
+          case _ =>
+            try {
+              lock.lock()
+              val result = context.executeSql(x.originSql)
+              logInfo(s"$command:$args")
+            } finally {
+              if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+              }
+            }
+        }
+      })
+
+    if (hasInsert) {
+      statementSet.execute() match {
+        case t if t != null =>
+          Try(t.getJobClient.get.getJobID).getOrElse(null) match {
+            case x if x != null => logInfo(s"jobId:$x")
+            case _ =>
+          }
+        case _ =>
+      }
+    } else {
+      logError("No 'INSERT' statement to trigger the execution of the Flink job.")
+      throw new RuntimeException("No 'INSERT' statement to trigger the execution of the Flink job.")
+    }
+
+    logInfo(
+      s"\n\n\n==============flinkSql==============\n\n $flinkSql\n\n============================\n\n\n")
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkSqlValidator.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkSqlValidator.scala
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.enums.FlinkSqlValidationFailedType
+import org.apache.streampark.common.util.{ExceptionUtils, Logger}
+import org.apache.streampark.flink.core.SqlCommand._
+
+import org.apache.calcite.config.Lex
+import org.apache.calcite.sql.parser.SqlParser
+import org.apache.calcite.sql.parser.SqlParser.Config
+import org.apache.flink.sql.parser.validate.FlinkSqlConformance
+import org.apache.flink.table.api.SqlDialect
+import org.apache.flink.table.api.SqlDialect.{DEFAULT, HIVE}
+import org.apache.flink.table.api.config.TableConfigOptions
+import org.apache.flink.table.planner.delegation.FlinkSqlParserFactories
+
+import scala.language.existentials
+import scala.util.{Failure, Try}
+
+object FlinkSqlValidator extends Logger {
+
+  private[this] val FLINK112_CALCITE_PARSER_CLASS =
+    "org.apache.flink.table.planner.calcite.CalciteParser"
+
+  private[this] val FLINK113_PLUS_CALCITE_PARSER_CLASS =
+    "org.apache.flink.table.planner.parse.CalciteParser"
+
+  private[this] val SYNTAX_ERROR_REGEXP =
+    ".*at\\sline\\s(\\d+),\\scolumn\\s(\\d+).*".r
+
+  private[this] lazy val sqlParserConfigMap: Map[String, SqlParser.Config] = {
+    def getConfig(sqlDialect: SqlDialect): Config = {
+      val conformance = sqlDialect match {
+        case HIVE =>
+          try {
+            FlinkSqlConformance.DEFAULT
+          } catch {
+            // for flink 1.18+
+            case _: NoSuchFieldError => FlinkSqlConformance.DEFAULT
+            case e: Throwable =>
+              throw new IllegalArgumentException("Init Flink sql Dialect error: ", e)
+          }
+        case DEFAULT => FlinkSqlConformance.DEFAULT
+        case _ =>
+          throw new UnsupportedOperationException(s"Unsupported sqlDialect: $sqlDialect")
+      }
+      SqlParser.config
+        .withParserFactory(FlinkSqlParserFactories.create(conformance))
+        .withConformance(conformance)
+        .withLex(Lex.JAVA)
+        .withIdentifierMaxLength(256)
+    }
+
+    Map(
+      SqlDialect.DEFAULT.name() -> getConfig(SqlDialect.DEFAULT),
+      SqlDialect.HIVE.name() -> getConfig(SqlDialect.HIVE))
+  }
+
+  def verifySql(sql: String): FlinkSqlValidationResult = {
+    val sqlCommands = SqlCommandParser.parseSQL(sql, r => return r)
+    var sqlDialect = SqlDialect.DEFAULT.name().toLowerCase()
+    var hasInsert = false
+    for (call <- sqlCommands) {
+      val args = call.operands.head
+      val command = call.command
+      command match {
+        case SET | RESET =>
+          if (command == SET && args == TableConfigOptions.TABLE_SQL_DIALECT.key()) {
+            sqlDialect = call.operands.last
+          }
+        case BEGIN_STATEMENT_SET | END_STATEMENT_SET =>
+          logWarn(s"SQL Client Syntax: ${call.command.name} ")
+        case _ =>
+          if (command == INSERT) {
+            hasInsert = true
+          }
+          Try {
+            val calciteClass = Try(Class.forName(FLINK112_CALCITE_PARSER_CLASS))
+              .getOrElse(Class.forName(FLINK113_PLUS_CALCITE_PARSER_CLASS))
+            sqlDialect.toUpperCase() match {
+              case "HIVE" =>
+              case "DEFAULT" =>
+                val parser = calciteClass
+                  .getConstructor(Array(classOf[Config]): _*)
+                  .newInstance(sqlParserConfigMap(sqlDialect.toUpperCase()))
+                val method =
+                  parser.getClass.getDeclaredMethod("parse", classOf[String])
+                method.setAccessible(true)
+                method.invoke(parser, call.originSql)
+              case _ =>
+                throw new UnsupportedOperationException(s"unsupported dialect: $sqlDialect")
+            }
+          } match {
+            case Failure(e) =>
+              val exception = ExceptionUtils.stringifyException(e)
+              val causedBy = exception.drop(exception.indexOf("Caused by:"))
+              val cleanUpError = exception.replaceAll("[\r\n]", "")
+              if (SYNTAX_ERROR_REGEXP.findAllMatchIn(cleanUpError).nonEmpty) {
+                val SYNTAX_ERROR_REGEXP(line, column) = cleanUpError
+                val errorLine = call.lineStart + line.toInt - 1
+                return FlinkSqlValidationResult(
+                  success = false,
+                  failedType = FlinkSqlValidationFailedType.SYNTAX_ERROR,
+                  lineStart = call.lineStart,
+                  lineEnd = call.lineEnd,
+                  errorLine = errorLine,
+                  errorColumn = column.toInt,
+                  sql = call.originSql,
+                  exception = causedBy.replaceAll(s"at\\sline\\s$line", s"at line $errorLine"))
+              } else {
+                return FlinkSqlValidationResult(
+                  success = false,
+                  failedType = FlinkSqlValidationFailedType.SYNTAX_ERROR,
+                  lineStart = call.lineStart,
+                  lineEnd = call.lineEnd,
+                  sql = call.originSql,
+                  exception = causedBy)
+              }
+            case _ =>
+          }
+      }
+    }
+
+    if (hasInsert) {
+      FlinkSqlValidationResult()
+    } else {
+      FlinkSqlValidationResult(
+        success = false,
+        failedType = FlinkSqlValidationFailedType.SYNTAX_ERROR,
+        lineStart = sqlCommands.head.lineStart,
+        lineEnd = sqlCommands.last.lineEnd,
+        exception = "No 'INSERT' statement to trigger the execution of the Flink job.")
+    }
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkStreamTableTraitV2.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkStreamTableTraitV2.scala
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Implicits.JavaList
+import org.apache.streampark.common.util.Utils
+import org.apache.streampark.flink.core.EnhancerImplicit._
+
+import org.apache.flink.api.common.{JobExecutionResult, RuntimeExecutionMode}
+import org.apache.flink.api.common.cache.DistributedCache
+import org.apache.flink.api.common.eventtime.WatermarkStrategy
+import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFormat}
+import org.apache.flink.api.connector.source.{Source, SourceSplit}
+import org.apache.flink.api.java.tuple
+import org.apache.flink.configuration.ReadableConfig
+import org.apache.flink.core.execution.{JobClient, JobListener}
+import org.apache.flink.streaming.api.CheckpointingMode
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.{CheckpointConfig, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.functions.source.FileProcessingMode
+import org.apache.flink.streaming.api.graph.StreamGraph
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.table.catalog.Catalog
+import org.apache.flink.table.functions._
+import org.apache.flink.table.module.Module
+import org.apache.flink.types.Row
+import org.apache.flink.util.{ParameterTool, SplittableIterator}
+
+import java.util.Optional
+
+/**
+ * Integration api of stream and table (Flink 2.0 - Java DataStream API)
+ *
+ * @param parameter
+ *   parameter
+ * @param streamEnv
+ *   streamEnv
+ * @param tableEnv
+ *   tableEnv
+ */
+abstract class FlinkStreamTableTraitV2(
+    val parameter: ParameterTool,
+    private val streamEnv: StreamExecutionEnvironment,
+    private val tableEnv: StreamTableEnvironment)
+  extends StreamTableEnvironment {
+
+  /**
+   * Once a Table has been converted to a DataStream, the DataStream job must be executed using the
+   * execute method of the StreamExecutionEnvironment.
+   */
+  var isConvertedToDataStream: Boolean = false
+
+  /** Recommended to use this Api to start tasks */
+  def start(name: String = null): JobExecutionResult = {
+    val appName = parameter.getAppName(name, true)
+    execute(appName)
+  }
+
+  @deprecated def execute(jobName: String): JobExecutionResult = {
+    Utils.printLogo(s"FlinkStreamTable $jobName Starting...")
+    if (isConvertedToDataStream) {
+      streamEnv.execute(jobName)
+    } else null
+  }
+
+  def sql(sql: String = null)(implicit callback: String => Unit = null): Unit =
+    FlinkSqlExecutor.executeSql(sql, parameter, this)
+
+  // ...streamEnv api start...
+
+  def $getCachedFiles: JavaList[tuple.Tuple2[String, DistributedCache.DistributedCacheEntry]] =
+    this.streamEnv.getCachedFiles
+
+  def $getJobListeners: JavaList[JobListener] = this.streamEnv.getJobListeners
+
+  def $setParallelism(parallelism: Int): Unit =
+    this.streamEnv.setParallelism(parallelism)
+
+  def $setRuntimeMode(deployMode: RuntimeExecutionMode): StreamExecutionEnvironment =
+    this.streamEnv.setRuntimeMode(deployMode)
+
+  def $setMaxParallelism(maxParallelism: Int): Unit =
+    this.streamEnv.setMaxParallelism(maxParallelism)
+
+  def $getParallelism: Int = this.streamEnv.getParallelism
+
+  def $getMaxParallelism: Int = this.streamEnv.getMaxParallelism
+
+  def $setBufferTimeout(timeoutMillis: Long): StreamExecutionEnvironment =
+    this.streamEnv.setBufferTimeout(timeoutMillis)
+
+  def $getBufferTimeout: Long = this.streamEnv.getBufferTimeout
+
+  def $disableOperatorChaining(): StreamExecutionEnvironment =
+    this.streamEnv.disableOperatorChaining()
+
+  def $getCheckpointConfig: CheckpointConfig =
+    this.streamEnv.getCheckpointConfig
+
+  def $enableCheckpointing(interval: Long, mode: CheckpointingMode): StreamExecutionEnvironment =
+    this.streamEnv.enableCheckpointing(interval, mode)
+
+  def $enableCheckpointing(interval: Long): StreamExecutionEnvironment =
+    this.streamEnv.enableCheckpointing(interval)
+
+  def $getCheckpointingMode: CheckpointingMode =
+    this.streamEnv.getCheckpointingMode
+
+  def $configure(configuration: ReadableConfig, classLoader: ClassLoader): Unit =
+    this.streamEnv.configure(configuration, classLoader)
+
+  def $fromSequence(from: Long, to: Long): DataStream[java.lang.Long] =
+    this.streamEnv.fromSequence(from, to)
+
+  // fromData with varargs removed in Flink 2.0
+  def $fromData[T](data: T): DataStream[T] =
+    this.streamEnv.fromData(data)
+
+  def $fromCollection[T](data: java.util.Collection[T]): DataStream[T] =
+    this.streamEnv.fromCollection(data)
+
+  def $fromParallelCollection[T](data: SplittableIterator[T], clazz: Class[T]): DataStream[T] =
+    this.streamEnv.fromParallelCollection(data, clazz)
+
+  def $readFile[T](inputFormat: FileInputFormat[T], filePath: String): DataStream[T] =
+    this.streamEnv.readFile(inputFormat, filePath)
+
+  def $readFile[T](
+      inputFormat: FileInputFormat[T],
+      filePath: String,
+      watchType: FileProcessingMode,
+      interval: Long): DataStream[T] =
+    this.streamEnv.readFile(inputFormat, filePath, watchType, interval)
+
+  def $socketTextStream(
+      hostname: String,
+      port: Int,
+      delimiter: Char,
+      maxRetry: Long): DataStream[String] =
+    this.streamEnv.socketTextStream(hostname, port, delimiter, maxRetry)
+
+  def $createInput[T](inputFormat: InputFormat[T, _]): DataStream[T] =
+    this.streamEnv.createInput(inputFormat)
+
+  def $fromSource[T](
+      source: Source[T, _ <: SourceSplit, _],
+      watermarkStrategy: WatermarkStrategy[T],
+      sourceName: String): DataStream[T] =
+    this.streamEnv.fromSource(source, watermarkStrategy, sourceName)
+
+  def $registerJobListener(jobListener: JobListener): Unit =
+    this.streamEnv.registerJobListener(jobListener)
+
+  def $clearJobListeners(): Unit = this.streamEnv.clearJobListeners()
+
+  def $executeAsync(): JobClient = this.streamEnv.executeAsync()
+
+  def $executeAsync(jobName: String): JobClient =
+    this.streamEnv.executeAsync(jobName)
+
+  def $getExecutionPlan: String = this.streamEnv.getExecutionPlan
+
+  def $getStreamGraph: StreamGraph = this.streamEnv.getStreamGraph
+
+  def $registerCachedFile(filePath: String, name: String): Unit =
+    this.streamEnv.registerCachedFile(filePath, name)
+
+  def $registerCachedFile(filePath: String, name: String, executable: Boolean): Unit =
+    this.streamEnv.registerCachedFile(filePath, name, executable)
+
+  def $isUnalignedCheckpointsEnabled: Boolean =
+    this.streamEnv.isUnalignedCheckpointsEnabled
+
+  def $isForceUnalignedCheckpoints: Boolean =
+    this.streamEnv.isForceUnalignedCheckpoints
+
+  @deprecated def $readFile[T](
+      inputFormat: FileInputFormat[T],
+      filePath: String,
+      watchType: FileProcessingMode,
+      interval: Long,
+      filter: FilePathFilter): DataStream[T] =
+    this.streamEnv.readFile(inputFormat, filePath, watchType, interval, filter)
+
+  // ...streamEnv api end...
+
+  override def fromDataStream[T](dataStream: DataStream[T]): Table =
+    tableEnv.fromDataStream(dataStream)
+
+  override def fromDataStream[T](dataStream: DataStream[T], schema: Schema): Table =
+    tableEnv.fromDataStream(dataStream, schema)
+
+  override def fromChangelogStream(dataStream: DataStream[Row]): Table =
+    tableEnv.fromChangelogStream(dataStream)
+
+  override def fromChangelogStream(dataStream: DataStream[Row], schema: Schema): Table =
+    tableEnv.fromChangelogStream(dataStream, schema)
+
+  override def fromChangelogStream(
+      dataStream: DataStream[Row],
+      schema: Schema,
+      changelogMode: org.apache.flink.table.connector.ChangelogMode): Table =
+    tableEnv.fromChangelogStream(dataStream, schema, changelogMode)
+
+  override def createTemporaryView[T](path: String, dataStream: DataStream[T]): Unit =
+    tableEnv.createTemporaryView(path, dataStream)
+
+  override def createTemporaryView[T](
+      path: String,
+      dataStream: DataStream[T],
+      schema: Schema): Unit =
+    tableEnv.createTemporaryView(path, dataStream, schema)
+
+  override def toDataStream(table: Table): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table)
+  }
+
+  override def toDataStream[T](table: Table, targetClass: Class[T]): DataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table, targetClass)
+  }
+
+  override def toDataStream[T](
+      table: Table,
+      targetDataType: org.apache.flink.table.types.AbstractDataType[_]): DataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table, targetDataType)
+  }
+
+  override def toChangelogStream(table: Table): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table)
+  }
+
+  override def toChangelogStream(table: Table, targetSchema: Schema): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema)
+  }
+
+  override def toChangelogStream(
+      table: Table,
+      targetSchema: Schema,
+      changelogMode: org.apache.flink.table.connector.ChangelogMode): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema, changelogMode)
+  }
+
+  override def createStatementSet(): org.apache.flink.table.api.bridge.java.StreamStatementSet =
+    tableEnv.createStatementSet()
+
+  // ...table env delegation...
+
+  override def fromValues(values: org.apache.flink.table.expressions.Expression*): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(
+      rowType: org.apache.flink.table.types.AbstractDataType[_],
+      values: org.apache.flink.table.expressions.Expression*): Table =
+    tableEnv.fromValues(rowType, values: _*)
+
+  override def fromValues(values: java.lang.Iterable[_]): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(
+      rowType: org.apache.flink.table.types.AbstractDataType[_],
+      values: java.lang.Iterable[_]): Table =
+    tableEnv.fromValues(rowType, values)
+
+  override def registerCatalog(catalogName: String, catalog: Catalog): Unit =
+    tableEnv.registerCatalog(catalogName, catalog)
+
+  override def getCatalog(catalogName: String): Optional[Catalog] =
+    tableEnv.getCatalog(catalogName)
+
+  override def loadModule(moduleName: String, module: Module): Unit =
+    tableEnv.loadModule(moduleName, module)
+
+  override def unloadModule(moduleName: String): Unit =
+    tableEnv.unloadModule(moduleName)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionClass)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionInstance)
+
+  override def dropTemporarySystemFunction(name: String): Boolean =
+    tableEnv.dropTemporarySystemFunction(name)
+
+  override def createFunction(path: String, functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def createFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def dropFunction(path: String): Boolean = tableEnv.dropFunction(path)
+
+  override def createTemporaryFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporaryFunction(path, functionClass)
+
+  override def createTemporaryFunction(path: String, functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporaryFunction(path, functionInstance)
+
+  override def dropTemporaryFunction(path: String): Boolean =
+    tableEnv.dropTemporaryFunction(path)
+
+  override def createTemporaryView(path: String, view: Table): Unit =
+    tableEnv.createTemporaryView(path, view)
+
+  override def from(path: String): Table = tableEnv.from(path)
+
+  override def listCatalogs(): Array[String] = tableEnv.listCatalogs()
+
+  override def listModules(): Array[String] = tableEnv.listModules()
+
+  override def listDatabases(): Array[String] = tableEnv.listDatabases()
+
+  override def listTables(): Array[String] = tableEnv.listTables()
+
+  override def listViews(): Array[String] = tableEnv.listViews()
+
+  override def listTemporaryTables(): Array[String] =
+    tableEnv.listTemporaryTables
+
+  override def listTemporaryViews(): Array[String] =
+    tableEnv.listTemporaryViews()
+
+  override def listUserDefinedFunctions(): Array[String] =
+    tableEnv.listUserDefinedFunctions()
+
+  override def listFunctions(): Array[String] = tableEnv.listFunctions()
+
+  override def dropTemporaryTable(path: String): Boolean =
+    tableEnv.dropTemporaryTable(path)
+
+  override def dropTemporaryView(path: String): Boolean =
+    tableEnv.dropTemporaryView(path)
+
+  override def explainSql(statement: String, extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, extraDetails: _*)
+
+  override def sqlQuery(query: String): Table = tableEnv.sqlQuery(query)
+
+  override def executeSql(statement: String): TableResult =
+    tableEnv.executeSql(statement)
+
+  override def getCurrentCatalog: String = tableEnv.getCurrentCatalog
+
+  override def useCatalog(catalogName: String): Unit =
+    tableEnv.useCatalog(catalogName)
+
+  override def getCurrentDatabase: String = tableEnv.getCurrentDatabase
+
+  override def useDatabase(databaseName: String): Unit =
+    tableEnv.useDatabase(databaseName)
+
+  override def getConfig: TableConfig = tableEnv.getConfig
+
+  @deprecated override def registerFunction(name: String, function: ScalarFunction): Unit =
+    tableEnv.registerFunction(name, function)
+
+  @deprecated override def registerTable(name: String, table: Table): Unit =
+    tableEnv.registerTable(name, table)
+
+  @deprecated override def scan(tablePath: String*): Table =
+    tableEnv.scan(tablePath: _*)
+
+  @deprecated override def getCompletionHints(statement: String, position: Int): Array[String] =
+    tableEnv.getCompletionHints(statement, position)
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializerV2.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializerV2.scala
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys._
+import org.apache.streampark.common.enums.ApiType
+import org.apache.streampark.common.enums.ApiType.ApiType
+import org.apache.streampark.common.util._
+import org.apache.streampark.common.util.Implicits._
+import org.apache.streampark.flink.core.conf.FlinkConfiguration
+
+import collection.{mutable, Map}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.util.ParameterTool
+
+import java.io.File
+
+private[flink] object FlinkStreamingInitializerV2 {
+
+  def initialize(
+      args: Array[String],
+      config: (StreamExecutionEnvironment, ParameterTool) => Unit): (ParameterTool, StreamExecutionEnvironment) = {
+    val flinkInitializer = new FlinkStreamingInitializerV2(args, ApiType.SCALA)
+    flinkInitializer.streamEnvConfFunc = config
+    (flinkInitializer.configuration.parameter, flinkInitializer.streamEnv)
+  }
+
+  def initialize(args: StreamEnvConfig): (ParameterTool, StreamExecutionEnvironment) = {
+    val flinkInitializer =
+      new FlinkStreamingInitializerV2(args.args, ApiType.JAVA)
+    flinkInitializer.javaStreamEnvConfFunc = args.conf
+    (flinkInitializer.configuration.parameter, flinkInitializer.streamEnv)
+  }
+}
+
+private[flink] class FlinkStreamingInitializerV2(args: Array[String], apiType: ApiType)
+  extends Logger {
+
+  var streamEnvConfFunc: (StreamExecutionEnvironment, ParameterTool) => Unit = _
+
+  var tableConfFunc: (TableConfig, ParameterTool) => Unit = _
+
+  var javaStreamEnvConfFunc: StreamEnvConfigFunction = _
+
+  var javaTableEnvConfFunc: TableEnvConfigFunction = _
+
+  implicit private[flink] val parameter: ParameterTool = configuration.parameter
+
+  lazy val streamEnv: StreamExecutionEnvironment = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment(configuration.envConfig)
+
+    apiType match {
+      case ApiType.JAVA if javaStreamEnvConfFunc != null =>
+        javaStreamEnvConfFunc.configuration(env, configuration.parameter)
+      case ApiType.SCALA if streamEnvConfFunc != null =>
+        streamEnvConfFunc(env, configuration.parameter)
+      case _ =>
+    }
+    env.getConfig.setGlobalJobParameters(configuration.parameter)
+    env
+  }
+
+  lazy val configuration: FlinkConfiguration = initParameter()
+
+  def initParameter(): FlinkConfiguration = {
+    val argsMap = ParameterTool.fromArgs(args)
+    val config = argsMap.get(KEY_APP_CONF(), null) match {
+      case null | "" =>
+        throw new ExceptionInInitializerError(
+          "[StreamPark] Usage:can't find config,please set \"--conf $path \" in main arguments")
+      case file => file
+    }
+    val configMap = parseConfig(config)
+    val properConf = extractConfigByPrefix(configMap, KEY_FLINK_PROPERTY_PREFIX)
+    val appConf = extractConfigByPrefix(configMap, KEY_APP_PREFIX)
+
+    // config priority: explicitly specified priority > project profiles > system profiles
+    val parameter = ParameterTool
+      .fromSystemProperties()
+      .mergeWith(ParameterTool.fromMap(properConf))
+      .mergeWith(ParameterTool.fromMap(appConf))
+      .mergeWith(argsMap)
+
+    val envConfig = Configuration.fromMap(properConf)
+    FlinkConfiguration(parameter, envConfig, null)
+  }
+
+  def parseConfig(config: String): Map[String, String] = {
+
+    lazy val content = DeflaterUtils.unzipString(config.drop(7))
+
+    def readConfig(text: String): Map[String, String] = {
+      val format = config.split("\\.").last.toLowerCase
+      format match {
+        case "yml" | "yaml" => PropertiesUtils.fromYamlText(text)
+        case "conf" => PropertiesUtils.fromHoconText(text)
+        case "properties" => PropertiesUtils.fromPropertiesText(text)
+        case _ =>
+          throw new IllegalArgumentException(
+            "[StreamPark] Usage: application config file error,must be [yaml|conf|properties]")
+      }
+    }
+
+    val map = config match {
+      case x if x.startsWith("yaml://") => PropertiesUtils.fromYamlText(content)
+      case x if x.startsWith("conf://") =>
+        PropertiesUtils.fromHoconText(content)
+      case x if x.startsWith("prop://") =>
+        PropertiesUtils.fromPropertiesText(content)
+      case x if x.startsWith("hdfs://") =>
+        // If the configuration file with the hdfs, user will need to copy the hdfs-related configuration files under the resources dir
+        val text = HdfsUtils.read(x)
+        readConfig(text)
+      case _ =>
+        val configFile = new File(config)
+        require(
+          configFile.exists(),
+          s"[StreamPark] Usage: application config file: $configFile is not found!!!")
+        val text = FileUtils.readFile(configFile)
+        readConfig(text)
+    }
+    map.filter(_._2.nonEmpty)
+  }
+
+  def extractConfigByPrefix(configMap: Map[String, String], prefix: String): Map[String, String] = {
+    val map = mutable.Map[String, String]()
+    configMap.foreach(x =>
+      if (x._1.startsWith(prefix)) {
+        map += x._1.drop(prefix.length) -> x._2
+      })
+    map
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkTableInitializerV2.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkTableInitializerV2.scala
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys._
+import org.apache.streampark.common.enums.{ApiType, PlannerType}
+import org.apache.streampark.common.enums.ApiType.ApiType
+import org.apache.streampark.common.util.{DeflaterUtils, PropertiesUtils}
+import org.apache.streampark.common.util.Implicits._
+import org.apache.streampark.flink.core.EnhancerImplicit._
+import org.apache.streampark.flink.core.conf.FlinkConfiguration
+
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.{EnvironmentSettings, TableConfig, TableEnvironment}
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.util.ParameterTool
+
+import java.io.File
+
+import scala.collection.{mutable, Map}
+import scala.util.{Failure, Success, Try}
+
+private[flink] object FlinkTableInitializerV2 {
+
+  def initialize(
+      args: Array[String],
+      config: (TableConfig, ParameterTool) => Unit): (ParameterTool, TableEnvironment) = {
+    val flinkInitializer = new FlinkTableInitializerV2(args, ApiType.SCALA)
+    flinkInitializer.tableConfFunc = config
+    (flinkInitializer.configuration.parameter, flinkInitializer.tableEnv)
+  }
+
+  def initialize(args: TableEnvConfig): (ParameterTool, TableEnvironment) = {
+    val flinkInitializer = new FlinkTableInitializerV2(args.args, ApiType.JAVA)
+    flinkInitializer.javaTableEnvConfFunc = args.conf
+    (flinkInitializer.configuration.parameter, flinkInitializer.tableEnv)
+  }
+
+  def initialize(
+      args: Array[String],
+      configStream: (StreamExecutionEnvironment, ParameterTool) => Unit,
+      configTable: (TableConfig, ParameterTool) => Unit): (ParameterTool, StreamExecutionEnvironment, StreamTableEnvironment) = {
+
+    val flinkInitializer = new FlinkTableInitializerV2(args, ApiType.SCALA)
+    flinkInitializer.streamEnvConfFunc = configStream
+    flinkInitializer.tableConfFunc = configTable
+    (
+      flinkInitializer.configuration.parameter,
+      flinkInitializer.streamEnv,
+      flinkInitializer.streamTableEnv)
+  }
+
+  def initialize(
+      args: StreamTableEnvConfig): (ParameterTool, StreamExecutionEnvironment, StreamTableEnvironment) = {
+    val flinkInitializer = new FlinkTableInitializerV2(args.args, ApiType.JAVA)
+    flinkInitializer.javaStreamEnvConfFunc = args.streamConfig
+    flinkInitializer.javaTableEnvConfFunc = args.tableConfig
+    (
+      flinkInitializer.configuration.parameter,
+      flinkInitializer.streamEnv,
+      flinkInitializer.streamTableEnv)
+  }
+
+}
+
+private[flink] class FlinkTableInitializerV2(args: Array[String], apiType: ApiType)
+  extends FlinkStreamingInitializerV2(args, apiType) {
+
+  private[this] lazy val envSettings = {
+
+    val builder = EnvironmentSettings.newInstance()
+
+    Try(PlannerType.withName(parameter.get(KEY_FLINK_TABLE_PLANNER)))
+      .getOrElse(PlannerType.BLINK) match {
+      case PlannerType.BLINK =>
+        val useBlinkPlanner =
+          Try(builder.getClass.getDeclaredMethod("useBlinkPlanner"))
+            .getOrElse(null)
+        if (useBlinkPlanner == null) {
+          logWarn("useBlinkPlanner deprecated")
+        } else {
+          useBlinkPlanner.setAccessible(true)
+          useBlinkPlanner.invoke(builder)
+          logInfo("blinkPlanner will be used.")
+        }
+      case PlannerType.OLD =>
+        val useOldPlanner = Try(builder.getClass.getDeclaredMethod("useOldPlanner")).getOrElse(null)
+        if (useOldPlanner == null) {
+          logWarn("useOldPlanner deprecated")
+        } else {
+          useOldPlanner.setAccessible(true)
+          useOldPlanner.invoke(builder)
+          logInfo("useOldPlanner will be used.")
+        }
+      case PlannerType.ANY =>
+        val useAnyPlanner = Try(builder.getClass.getDeclaredMethod("useAnyPlanner")).getOrElse(null)
+        if (useAnyPlanner == null) {
+          logWarn("useAnyPlanner deprecated")
+        } else {
+          logInfo("useAnyPlanner will be used.")
+          useAnyPlanner.setAccessible(true)
+          useAnyPlanner.invoke(builder)
+        }
+    }
+
+    parameter.get(KEY_FLINK_CONF(), null) match {
+      case null | "" =>
+        throw new ExceptionInInitializerError(
+          "[StreamPark] Usage:can't find config,please set \"--flink.conf $conf \" in main arguments")
+      case conf => builder.withConfiguration(
+          Configuration.fromMap(PropertiesUtils.fromYamlText(DeflaterUtils.unzipString(conf))))
+    }
+    val buildWith =
+      (parameter.get(KEY_FLINK_TABLE_CATALOG), parameter.get(KEY_FLINK_TABLE_DATABASE))
+    buildWith match {
+      case (x: String, y: String) if x != null && y != null =>
+        logInfo(s"with built in catalog: $x")
+        logInfo(s"with built in database: $y")
+        builder.withBuiltInCatalogName(x)
+        builder.withBuiltInDatabaseName(y)
+      case (x: String, _) if x != null =>
+        logInfo(s"with built in catalog: $x")
+        builder.withBuiltInCatalogName(x)
+      case (_, y: String) if y != null =>
+        logInfo(s"with built in database: $y")
+        builder.withBuiltInDatabaseName(y)
+      case _ =>
+    }
+    builder
+  }
+
+  lazy val tableEnv: TableEnvironment = {
+    logInfo(s"job working in batch mode")
+    envSettings.inBatchMode()
+    val tableEnv = TableEnvironment.create(envSettings.build()).setAppName
+    apiType match {
+      case ApiType.JAVA if javaTableEnvConfFunc != null =>
+        javaTableEnvConfFunc.configuration(tableEnv.getConfig, parameter)
+      case ApiType.SCALA if tableConfFunc != null =>
+        tableConfFunc(tableEnv.getConfig, parameter)
+      case _ =>
+    }
+    tableEnv
+  }
+
+  lazy val streamTableEnv: StreamTableEnvironment = {
+    logInfo(s"components should work in streaming mode")
+    envSettings.inStreamingMode()
+    val setting = envSettings.build()
+
+    if (streamEnvConfFunc != null) {
+      streamEnvConfFunc(streamEnv, parameter)
+    }
+    if (javaStreamEnvConfFunc != null) {
+      javaStreamEnvConfFunc.configuration(streamEnv, parameter)
+    }
+    val streamTableEnv =
+      StreamTableEnvironment.create(streamEnv, setting).setAppName
+    apiType match {
+      case ApiType.JAVA if javaTableEnvConfFunc != null =>
+        javaTableEnvConfFunc.configuration(streamTableEnv.getConfig, parameter)
+      case ApiType.SCALA if tableConfFunc != null =>
+        tableConfFunc(streamTableEnv.getConfig, parameter)
+      case _ =>
+    }
+    streamTableEnv
+  }
+
+  /** In case of table SQL, the parameter conf is not required, it depends on the developer. */
+
+  override def initParameter(): FlinkConfiguration = {
+    val configuration = {
+      val argsMap = ParameterTool.fromArgs(args)
+      argsMap.get(KEY_APP_CONF(), null) match {
+        case null | "" =>
+          logWarn("Usage:can't find config,you can set \"--conf $path \" in main arguments")
+          val parameter =
+            ParameterTool.fromSystemProperties().mergeWith(argsMap)
+          FlinkConfiguration(parameter, new Configuration(), new Configuration())
+        case file =>
+          val configMap = parseConfig(file)
+          // set sql..
+          val sqlConf = mutable.Map[String, String]()
+          configMap.foreach(x => {
+            if (x._1.startsWith(KEY_SQL_PREFIX)) {
+              sqlConf += x._1.drop(KEY_SQL_PREFIX.length) -> x._2
+            }
+          })
+
+          // config priority: explicitly specified priority > project profiles > system profiles
+          val properConf =
+            extractConfigByPrefix(configMap, KEY_FLINK_PROPERTY_PREFIX)
+          val appConf = extractConfigByPrefix(configMap, KEY_APP_PREFIX)
+          val tableConf =
+            extractConfigByPrefix(configMap, KEY_FLINK_TABLE_PREFIX)
+
+          val tableConfig = Configuration.fromMap(tableConf)
+          val envConfig = Configuration.fromMap(properConf)
+
+          val parameter = ParameterTool
+            .fromSystemProperties()
+            .mergeWith(ParameterTool.fromMap(properConf))
+            .mergeWith(ParameterTool.fromMap(tableConf))
+            .mergeWith(ParameterTool.fromMap(appConf))
+            .mergeWith(ParameterTool.fromMap(sqlConf))
+            .mergeWith(argsMap)
+
+          FlinkConfiguration(parameter, envConfig, tableConfig)
+      }
+    }
+
+    configuration.parameter.get(KEY_FLINK_SQL()) match {
+      case null => configuration
+      case param =>
+        // for streampark-console
+        Try(DeflaterUtils.unzipString(param)) match {
+          case Success(value) =>
+            configuration.copy(parameter = configuration.parameter.mergeWith(
+              ParameterTool.fromMap(Map(KEY_FLINK_SQL() -> value))))
+          case Failure(_) =>
+            val sqlFile = new File(param)
+            Try(PropertiesUtils.fromYamlFile(sqlFile.getAbsolutePath)) match {
+              case Success(value) =>
+                configuration.copy(parameter =
+                  configuration.parameter.mergeWith(ParameterTool.fromMap(value)))
+              case Failure(e) =>
+                new IllegalArgumentException(s"[StreamPark] init sql error.$e")
+                configuration
+            }
+        }
+    }
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkTableTrait.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/FlinkTableTrait.scala
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Utils
+import org.apache.streampark.flink.core.EnhancerImplicit._
+
+import org.apache.flink.api.common.JobExecutionResult
+import org.apache.flink.table.api._
+import org.apache.flink.table.catalog.Catalog
+import org.apache.flink.table.expressions.Expression
+import org.apache.flink.table.functions._
+import org.apache.flink.table.module.Module
+import org.apache.flink.table.types.AbstractDataType
+import org.apache.flink.util.ParameterTool
+
+import java.lang
+import java.util.Optional
+
+abstract class FlinkTableTrait(val parameter: ParameterTool, private val tableEnv: TableEnvironment)
+  extends TableEnvironment {
+
+  def start(): JobExecutionResult = {
+    val appName = parameter.getAppName(required = true)
+    execute(appName)
+  }
+
+  def execute(jobName: String): JobExecutionResult = {
+    Utils.printLogo(s"FlinkTable $jobName Starting...")
+    null
+  }
+
+  def sql(sql: String = null): Unit =
+    FlinkSqlExecutor.executeSql(sql, parameter, this)
+
+  override def fromValues(values: Expression*): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(rowType: AbstractDataType[_], values: Expression*): Table =
+    tableEnv.fromValues(rowType, values: _*)
+
+  override def fromValues(values: lang.Iterable[_]): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(rowType: AbstractDataType[_], values: lang.Iterable[_]): Table =
+    tableEnv.fromValues(rowType, values)
+
+  override def registerCatalog(catalogName: String, catalog: Catalog): Unit =
+    tableEnv.registerCatalog(catalogName, catalog)
+
+  override def getCatalog(catalogName: String): Optional[Catalog] =
+    tableEnv.getCatalog(catalogName)
+
+  override def loadModule(moduleName: String, module: Module): Unit =
+    tableEnv.loadModule(moduleName, module)
+
+  override def unloadModule(moduleName: String): Unit =
+    tableEnv.unloadModule(moduleName)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionClass)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionInstance)
+
+  override def dropTemporarySystemFunction(name: String): Boolean =
+    tableEnv.dropTemporarySystemFunction(name)
+
+  override def createFunction(path: String, functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def createFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def dropFunction(path: String): Boolean = tableEnv.dropFunction(path)
+
+  override def createTemporaryFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporaryFunction(path, functionClass)
+
+  override def createTemporaryFunction(path: String, functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporaryFunction(path, functionInstance)
+
+  override def dropTemporaryFunction(path: String): Boolean =
+    tableEnv.dropTemporaryFunction(path)
+
+  override def createTemporaryView(path: String, view: Table): Unit =
+    tableEnv.createTemporaryView(path, view)
+
+  override def from(path: String): Table = tableEnv.from(path)
+
+  override def listCatalogs(): Array[String] = tableEnv.listCatalogs()
+
+  override def listModules(): Array[String] = tableEnv.listModules()
+
+  override def listDatabases(): Array[String] = tableEnv.listDatabases()
+
+  override def listTables(): Array[String] = tableEnv.listTables()
+
+  override def listViews(): Array[String] = tableEnv.listViews()
+
+  override def listTemporaryTables(): Array[String] =
+    tableEnv.listTemporaryTables
+
+  override def listTemporaryViews(): Array[String] =
+    tableEnv.listTemporaryViews()
+
+  override def listUserDefinedFunctions(): Array[String] =
+    tableEnv.listUserDefinedFunctions()
+
+  override def listFunctions(): Array[String] = tableEnv.listFunctions()
+
+  override def dropTemporaryTable(path: String): Boolean =
+    tableEnv.dropTemporaryTable(path)
+
+  override def dropTemporaryView(path: String): Boolean =
+    tableEnv.dropTemporaryView(path)
+
+  override def explainSql(statement: String, extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, extraDetails: _*)
+
+  override def sqlQuery(query: String): Table = tableEnv.sqlQuery(query)
+
+  override def executeSql(statement: String): TableResult =
+    tableEnv.executeSql(statement)
+
+  override def getCurrentCatalog: String = tableEnv.getCurrentCatalog
+
+  override def useCatalog(catalogName: String): Unit =
+    tableEnv.useCatalog(catalogName)
+
+  override def getCurrentDatabase: String = tableEnv.getCurrentDatabase
+
+  override def useDatabase(databaseName: String): Unit =
+    tableEnv.useDatabase(databaseName)
+
+  override def getConfig: TableConfig = tableEnv.getConfig
+
+  override def createStatementSet(): StatementSet =
+    tableEnv.createStatementSet()
+
+  @deprecated override def registerFunction(name: String, function: ScalarFunction): Unit =
+    tableEnv.registerFunction(name, function)
+
+  @deprecated override def registerTable(name: String, table: Table): Unit =
+    tableEnv.registerTable(name, table)
+
+  @deprecated override def scan(tablePath: String*): Table =
+    tableEnv.scan(tablePath: _*)
+
+  @deprecated override def getCompletionHints(statement: String, position: Int): Array[String] =
+    tableEnv.getCompletionHints(statement, position)
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/SqlCommandParser.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/SqlCommandParser.scala
@@ -1,0 +1,651 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys.PARAM_PREFIX
+import org.apache.streampark.common.enums.FlinkSqlValidationFailedType
+import org.apache.streampark.common.util.Logger
+
+import enumeratum.EnumEntry
+import org.apache.commons.lang3.StringUtils
+
+import java.lang.{Boolean => JavaBool}
+import java.util.Scanner
+import java.util.regex.{Matcher, Pattern}
+
+import scala.annotation.tailrec
+import scala.collection.{immutable, mutable}
+import scala.collection.mutable.ListBuffer
+import scala.util.control.Breaks.{break, breakable}
+
+object SqlCommandParser extends Logger {
+
+  def parseSQL(
+      sql: String,
+      validationCallback: FlinkSqlValidationResult => Unit = null): List[SqlCommandCall] = {
+    val sqlEmptyError = "verify failed: flink sql cannot be empty."
+    require(StringUtils.isNotBlank(sql), sqlEmptyError)
+    val sqlSegments = SqlSplitter.splitSql(sql)
+    sqlSegments match {
+      case s if s.isEmpty =>
+        if (validationCallback != null) {
+          validationCallback(
+            FlinkSqlValidationResult(
+              success = false,
+              failedType = FlinkSqlValidationFailedType.VERIFY_FAILED,
+              exception = sqlEmptyError))
+          null
+        } else {
+          throw new IllegalArgumentException(sqlEmptyError)
+        }
+      case segments =>
+        val calls = new ListBuffer[SqlCommandCall]
+        for (segment <- segments) {
+          parseLine(segment) match {
+            case Some(x) => calls += x
+            case _ =>
+              if (validationCallback != null) {
+                validationCallback(
+                  FlinkSqlValidationResult(
+                    success = false,
+                    failedType = FlinkSqlValidationFailedType.UNSUPPORTED_SQL,
+                    lineStart = segment.start,
+                    lineEnd = segment.end,
+                    exception = s"unsupported sql",
+                    sql = segment.sql))
+              } else {
+                throw new UnsupportedOperationException(s"unsupported sql: ${segment.sql}")
+              }
+          }
+        }
+
+        calls.toList match {
+          case c if c.isEmpty =>
+            if (validationCallback != null) {
+              validationCallback(
+                FlinkSqlValidationResult(
+                  success = false,
+                  failedType = FlinkSqlValidationFailedType.VERIFY_FAILED,
+                  exception = "flink sql syntax error, no executable sql"))
+              null
+            } else {
+              throw new UnsupportedOperationException("flink sql syntax error, no executable sql")
+            }
+          case r => r
+        }
+    }
+  }
+
+  private[this] def parseLine(sqlSegment: SqlSegment): Option[SqlCommandCall] = {
+    val sqlCommand = SqlCommand.get(sqlSegment.sql.trim)
+    if (sqlCommand == null) None
+    else {
+      val matcher = sqlCommand.matcher
+      val groups = new Array[String](matcher.groupCount)
+      for (i <- groups.indices) {
+        groups(i) = matcher.group(i + 1)
+      }
+      sqlCommand
+        .converter(groups)
+        .map(x =>
+          SqlCommandCall(sqlSegment.start, sqlSegment.end, sqlCommand, x, sqlSegment.sql.trim))
+    }
+  }
+
+}
+
+object Converters {
+  val NO_OPERANDS = (_: Array[String]) => Some(Array.empty[String])
+}
+
+sealed abstract class SqlCommand(
+    val name: String,
+    private val regex: String,
+    val converter: Array[String] => Option[Array[String]] = (x: Array[String]) =>
+      Some(Array[String](x.head)))
+  extends EnumEntry {
+  var matcher: Matcher = _
+
+  def matches(input: String): Boolean = {
+    if (StringUtils.isBlank(regex)) false
+    else {
+      val pattern =
+        Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL)
+      matcher = pattern.matcher(input)
+      matcher.matches()
+    }
+  }
+}
+
+object SqlCommand extends enumeratum.Enum[SqlCommand] {
+
+  def get(stmt: String): SqlCommand = {
+    var cmd: SqlCommand = null
+    breakable {
+      this.values.foreach(x => {
+        if (x.matches(stmt)) {
+          cmd = x
+          break()
+        }
+      })
+    }
+    cmd
+  }
+
+  val values: immutable.IndexedSeq[SqlCommand] = findValues
+
+  // ---- SELECT Statements--------------------------------------------------------------------------------------------------------------------------------
+  case object SELECT extends SqlCommand("select", "(SELECT\\s+.+)")
+
+  // ----CREATE Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * <pre> CREATE [TEMPORARY] TABLE [IF NOT EXISTS] [catalog_name.][db_name.]table_name ( {
+   * <physical_column_definition> | <metadata_column_definition> | <computed_column_definition> }[ ,
+   * ...n] [ <watermark_definition> ] [ <table_constraint> ][ , ...n] ) [COMMENT table_comment]
+   * [PARTITIONED BY (partition_column_name1, partition_column_name2, ...)] WITH (key1=val1,
+   * key2=val2, ...) [ LIKE source_table [( <like_options> )] ] </pre
+   */
+  case object CREATE_TABLE
+    extends SqlCommand("create table", "(CREATE\\s+(TEMPORARY\\s+|)TABLE\\s+.+)")
+
+  /** <pre> CREATE CATALOG catalog_name WITH (key1=val1, key2=val2, ...) </pre> */
+  case object CREATE_CATALOG extends SqlCommand("create catalog", "(CREATE\\s+CATALOG\\s+.+)")
+
+  /**
+   * <pre> CREATE DATABASE [IF NOT EXISTS] [catalog_name.]db_name<br> [COMMENT database_comment]<br>
+   * WITH (key1=val1, key2=val2, ...)<br> </pre>
+   */
+  case object CREATE_DATABASE extends SqlCommand("create database", "(CREATE\\s+DATABASE\\s+.+)")
+
+  /**
+   * <pre> CREATE [TEMPORARY] VIEW [IF NOT EXISTS] [catalog_name.][db_name.]view_name [( columnName
+   * [, columnName ]* )] [COMMENT view_comment] AS query_expression< </pre
+   */
+  case object CREATE_VIEW
+    extends SqlCommand(
+      "create view",
+      "(CREATE\\s+(TEMPORARY\\s+|)VIEW\\s+(IF\\s+NOT\\s+EXISTS\\s+|)(\\S+)\\s+AS\\s+SELECT\\s+.+)")
+
+  /**
+   * <pre> CREATE [TEMPORARY|TEMPORARY SYSTEM] FUNCTION [IF NOT EXISTS]
+   * [catalog_name.][db_name.]function_name AS identifier [LANGUAGE JAVA|SCALA|PYTHON] </pre
+   */
+  case object CREATE_FUNCTION
+    extends SqlCommand(
+      "create function",
+      "(CREATE\\s+(TEMPORARY\\s+|TEMPORARY\\s+SYSTEM\\s+|)FUNCTION\\s+(IF\\s+NOT\\s+EXISTS\\s+|)(\\S+)\\s+AS\\s+.*)")
+
+  // ----DROP Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * <pre> DROP statements are used to remove a catalog with the given catalog name or to remove a
+   * registered table/view/function from the current or specified Catalog.
+   *
+   * Flink SQL supports the following DROP statements for now: * DROP CATALOG * DROP TABLE * DROP
+   * DATABASE * DROP VIEW * DROP FUNCTION </pre>
+   */
+
+  /** <strong>DROP CATALOG [IF EXISTS] catalog_name</strong> */
+  case object DROP_CATALOG extends SqlCommand("drop catalog", "(DROP\\s+CATALOG\\s+.+)")
+
+  /** <strong>DROP [TEMPORARY] TABLE [IF EXISTS] [catalog_name.][db_name.]table_name</strong> */
+  case object DROP_TABLE extends SqlCommand("drop table", "(DROP\\s+(TEMPORARY\\s+|)TABLE\\s+.+)")
+
+  /** <strong>DROP DATABASE [IF EXISTS] [catalog_name.]db_name [ (RESTRICT | CASCADE) ]</strong> */
+  case object DROP_DATABASE extends SqlCommand("drop database", "(DROP\\s+DATABASE\\s+.+)")
+
+  /** <strong>DROP [TEMPORARY] VIEW [IF EXISTS] [catalog_name.][db_name.]view_name</strong> */
+  case object DROP_VIEW extends SqlCommand("drop view", "(DROP\\s+(TEMPORARY\\s+|)VIEW\\s+.+)")
+
+  /**
+   * <strong>DROP [TEMPORARY|TEMPORARY SYSTEM] FUNCTION [IF EXISTS]
+   * [catalog_name.][db_name.]function_name</strong>
+   */
+  case object DROP_FUNCTION
+    extends SqlCommand(
+      "drop function",
+      "(DROP\\s+(TEMPORARY\\s+|TEMPORARY\\s+SYSTEM\\s+|)FUNCTION\\s+.+)")
+
+  // ----ALTER Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * <strong>ALTER TABLE [catalog_name.][db_name.]table_name RENAME TO new_table_name</strong>
+   *
+   * <strong>ALTER TABLE [catalog_name.][db_name.]table_name SET (key1=val1, key2=val2,
+   * ...)</strong>
+   */
+  case object ALTER_TABLE extends SqlCommand("alter table", "(ALTER\\s+TABLE\\s+.+)")
+
+  /**
+   * <strong>ALTER VIEW [catalog_name.][db_name.]view_name RENAME TO new_view_name</strong>
+   *
+   * <strong>ALTER VIEW [catalog_name.][db_name.]view_name AS new_query_expression</strong>
+   */
+  case object ALTER_VIEW extends SqlCommand("alter view", "(ALTER\\s+VIEW\\s+.+)")
+
+  /** <strong>ALTER DATABASE [catalog_name.]db_name SET (key1=val1, key2=val2, ...)</strong> */
+  case object ALTER_DATABASE extends SqlCommand("alter database", "(ALTER\\s+DATABASE\\s+.+)")
+
+  /**
+   * <strong> ALTER [TEMPORARY|TEMPORARY SYSTEM] FUNCTION [IF EXISTS]
+   * [catalog_name.][db_name.]function_name AS identifier [LANGUAGE JAVA|SCALA|PYTHON] </strong>
+   */
+  case object ALTER_FUNCTION
+    extends SqlCommand(
+      "alter function",
+      "(ALTER\\s+(TEMPORARY\\s+|TEMPORARY\\s+SYSTEM\\s+|)FUNCTION\\s+.+)")
+
+  // ---- INSERT Statement--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * INSERT { INTO | OVERWRITE } [catalog_name.][db_name.]table_name [PARTITION part_spec]
+   * [column_list] select_statement INSERT { INTO | OVERWRITE } [catalog_name.][db_name.]table_name
+   * VALUES values_row [, values_row ...]
+   */
+  case object INSERT extends SqlCommand("insert", "(INSERT\\s+(INTO|OVERWRITE)\\s+.+)")
+
+  // ---- DESCRIBE Statement--------------------------------------------------------------------------------------------------------------------------------
+
+  /** { DESCRIBE | DESC } [catalog_name.][db_name.]table_name */
+  case object DESC extends SqlCommand("desc", "(DESC\\s+.+)")
+
+  /** { DESCRIBE | DESC } [catalog_name.][db_name.]table_name */
+  case object DESCRIBE extends SqlCommand("describe", "(DESCRIBE\\s+.+)")
+
+  // ---- EXPLAIN Statement--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * For flink-1.13.x: EXPLAIN PLAN FOR `<query_statement_or_insert_statement>` <br> For
+   * flink-1.14.x: EXPLAIN ESTIMATED_COST, CHANGELOG_MODE, JSON_EXECUTION_PLAN
+   * `<query_statement_or_insert_statement>`<br> For flink-1.15.x: <br> <pre> EXPLAIN
+   * [([ExplainDetail[, ExplainDetail]*]) | PLAN FOR]
+   * <query_statement_or_insert_statement_or_statement_set>
+   *
+   * statement_set: EXECUTE STATEMENT SET BEGIN insert_statement; ... insert_statement; END; </pre>
+   * Recommended not to use the form of flink-1.15.x
+   */
+  case object EXPLAIN extends SqlCommand("explain", "(EXPLAIN\\s+.+)")
+
+  // ---- USE Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** USE CATALOG catalog_name */
+  case object USE_CATALOG extends SqlCommand("use catalog", "(USE\\s+CATALOG\\s+.+)")
+
+  /** USE MODULES module_name1[, module_name2, ...] */
+  case object USE_MODULES extends SqlCommand("use modules", "(USE\\s+MODULES\\s+.+)")
+
+  /** USE [catalog_name.]database_name */
+  case object USE_DATABASE extends SqlCommand("use database", "(USE\\s+(?!(CATALOG|MODULES)).+)")
+
+  // ----SHOW Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** SHOW CATALOGS */
+  case object SHOW_CATALOGS extends SqlCommand("show catalogs", "(SHOW\\s+CATALOGS\\s*)")
+
+  /** SHOW CURRENT CATALOG */
+  case object SHOW_CURRENT_CATALOG
+    extends SqlCommand("show current catalog", "(SHOW\\s+CURRENT\\s+CATALOG\\s*)")
+
+  /** SHOW DATABASES */
+  case object SHOW_DATABASES extends SqlCommand("show databases", "(SHOW\\s+DATABASES\\s*)")
+
+  /** SHOW CURRENT DATABASE */
+  case object SHOW_CURRENT_DATABASE
+    extends SqlCommand("show current database", "(SHOW\\s+CURRENT\\s+DATABASE\\s*)")
+
+  /**
+   * SHOW TABLES,support from flink-1.13.x<br> SHOW TABLES [ ( FROM | IN )
+   * [catalog_name.]database_name ] [ [NOT] LIKE `<sql_like_pattern`> ], support from flink-1.15.x
+   */
+  case object SHOW_TABLES extends SqlCommand("show tables", "(SHOW\\s+TABLES.*)")
+
+  /** SHOW CREATE TABLE, flink-1.14.x support. */
+  case object SHOW_CREATE_TABLE
+    extends SqlCommand("show create table", "(SHOW\\s+CREATE\\s+TABLE\\s+.+)")
+
+  /**
+   * SHOW COLUMNS ( FROM | IN ) [`[`catalog_name.]database.]`<table_name>` [ [NOT] LIKE
+   * `<sql_like_pattern>`],flink-1.15.x support.
+   */
+  case object SHOW_COLUMNS extends SqlCommand("show columns", "(SHOW\\s+COLUMNS\\s+.+)")
+
+  /** SHOW VIEWS */
+  case object SHOW_VIEWS extends SqlCommand("show views", "(SHOW\\s+VIEWS\\s*)")
+
+  /** SHOW CREATE VIEW */
+  case object SHOW_CREATE_VIEW
+    extends SqlCommand("show create view", "(SHOW\\s+CREATE\\s+VIEW\\s+.+)")
+
+  /** SHOW [USER] FUNCTIONS */
+  case object SHOW_FUNCTIONS
+    extends SqlCommand("show functions", "(SHOW\\s+(USER\\s+|)FUNCTIONS\\s*)")
+
+  /** SHOW [FULL] MODULES */
+  case object SHOW_MODULES extends SqlCommand("show modules", "(SHOW\\s+(FULL\\s+|)MODULES\\s*)")
+
+  // ----LOAD Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** LOAD MODULE module_name [WITH ('key1' = 'val1', 'key2' = 'val2', ...)] */
+  case object LOAD_MODULE extends SqlCommand("load module", "(LOAD\\s+MODULE\\s+.+)")
+
+  // ----UNLOAD Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** UNLOAD MODULE module_name */
+  case object UNLOAD_MODULE extends SqlCommand("unload module", "(UNLOAD\\s+MODULE\\s+.+)")
+
+  // ----SET Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** SET ('key' = 'value') */
+  case object SET
+    extends SqlCommand(
+      "set",
+      "SET(\\s+(\\S+)\\s*=(.*))?",
+      {
+        case a if a.length < 3 => None
+        case a if a.head == null => Some(Array[String](cleanUp(a.head)))
+        case a => Some(Array[String](cleanUp(a(1)), cleanUp(a(2))))
+      })
+
+  // ----RESET Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** RESET ('key') */
+  case object RESET extends SqlCommand("reset", "RESET\\s+'(.*)'")
+
+  /** RESET */
+  case object RESET_ALL extends SqlCommand("reset all", "RESET", _ => Some(Array[String]("ALL")))
+
+  // ----INSERT SET Statements--------------------------------------------------------------------------------------------------------------------------------
+  /*
+   * <pre>
+   * SQL Client execute each INSERT INTO statement as a single Flink job. However,
+   * this is sometimes not optimal because some part of the pipeline can be reused.
+   * SQL Client supports STATEMENT SET syntax to execute a set of SQL statements.
+   * This is an equivalent feature with StatementSet in Table API.
+   * The STATEMENT SET syntax encloses one or more INSERT INTO statements.
+   * All statements in a STATEMENT SET block are holistically optimized and executed as a single Flink job.
+   * Joint optimization and execution allows for reusing common intermediate results and can therefore significantly
+   * improve the efficiency of executing multiple queries.
+   * </pre>
+   */
+  /** This is SQL Client's syntax, don't use in our platform. */
+  @deprecated
+  case object BEGIN_STATEMENT_SET
+    extends SqlCommand("begin statement set", "BEGIN\\s+STATEMENT\\s+SET", Converters.NO_OPERANDS)
+
+  /** This is SQL Client's syntax, don't use in our platform. */
+  @deprecated
+  case object END_STATEMENT_SET
+    extends SqlCommand("end statement set", "END", Converters.NO_OPERANDS)
+
+  // Since: 2.1.2 for flink 1.18
+  case object DELETE extends SqlCommand("delete", "(DELETE\\s+FROM\\s+.+)")
+
+  // Since: 2.1.2 for flink 1.18
+  case object UPDATE extends SqlCommand("update", "(UPDATE\\s+.+)")
+
+  private[this] def cleanUp(sql: String): String =
+    sql.trim.replaceAll("^(['\"])|(['\"])$", "")
+
+}
+
+/** Call of SQL command with operands and command type. */
+case class SqlCommandCall(
+    lineStart: Int,
+    lineEnd: Int,
+    command: SqlCommand,
+    operands: Array[String],
+    originSql: String) {}
+
+case class FlinkSqlValidationResult(
+    success: JavaBool = true,
+    failedType: FlinkSqlValidationFailedType = null,
+    lineStart: Int = 0,
+    lineEnd: Int = 0,
+    errorLine: Int = 0,
+    errorColumn: Int = 0,
+    sql: String = null,
+    exception: String = null)
+
+case class SqlSegment(start: Int, end: Int, sql: String)
+
+object SqlSplitter {
+
+  private lazy val singleLineCommentPrefixList = Set[String](PARAM_PREFIX)
+
+  /**
+   * Split whole text into multiple sql statements. Two Steps: Step 1, split the whole text into
+   * multiple sql statements. Step 2, refine the results. Replace the preceding sql statements with
+   * empty lines, so that we can get the correct line number in the parsing error message. e.g:
+   * select a from table_1; select a from table_2; select a from table_3; The above text will be
+   * splitted into: sql_1: select a from table_1 sql_2: \nselect a from table_2 sql_3: \n\nselect a
+   * from table_3
+   *
+   * @param sql
+   * @return
+   */
+  def splitSql(sql: String): List[SqlSegment] = {
+    val queries = ListBuffer[String]()
+    val lastIndex = if (StringUtils.isNotBlank(sql)) sql.length - 1 else 0
+    var query = new mutable.StringBuilder
+
+    var multiLineComment = false
+    var singleLineComment = false
+    var singleQuoteString = false
+    var doubleQuoteString = false
+    var lineNum: Int = 0
+    val lineNumMap = new collection.mutable.HashMap[Int, (Int, Int)]()
+
+    // Whether each line of the record is empty. If it is empty, it is false. If it is not empty, it is true
+    val lineDescriptor = {
+      val scanner = new Scanner(sql)
+      val descriptor = new collection.mutable.HashMap[Int, Boolean]
+      var lineNumber = 0
+      var startComment = false
+      var hasComment = false
+
+      while (scanner.hasNextLine) {
+        lineNumber += 1
+        val line = scanner.nextLine().trim
+        val nonEmpty =
+          StringUtils.isNotBlank(line) && !line.startsWith(PARAM_PREFIX)
+        if (line.startsWith("/*")) {
+          startComment = true
+          hasComment = true
+        }
+
+        descriptor += lineNumber -> (nonEmpty && !hasComment)
+
+        if (startComment && line.endsWith("*/")) {
+          startComment = false
+          hasComment = false
+        }
+      }
+      descriptor
+    }
+
+    @tailrec
+    def findStartLine(num: Int): Int =
+      if (num >= lineDescriptor.size || lineDescriptor(num)) num
+      else findStartLine(num + 1)
+
+    def markLineNumber(): Unit = {
+      val line = lineNum + 1
+      if (lineNumMap.isEmpty) {
+        lineNumMap += (0 -> (findStartLine(1) -> line))
+      } else {
+        val index = lineNumMap.size
+        val start = lineNumMap(lineNumMap.size - 1)._2 + 1
+        lineNumMap += (index -> (findStartLine(start) -> line))
+      }
+    }
+
+    for (idx <- 0 until sql.length) {
+
+      if (sql.charAt(idx) == '\n') lineNum += 1
+
+      breakable {
+        val ch = sql.charAt(idx)
+
+        // end of single line comment
+        if (singleLineComment && (ch == '\n')) {
+          singleLineComment = false
+          query += ch
+          if (idx == lastIndex && query.toString.trim.nonEmpty) {
+            // add query when it is the end of sql.
+            queries += query.toString
+          }
+          break()
+        }
+
+        // end of multiple line comment
+        if (multiLineComment && (idx - 1) >= 0 && sql.charAt(idx - 1) == '/'
+          && (idx - 2) >= 0 && sql.charAt(idx - 2) == '*') {
+          multiLineComment = false
+        }
+
+        // single quote start or end mark
+        if (ch == '\'' && !(singleLineComment || multiLineComment)) {
+          if (singleQuoteString) {
+            singleQuoteString = false
+          } else if (!doubleQuoteString) {
+            singleQuoteString = true
+          }
+        }
+
+        // double quote start or end mark
+        if (ch == '"' && !(singleLineComment || multiLineComment)) {
+          if (doubleQuoteString && idx > 0) {
+            doubleQuoteString = false
+          } else if (!singleQuoteString) {
+            doubleQuoteString = true
+          }
+        }
+
+        // single line comment or multiple line comment start mark
+        if (!singleQuoteString && !doubleQuoteString && !multiLineComment && !singleLineComment && idx < lastIndex) {
+          if (isSingleLineComment(sql.charAt(idx), sql.charAt(idx + 1))) {
+            singleLineComment = true
+          } else if (sql.charAt(idx) == '/' && sql.length > (idx + 2)
+            && sql.charAt(idx + 1) == '*' && sql.charAt(idx + 2) != '+') {
+            multiLineComment = true
+          }
+        }
+
+        if (ch == ';' && !singleQuoteString && !doubleQuoteString && !multiLineComment && !singleLineComment) {
+          markLineNumber()
+          // meet the end of semicolon
+          if (query.toString.trim.nonEmpty) {
+            queries += query.toString
+            query = new mutable.StringBuilder
+          }
+        } else if (idx == lastIndex) {
+          markLineNumber()
+
+          // meet the last character
+          if (!singleLineComment && !multiLineComment) {
+            query += ch
+          }
+
+          if (query.toString.trim.nonEmpty) {
+            queries += query.toString
+            query = new mutable.StringBuilder
+          }
+        } else if (!singleLineComment && !multiLineComment) {
+          // normal case, not in single line comment and not in multiple line comment
+          query += ch
+        } else if (ch == '\n') {
+          query += ch
+        }
+      }
+    }
+
+    val refinedQueries = new collection.mutable.HashMap[Int, String]()
+    for (i <- queries.indices) {
+      val currStatement = queries(i)
+      if (isSingleLineComment(currStatement) || isMultipleLineComment(currStatement)) {
+        // transform comment line as blank lines
+        if (refinedQueries.nonEmpty) {
+          val lastRefinedQuery = refinedQueries.last
+          refinedQueries(refinedQueries.size - 1) =
+            lastRefinedQuery + extractLineBreaks(currStatement)
+        }
+      } else {
+        var linesPlaceholder = ""
+        if (i > 0) {
+          linesPlaceholder = extractLineBreaks(refinedQueries(i - 1))
+        }
+        // add some blank lines before the statement to keep the original line number
+        val refinedQuery = linesPlaceholder + currStatement
+        refinedQueries += refinedQueries.size -> refinedQuery
+      }
+    }
+
+    val set = new ListBuffer[SqlSegment]
+    refinedQueries.foreach(x => {
+      val line = lineNumMap(x._1)
+      set += SqlSegment(line._1, line._2, x._2)
+    })
+    set.toList.sortWith((a, b) => a.start < b.start)
+  }
+
+  /**
+   * extract line breaks
+   *
+   * @param text
+   * @return
+   */
+  private[this] def extractLineBreaks(text: String): String = {
+    val builder = new mutable.StringBuilder
+    for (i <- 0 until text.length) {
+      if (text.charAt(i) == '\n') {
+        builder.append('\n')
+      }
+    }
+    builder.toString
+  }
+
+  private[this] def isSingleLineComment(text: String) =
+    text.trim.startsWith(PARAM_PREFIX)
+
+  private[this] def isMultipleLineComment(text: String) =
+    text.trim.startsWith("/*") && text.trim.endsWith("*/")
+
+  /**
+   * check single-line comment
+   *
+   * @param curChar
+   * @param nextChar
+   * @return
+   */
+  private[this] def isSingleLineComment(curChar: Char, nextChar: Char): Boolean = {
+    var flag = false
+    for (singleCommentPrefix <- singleLineCommentPrefixList) {
+      singleCommentPrefix.length match {
+        case 1 if curChar == singleCommentPrefix.charAt(0) => flag = true
+        case 2
+            if curChar == singleCommentPrefix.charAt(0) && nextChar == singleCommentPrefix.charAt(
+              1) =>
+          flag = true
+        case _ =>
+      }
+    }
+    flag
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/StreamEnvConfig.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/StreamEnvConfig.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+class StreamEnvConfig(val args: Array[String], val conf: StreamEnvConfigFunction)
+
+class StreamTableEnvConfig(
+    val args: Array[String],
+    val streamConfig: StreamEnvConfigFunction,
+    val tableConfig: TableEnvConfigFunction)
+
+class TableEnvConfig(val args: Array[String], val conf: TableEnvConfigFunction)

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/StreamTableContext.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/StreamTableContext.scala
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Implicits.JavaList
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.tuple
+import org.apache.flink.streaming.api.datastream.{DataStream => JavaDataStream}
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.ModelDescriptor
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.table.catalog.CatalogDescriptor
+import org.apache.flink.table.connector.ChangelogMode
+import org.apache.flink.table.expressions.Expression
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.module.ModuleEntry
+import org.apache.flink.table.resource.ResourceUri
+import org.apache.flink.table.types.AbstractDataType
+import org.apache.flink.types.Row
+import org.apache.flink.util.ParameterTool
+
+class StreamTableContext(
+    override val parameter: ParameterTool,
+    private val streamEnv: StreamExecutionEnvironment,
+    private val tableEnv: StreamTableEnvironment)
+  extends FlinkStreamTableTraitV2(parameter, streamEnv, tableEnv) {
+
+  def this(args: (ParameterTool, StreamExecutionEnvironment, StreamTableEnvironment)) =
+    this(args._1, args._2, args._3)
+
+  def this(args: StreamTableEnvConfig) =
+    this(FlinkTableInitializerV2.initialize(args))
+
+  override def fromDataStream[T](dataStream: JavaDataStream[T], schema: Schema): Table =
+    tableEnv.fromDataStream[T](dataStream, schema)
+
+  /** @deprecated old API */
+  override def fromDataStream[T](dataStream: JavaDataStream[T], expressions: Expression*): Table =
+    tableEnv.fromDataStream(dataStream, expressions: _*)
+
+  override def fromChangelogStream(dataStream: JavaDataStream[Row]): Table =
+    tableEnv.fromChangelogStream(dataStream)
+
+  override def fromChangelogStream(dataStream: JavaDataStream[Row], schema: Schema): Table =
+    tableEnv.fromChangelogStream(dataStream, schema)
+
+  override def fromChangelogStream(
+      dataStream: JavaDataStream[Row],
+      schema: Schema,
+      changelogMode: ChangelogMode): Table =
+    tableEnv.fromChangelogStream(dataStream, schema, changelogMode)
+
+  override def createTemporaryView[T](
+      path: String,
+      dataStream: JavaDataStream[T],
+      schema: Schema): Unit =
+    tableEnv.createTemporaryView[T](path, dataStream, schema)
+
+  /** @deprecated old API */
+  @deprecated override def createTemporaryView[T](
+      path: String,
+      dataStream: JavaDataStream[T],
+      expressions: Expression*): Unit =
+    tableEnv.createTemporaryView(path, dataStream, expressions: _*)
+
+  override def toDataStream(table: Table): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table)
+  }
+
+  override def toDataStream[T](table: Table, targetClass: Class[T]): JavaDataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream[T](table, targetClass)
+  }
+
+  override def toDataStream[T](table: Table, targetDataType: AbstractDataType[_]): JavaDataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream[T](table, targetDataType)
+  }
+
+  override def toChangelogStream(table: Table): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table)
+  }
+
+  override def toChangelogStream(table: Table, targetSchema: Schema): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema)
+  }
+
+  override def toChangelogStream(
+      table: Table,
+      targetSchema: Schema,
+      changelogMode: ChangelogMode): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema, changelogMode)
+  }
+
+  override def createStatementSet(): org.apache.flink.table.api.bridge.java.StreamStatementSet =
+    tableEnv.createStatementSet()
+
+  override def useModules(strings: String*): Unit =
+    tableEnv.useModules(strings: _*)
+
+  override def createTemporaryTable(path: String, descriptor: TableDescriptor): Unit =
+    tableEnv.createTemporaryTable(path, descriptor)
+
+  override def createTable(path: String, descriptor: TableDescriptor): Unit =
+    tableEnv.createTable(path, descriptor)
+
+  override def from(descriptor: TableDescriptor): Table =
+    tableEnv.from(descriptor)
+
+  override def listFullModules(): Array[ModuleEntry] =
+    tableEnv.listFullModules()
+
+  /** @since 1.15 */
+  override def listTables(s: String, s1: String): Array[String] =
+    tableEnv.listTables(s, s1)
+
+  /** @since 1.15 */
+  override def loadPlan(planReference: PlanReference): CompiledPlan =
+    tableEnv.loadPlan(planReference)
+
+  /** @since 1.15 */
+  override def compilePlanSql(s: String): CompiledPlan =
+    tableEnv.compilePlanSql(s)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, className, resourceUris, ignoreIfExists)
+
+  /** @since 1.17 */
+  override def createTemporaryFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporaryFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createTemporarySystemFunction(
+      name: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporarySystemFunction(name, className, resourceUris)
+
+  /** @since 1.17 */
+  override def explainSql(
+      statement: String,
+      format: ExplainFormat,
+      extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, format, extraDetails: _*)
+
+  /** @since 1.18 */
+  override def createCatalog(catalog: String, catalogDescriptor: CatalogDescriptor): Unit = {
+    tableEnv.createCatalog(catalog, catalogDescriptor)
+  }
+
+  /** @deprecated old API */
+  @deprecated override def toAppendStream[T](
+      table: Table,
+      typeInformation: TypeInformation[T]): JavaDataStream[T] =
+    tableEnv.toAppendStream(table, typeInformation)
+
+  /** @deprecated old API */
+  @deprecated override def toRetractStream[T](
+      table: Table,
+      typeInformation: TypeInformation[T]): JavaDataStream[tuple.Tuple2[java.lang.Boolean, T]] =
+    tableEnv.toRetractStream(table, typeInformation)
+
+  /** since Flink 2.0 */
+  override def toAppendStream[T](table: Table, clazz: Class[T]): JavaDataStream[T] =
+    tableEnv.toAppendStream(table, clazz)
+
+  /** since Flink 2.0 */
+  override def toRetractStream[T](table: Table, clazz: Class[T]): JavaDataStream[tuple.Tuple2[java.lang.Boolean, T]] =
+    tableEnv.toRetractStream(table, clazz)
+
+  /** since Flink 2.0 */
+  override def createTable(path: String, descriptor: TableDescriptor, ignoreIfExists: Boolean): Boolean =
+    tableEnv.createTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createTemporaryTable(
+      path: String,
+      descriptor: TableDescriptor,
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createTemporaryTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table, ignoreIfExists: Boolean): Boolean =
+    tableEnv.createView(path, view, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table): Unit =
+    tableEnv.createView(path, view)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropTable(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String): Boolean =
+    tableEnv.dropTable(path)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropView(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String): Boolean =
+    tableEnv.dropView(path)
+
+  /** since Flink 2.1 */
+  override def createModel(path: String, descriptor: ModelDescriptor, ignoreIfExists: Boolean): Unit =
+    tableEnv.createModel(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.1 */
+  override def createModel(path: String, descriptor: ModelDescriptor): Unit =
+    tableEnv.createModel(path, descriptor)
+
+  /** since Flink 2.1 */
+  override def createTemporaryModel(path: String, descriptor: ModelDescriptor, ignoreIfExists: Boolean): Unit =
+    tableEnv.createTemporaryModel(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.1 */
+  override def createTemporaryModel(path: String, descriptor: ModelDescriptor): Unit =
+    tableEnv.createTemporaryModel(path, descriptor)
+
+  /** since Flink 2.1 */
+  override def dropModel(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropModel(path, ignoreIfNotExists)
+
+  /** since Flink 2.1 */
+  override def dropModel(path: String): Boolean =
+    tableEnv.dropModel(path)
+
+  /** since Flink 2.1 */
+  override def dropTemporaryModel(path: String): Boolean =
+    tableEnv.dropTemporaryModel(path)
+
+  /** since Flink 2.1 */
+  override def fromCall(functionClass: Class[_ <: UserDefinedFunction], arguments: Object*): Table =
+    tableEnv.fromCall(functionClass, arguments: _*)
+
+  /** since Flink 2.1 */
+  override def fromCall(functionName: String, arguments: Object*): Table =
+    tableEnv.fromCall(functionName, arguments: _*)
+
+  /** since Flink 2.1 */
+  override def listModels(): Array[String] =
+    tableEnv.listModels()
+
+  /** since Flink 2.1 */
+  override def listTemporaryModels(): Array[String] =
+    tableEnv.listTemporaryModels()
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/TableContext.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/TableContext.scala
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Implicits.JavaList
+
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.ModelDescriptor
+import org.apache.flink.table.catalog.CatalogDescriptor
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.module.ModuleEntry
+import org.apache.flink.table.resource.ResourceUri
+import org.apache.flink.util.ParameterTool
+
+class TableContext(override val parameter: ParameterTool, private val tableEnv: TableEnvironment)
+  extends FlinkTableTrait(parameter, tableEnv) {
+
+  def this(args: (ParameterTool, TableEnvironment)) = this(args._1, args._2)
+
+  def this(args: TableEnvConfig) = this(FlinkTableInitializerV2.initialize(args))
+
+  override def useModules(strings: String*): Unit =
+    tableEnv.useModules(strings: _*)
+
+  override def createTemporaryTable(path: String, descriptor: TableDescriptor): Unit = {
+    tableEnv.createTemporaryTable(path, descriptor)
+  }
+
+  override def createTable(path: String, descriptor: TableDescriptor): Unit = {
+    tableEnv.createTable(path, descriptor)
+  }
+
+  override def from(tableDescriptor: TableDescriptor): Table = {
+    tableEnv.from(tableDescriptor)
+  }
+
+  override def listFullModules(): Array[ModuleEntry] =
+    tableEnv.listFullModules()
+
+  /** @since 1.15 */
+  override def listTables(catalogName: String, databaseName: String): Array[String] =
+    tableEnv.listTables(catalogName, databaseName)
+
+  /** @since 1.15 */
+  override def loadPlan(planReference: PlanReference): CompiledPlan =
+    tableEnv.loadPlan(planReference)
+
+  /** @since 1.15 */
+  override def compilePlanSql(stmt: String): CompiledPlan =
+    tableEnv.compilePlanSql(stmt)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, className, resourceUris, ignoreIfExists)
+
+  /** @since 1.17 */
+  override def createTemporaryFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporaryFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createTemporarySystemFunction(
+      name: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporarySystemFunction(name, className, resourceUris)
+
+  /** @since 1.17 */
+  override def explainSql(
+      statement: String,
+      format: ExplainFormat,
+      extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, format, extraDetails: _*)
+
+  /** @since 1.18 */
+  override def createCatalog(catalog: String, catalogDescriptor: CatalogDescriptor): Unit = {
+    tableEnv.createCatalog(catalog, catalogDescriptor)
+  }
+
+  /** since Flink 2.0 */
+  override def createTable(
+      path: String,
+      descriptor: TableDescriptor,
+      ignoreIfExists: Boolean): Boolean =
+    tableEnv.createTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createTemporaryTable(
+      path: String,
+      descriptor: TableDescriptor,
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createTemporaryTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table, ignoreIfExists: Boolean): Boolean =
+    tableEnv.createView(path, view, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table): Unit =
+    tableEnv.createView(path, view)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropTable(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String): Boolean =
+    tableEnv.dropTable(path)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropView(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String): Boolean =
+    tableEnv.dropView(path)
+
+  /** since Flink 2.1 */
+  override def createModel(path: String, descriptor: ModelDescriptor, ignoreIfExists: Boolean): Unit =
+    tableEnv.createModel(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.1 */
+  override def createModel(path: String, descriptor: ModelDescriptor): Unit =
+    tableEnv.createModel(path, descriptor)
+
+  /** since Flink 2.1 */
+  override def createTemporaryModel(path: String, descriptor: ModelDescriptor, ignoreIfExists: Boolean): Unit =
+    tableEnv.createTemporaryModel(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.1 */
+  override def createTemporaryModel(path: String, descriptor: ModelDescriptor): Unit =
+    tableEnv.createTemporaryModel(path, descriptor)
+
+  /** since Flink 2.1 */
+  override def dropModel(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropModel(path, ignoreIfNotExists)
+
+  /** since Flink 2.1 */
+  override def dropModel(path: String): Boolean =
+    tableEnv.dropModel(path)
+
+  /** since Flink 2.1 */
+  override def dropTemporaryModel(path: String): Boolean =
+    tableEnv.dropTemporaryModel(path)
+
+  /** since Flink 2.1 */
+  override def fromCall(functionClass: Class[_ <: UserDefinedFunction], arguments: Object*): Table =
+    tableEnv.fromCall(functionClass, arguments: _*)
+
+  /** since Flink 2.1 */
+  override def fromCall(functionName: String, arguments: Object*): Table =
+    tableEnv.fromCall(functionName, arguments: _*)
+
+  /** since Flink 2.1 */
+  override def listModels(): Array[String] =
+    tableEnv.listModels()
+
+  /** since Flink 2.1 */
+  override def listTemporaryModels(): Array[String] =
+    tableEnv.listTemporaryModels()
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/TableExt.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/TableExt.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.api.{Table => FlinkTable}
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.types.Row
+
+object TableExt {
+
+  class Table(val table: FlinkTable) {
+    def ->(field: String, fields: String*): FlinkTable =
+      table.as(field, fields: _*)
+  }
+
+  class TableConversions(
+      table: FlinkTable,
+      streamTableEnv: StreamTableEnvironment) {
+
+    def \\ : DataStream[Row] = streamTableEnv.toDataStream(table)
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/conf/FlinkConfiguration.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.1/src/main/scala/org/apache/streampark/flink/core/conf/FlinkConfiguration.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core.conf
+
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.util.ParameterTool
+
+case class FlinkConfiguration(
+    parameter: ParameterTool,
+    envConfig: Configuration,
+    tableConfig: Configuration)

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.streampark</groupId>
+        <artifactId>streampark-flink-shims</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>streampark-flink-shims_flink-2.2_${scala.binary.version}</artifactId>
+    <name>StreamPark : Flink Shims 2.2</name>
+
+    <properties>
+        <flink.version>2.2.1</flink.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.streampark</groupId>
+            <artifactId>streampark-common_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Flink 2.x removed Scala DataStream API, use Java API only -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-kubernetes</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-yarn</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-statebackend-rocksdb</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/java/org/apache/streampark/flink/core/StreamEnvConfigFunction.java
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/java/org/apache/streampark/flink/core/StreamEnvConfigFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.ParameterTool;
+
+@FunctionalInterface
+public interface StreamEnvConfigFunction {
+
+    /**
+     * When used to initialize StreamExecutionEnvironment, it can be used to implement this function
+     * and customize the parameters to be set...
+     *
+     * @param environment
+     * @param parameterTool
+     */
+    void configuration(StreamExecutionEnvironment environment, ParameterTool parameterTool);
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/java/org/apache/streampark/flink/core/TableEnvConfigFunction.java
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/java/org/apache/streampark/flink/core/TableEnvConfigFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.util.ParameterTool;
+
+@FunctionalInterface
+public interface TableEnvConfigFunction {
+
+    /**
+     * When used to initialize the TableEnvironment, it can be used to implement this function and
+     * customize the parameters to be set...
+     *
+     * @param tableConfig
+     * @param parameterTool
+     */
+    void configuration(TableConfig tableConfig, ParameterTool parameterTool);
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/EnhancerImplicit.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/EnhancerImplicit.scala
@@ -20,11 +20,10 @@ package org.apache.streampark.flink.core
 import org.apache.streampark.common.conf.ConfigKeys.{KEY_APP_NAME, KEY_FLINK_APP_NAME}
 import org.apache.streampark.common.util.DeflaterUtils
 
-import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.configuration.PipelineOptions
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
-import org.apache.flink.table.api.bridge.scala.{StreamTableEnvironment => ScalaStreamTableEnvironment}
+import org.apache.flink.util.ParameterTool
 
 import scala.util.Try
 
@@ -52,30 +51,19 @@ object EnhancerImplicit {
     private[flink] def setAppName(implicit parameter: ParameterTool): TableEnvironment = {
       val appName = parameter.getAppName()
       if (appName != null) {
-        env.getConfig.getConfiguration.setString(PipelineOptions.NAME, appName)
+        env.getConfig.getConfiguration.setString(PipelineOptions.NAME.key, appName)
       }
       env
     }
 
   }
 
-  implicit class EnhanceStreamExecutionEnvironment(env: ScalaStreamTableEnvironment) {
-
-    private[flink] def setAppName(implicit parameter: ParameterTool): ScalaStreamTableEnvironment = {
-      val appName = parameter.getAppName()
-      if (appName != null) {
-        env.getConfig.getConfiguration.setString(PipelineOptions.NAME, appName)
-      }
-      env
-    }
-  }
-
-  implicit class EnhanceJavaStreamTableEnvironment(env: StreamTableEnvironment) {
+  implicit class EnhanceStreamTableEnvironment(env: StreamTableEnvironment) {
 
     private[flink] def setAppName(implicit parameter: ParameterTool): StreamTableEnvironment = {
       val appName = parameter.getAppName()
       if (appName != null) {
-        env.getConfig.getConfiguration.setString(PipelineOptions.NAME, appName)
+        env.getConfig.getConfiguration.setString(PipelineOptions.NAME.key, appName)
       }
       env
     }

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkClientTrait.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkClientTrait.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.api.common.JobID
+import org.apache.flink.client.program.ClusterClient
+import org.apache.flink.core.execution.SavepointFormatType
+
+import java.util.concurrent.CompletableFuture
+
+abstract class FlinkClientTrait[T](clusterClient: ClusterClient[T]) {
+
+  def triggerSavepoint(
+      jobID: JobID,
+      savepointDir: String,
+      nativeFormat: Boolean = false): CompletableFuture[String] = {
+    clusterClient.triggerSavepoint(jobID, savepointDir, SavepointFormatType.DEFAULT)
+  }
+
+  def cancelWithSavepoint(
+      jobID: JobID,
+      savepointDir: String,
+      nativeFormat: Boolean = false): CompletableFuture[String] = {
+    clusterClient.cancelWithSavepoint(jobID, savepointDir, SavepointFormatType.DEFAULT)
+  }
+
+  def stopWithSavepoint(
+      jobID: JobID,
+      advanceToEndOfEventTime: Boolean,
+      savepointDir: String,
+      nativeFormat: Boolean = false): CompletableFuture[String] =
+    clusterClient.stopWithSavepoint(jobID, advanceToEndOfEventTime, savepointDir, SavepointFormatType.DEFAULT)
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkClusterClient.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkClusterClient.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.api.common.JobID
+import org.apache.flink.client.program.ClusterClient
+import org.apache.flink.core.execution.SavepointFormatType
+
+import java.util.concurrent.CompletableFuture
+
+class FlinkClusterClient[T](clusterClient: ClusterClient[T])
+  extends FlinkClientTrait[T](clusterClient) {
+
+  override def triggerSavepoint(
+      jobID: JobID,
+      savepointDir: String,
+      nativeFormat: Boolean): CompletableFuture[String] = {
+    clusterClient.triggerSavepoint(
+      jobID,
+      savepointDir,
+      if (nativeFormat) SavepointFormatType.NATIVE
+      else SavepointFormatType.CANONICAL)
+  }
+
+  override def cancelWithSavepoint(
+      jobID: JobID,
+      savepointDirectory: String,
+      nativeFormat: Boolean): CompletableFuture[String] = {
+    clusterClient.cancelWithSavepoint(
+      jobID,
+      savepointDirectory,
+      if (nativeFormat) SavepointFormatType.NATIVE
+      else SavepointFormatType.CANONICAL)
+  }
+
+  override def stopWithSavepoint(
+      jobID: JobID,
+      advanceToEndOfEventTime: Boolean,
+      savepointDirectory: String,
+      nativeFormat: Boolean): CompletableFuture[String] = {
+    clusterClient.stopWithSavepoint(
+      jobID,
+      advanceToEndOfEventTime,
+      savepointDirectory,
+      if (nativeFormat) SavepointFormatType.NATIVE
+      else SavepointFormatType.CANONICAL)
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClient.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClient.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService
+
+import java.util.Optional
+
+class FlinkKubernetesClient(kubeClient: FlinkKubeClient)
+  extends FlinkKubernetesClientTrait(kubeClient) {
+
+  override def getService(serviceName: String): Optional[KubernetesService] = {
+    kubeClient.getService(serviceName)
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClientTrait.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkKubernetesClientTrait.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService
+
+import java.util.Optional
+
+abstract class FlinkKubernetesClientTrait(kubeClient: FlinkKubeClient) {
+
+  /**
+   * Get the kubernetes service of the given flink clusterId.
+   *
+   * @param serviceName
+   *   the name of the service
+   * @return
+   *   Return the optional kubernetes service of the specified name.
+   */
+  def getService(serviceName: String): Optional[KubernetesService] =
+    kubeClient.getService(serviceName)
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkSqlExecutor.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkSqlExecutor.scala
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys.KEY_FLINK_SQL
+import org.apache.streampark.common.util.{AssertUtils, Logger}
+import org.apache.streampark.flink.core.SqlCommand._
+
+import org.apache.commons.lang3.StringUtils
+import org.apache.flink.configuration.{Configuration, ExecutionOptions}
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.util.ParameterTool
+
+import java.util
+import java.util.concurrent.locks.ReentrantReadWriteLock
+
+import scala.collection.mutable
+import scala.util.Try
+
+object FlinkSqlExecutor extends Logger {
+
+  private[this] val lock = new ReentrantReadWriteLock().writeLock
+
+  private[streampark] def executeSql(
+      sql: String,
+      parameter: ParameterTool,
+      context: TableEnvironment)(implicit callbackFunc: String => Unit = null): Unit = {
+
+    val flinkSql: String =
+      if (StringUtils.isBlank(sql)) parameter.get(KEY_FLINK_SQL())
+      else parameter.get(sql)
+    require(StringUtils.isNotBlank(flinkSql), "verify failed: flink sql cannot be empty")
+
+    def callback(r: String): Unit = {
+      callbackFunc match {
+        case null => logInfo(r)
+        case x => x(r)
+      }
+    }
+
+    val runMode = parameter.get(ExecutionOptions.RUNTIME_MODE.key())
+
+    var hasInsert = false
+    val statementSet = context.createStatementSet()
+    SqlCommandParser
+      .parseSQL(flinkSql)
+      .foreach(x => {
+        val args = if (x.operands.isEmpty) null else x.operands.head
+        val command = x.command.name
+        x.command match {
+          // For display sql statement result information
+          case SHOW_CATALOGS =>
+            val catalogs = context.listCatalogs
+            callback(s"$command: ${catalogs.mkString("\n")}")
+          case SHOW_CURRENT_CATALOG =>
+            val catalog = context.getCurrentCatalog
+            callback(s"$command: $catalog")
+          case SHOW_DATABASES =>
+            val databases = context.listDatabases
+            callback(s"$command: ${databases.mkString("\n")}")
+          case SHOW_CURRENT_DATABASE =>
+            val database = context.getCurrentDatabase
+            callback(s"$command: $database")
+          case SHOW_TABLES =>
+            val tables =
+              context.listTables().filter(!_.startsWith("UnnamedTable"))
+            callback(s"$command: ${tables.mkString("\n")}")
+          case SHOW_FUNCTIONS =>
+            val functions = context.listUserDefinedFunctions()
+            callback(s"$command: ${functions.mkString("\n")}")
+          case SHOW_MODULES =>
+            val modules = context.listModules()
+            callback(s"$command: ${modules.mkString("\n")}")
+          case DESC | DESCRIBE =>
+            val schema = context.scan(args).getSchema
+            val builder = new mutable.StringBuilder()
+            builder.append("Column\tType\n")
+            for (i <- 0 to schema.getFieldCount) {
+              builder.append(
+                schema.getFieldName(i).get() + "\t" + schema
+                  .getFieldDataType(i)
+                  .get() + "\n")
+            }
+            callback(builder.toString())
+          case EXPLAIN =>
+            val tableResult = context.executeSql(x.originSql)
+            val r = tableResult.collect().next().getField(0).toString
+            callback(r)
+          // For specific statement, such as: SET/RESET/INSERT/SELECT
+          case SET =>
+            val operand = x.operands(1)
+            logInfo(s"$command: $args --> $operand")
+            context.getConfig.getConfiguration.setString(args, operand)
+          case RESET | RESET_ALL =>
+            val confDataField =
+              classOf[Configuration].getDeclaredField("confData")
+            confDataField.setAccessible(true)
+            val confData = confDataField
+              .get(context.getConfig.getConfiguration)
+              .asInstanceOf[util.HashMap[String, AnyRef]]
+            confData.synchronized {
+              if (x.command == RESET) {
+                confData.remove(args)
+              } else {
+                confData.clear()
+              }
+            }
+            logInfo(s"$command: $args")
+          case BEGIN_STATEMENT_SET | END_STATEMENT_SET =>
+            logWarn(s"SQL Client Syntax: ${x.command.name} ")
+          case INSERT =>
+            statementSet.addInsertSql(x.originSql)
+            hasInsert = true
+          case SELECT =>
+            logError("StreamPark dose not support 'SELECT' statement now!")
+            throw new RuntimeException("StreamPark dose not support 'select' statement now!")
+          case DELETE | UPDATE =>
+            AssertUtils.required(
+              runMode != "STREAMING",
+              s"Currently, ${command.toUpperCase()} statement only supports in batch mode, " +
+                s"and it requires the target table connector implements the SupportsRowLevelDelete, " +
+                s"For more details please refer to: https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/dev/table/sql/$command")
+          case _ =>
+            try {
+              lock.lock()
+              val result = context.executeSql(x.originSql)
+              logInfo(s"$command:$args")
+            } finally {
+              if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+              }
+            }
+        }
+      })
+
+    if (hasInsert) {
+      statementSet.execute() match {
+        case t if t != null =>
+          Try(t.getJobClient.get.getJobID).getOrElse(null) match {
+            case x if x != null => logInfo(s"jobId:$x")
+            case _ =>
+          }
+        case _ =>
+      }
+    } else {
+      logError("No 'INSERT' statement to trigger the execution of the Flink job.")
+      throw new RuntimeException("No 'INSERT' statement to trigger the execution of the Flink job.")
+    }
+
+    logInfo(
+      s"\n\n\n==============flinkSql==============\n\n $flinkSql\n\n============================\n\n\n")
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkSqlValidator.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkSqlValidator.scala
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.enums.FlinkSqlValidationFailedType
+import org.apache.streampark.common.util.{ExceptionUtils, Logger}
+import org.apache.streampark.flink.core.SqlCommand._
+
+import org.apache.calcite.config.Lex
+import org.apache.calcite.sql.parser.SqlParser
+import org.apache.calcite.sql.parser.SqlParser.Config
+import org.apache.flink.sql.parser.validate.FlinkSqlConformance
+import org.apache.flink.table.api.SqlDialect
+import org.apache.flink.table.api.SqlDialect.{DEFAULT, HIVE}
+import org.apache.flink.table.api.config.TableConfigOptions
+import org.apache.flink.table.planner.delegation.FlinkSqlParserFactories
+
+import scala.language.existentials
+import scala.util.{Failure, Try}
+
+object FlinkSqlValidator extends Logger {
+
+  private[this] val FLINK112_CALCITE_PARSER_CLASS =
+    "org.apache.flink.table.planner.calcite.CalciteParser"
+
+  private[this] val FLINK113_PLUS_CALCITE_PARSER_CLASS =
+    "org.apache.flink.table.planner.parse.CalciteParser"
+
+  private[this] val SYNTAX_ERROR_REGEXP =
+    ".*at\\sline\\s(\\d+),\\scolumn\\s(\\d+).*".r
+
+  private[this] lazy val sqlParserConfigMap: Map[String, SqlParser.Config] = {
+    def getConfig(sqlDialect: SqlDialect): Config = {
+      val conformance = sqlDialect match {
+        case HIVE =>
+          try {
+            FlinkSqlConformance.DEFAULT
+          } catch {
+            // for flink 1.18+
+            case _: NoSuchFieldError => FlinkSqlConformance.DEFAULT
+            case e: Throwable =>
+              throw new IllegalArgumentException("Init Flink sql Dialect error: ", e)
+          }
+        case DEFAULT => FlinkSqlConformance.DEFAULT
+        case _ =>
+          throw new UnsupportedOperationException(s"Unsupported sqlDialect: $sqlDialect")
+      }
+      SqlParser.config
+        .withParserFactory(FlinkSqlParserFactories.create(conformance))
+        .withConformance(conformance)
+        .withLex(Lex.JAVA)
+        .withIdentifierMaxLength(256)
+    }
+
+    Map(
+      SqlDialect.DEFAULT.name() -> getConfig(SqlDialect.DEFAULT),
+      SqlDialect.HIVE.name() -> getConfig(SqlDialect.HIVE))
+  }
+
+  def verifySql(sql: String): FlinkSqlValidationResult = {
+    val sqlCommands = SqlCommandParser.parseSQL(sql, r => return r)
+    var sqlDialect = SqlDialect.DEFAULT.name().toLowerCase()
+    var hasInsert = false
+    for (call <- sqlCommands) {
+      val args = call.operands.head
+      val command = call.command
+      command match {
+        case SET | RESET =>
+          if (command == SET && args == TableConfigOptions.TABLE_SQL_DIALECT.key()) {
+            sqlDialect = call.operands.last
+          }
+        case BEGIN_STATEMENT_SET | END_STATEMENT_SET =>
+          logWarn(s"SQL Client Syntax: ${call.command.name} ")
+        case _ =>
+          if (command == INSERT) {
+            hasInsert = true
+          }
+          Try {
+            val calciteClass = Try(Class.forName(FLINK112_CALCITE_PARSER_CLASS))
+              .getOrElse(Class.forName(FLINK113_PLUS_CALCITE_PARSER_CLASS))
+            sqlDialect.toUpperCase() match {
+              case "HIVE" =>
+              case "DEFAULT" =>
+                val parser = calciteClass
+                  .getConstructor(Array(classOf[Config]): _*)
+                  .newInstance(sqlParserConfigMap(sqlDialect.toUpperCase()))
+                val method =
+                  parser.getClass.getDeclaredMethod("parse", classOf[String])
+                method.setAccessible(true)
+                method.invoke(parser, call.originSql)
+              case _ =>
+                throw new UnsupportedOperationException(s"unsupported dialect: $sqlDialect")
+            }
+          } match {
+            case Failure(e) =>
+              val exception = ExceptionUtils.stringifyException(e)
+              val causedBy = exception.drop(exception.indexOf("Caused by:"))
+              val cleanUpError = exception.replaceAll("[\r\n]", "")
+              if (SYNTAX_ERROR_REGEXP.findAllMatchIn(cleanUpError).nonEmpty) {
+                val SYNTAX_ERROR_REGEXP(line, column) = cleanUpError
+                val errorLine = call.lineStart + line.toInt - 1
+                return FlinkSqlValidationResult(
+                  success = false,
+                  failedType = FlinkSqlValidationFailedType.SYNTAX_ERROR,
+                  lineStart = call.lineStart,
+                  lineEnd = call.lineEnd,
+                  errorLine = errorLine,
+                  errorColumn = column.toInt,
+                  sql = call.originSql,
+                  exception = causedBy.replaceAll(s"at\\sline\\s$line", s"at line $errorLine"))
+              } else {
+                return FlinkSqlValidationResult(
+                  success = false,
+                  failedType = FlinkSqlValidationFailedType.SYNTAX_ERROR,
+                  lineStart = call.lineStart,
+                  lineEnd = call.lineEnd,
+                  sql = call.originSql,
+                  exception = causedBy)
+              }
+            case _ =>
+          }
+      }
+    }
+
+    if (hasInsert) {
+      FlinkSqlValidationResult()
+    } else {
+      FlinkSqlValidationResult(
+        success = false,
+        failedType = FlinkSqlValidationFailedType.SYNTAX_ERROR,
+        lineStart = sqlCommands.head.lineStart,
+        lineEnd = sqlCommands.last.lineEnd,
+        exception = "No 'INSERT' statement to trigger the execution of the Flink job.")
+    }
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkStreamTableTraitV2.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkStreamTableTraitV2.scala
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Implicits.JavaList
+import org.apache.streampark.common.util.Utils
+import org.apache.streampark.flink.core.EnhancerImplicit._
+
+import org.apache.flink.api.common.{JobExecutionResult, RuntimeExecutionMode}
+import org.apache.flink.api.common.cache.DistributedCache
+import org.apache.flink.api.common.eventtime.WatermarkStrategy
+import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFormat}
+import org.apache.flink.api.connector.source.{Source, SourceSplit}
+import org.apache.flink.api.java.tuple
+import org.apache.flink.configuration.ReadableConfig
+import org.apache.flink.core.execution.{JobClient, JobListener}
+import org.apache.flink.streaming.api.CheckpointingMode
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.{CheckpointConfig, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.functions.source.FileProcessingMode
+import org.apache.flink.streaming.api.graph.StreamGraph
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.table.catalog.Catalog
+import org.apache.flink.table.functions._
+import org.apache.flink.table.module.Module
+import org.apache.flink.types.Row
+import org.apache.flink.util.{ParameterTool, SplittableIterator}
+
+import java.util.Optional
+
+/**
+ * Integration api of stream and table (Flink 2.0 - Java DataStream API)
+ *
+ * @param parameter
+ *   parameter
+ * @param streamEnv
+ *   streamEnv
+ * @param tableEnv
+ *   tableEnv
+ */
+abstract class FlinkStreamTableTraitV2(
+    val parameter: ParameterTool,
+    private val streamEnv: StreamExecutionEnvironment,
+    private val tableEnv: StreamTableEnvironment)
+  extends StreamTableEnvironment {
+
+  /**
+   * Once a Table has been converted to a DataStream, the DataStream job must be executed using the
+   * execute method of the StreamExecutionEnvironment.
+   */
+  var isConvertedToDataStream: Boolean = false
+
+  /** Recommended to use this Api to start tasks */
+  def start(name: String = null): JobExecutionResult = {
+    val appName = parameter.getAppName(name, true)
+    execute(appName)
+  }
+
+  @deprecated def execute(jobName: String): JobExecutionResult = {
+    Utils.printLogo(s"FlinkStreamTable $jobName Starting...")
+    if (isConvertedToDataStream) {
+      streamEnv.execute(jobName)
+    } else null
+  }
+
+  def sql(sql: String = null)(implicit callback: String => Unit = null): Unit =
+    FlinkSqlExecutor.executeSql(sql, parameter, this)
+
+  // ...streamEnv api start...
+
+  def $getCachedFiles: JavaList[tuple.Tuple2[String, DistributedCache.DistributedCacheEntry]] =
+    this.streamEnv.getCachedFiles
+
+  def $getJobListeners: JavaList[JobListener] = this.streamEnv.getJobListeners
+
+  def $setParallelism(parallelism: Int): Unit =
+    this.streamEnv.setParallelism(parallelism)
+
+  def $setRuntimeMode(deployMode: RuntimeExecutionMode): StreamExecutionEnvironment =
+    this.streamEnv.setRuntimeMode(deployMode)
+
+  def $setMaxParallelism(maxParallelism: Int): Unit =
+    this.streamEnv.setMaxParallelism(maxParallelism)
+
+  def $getParallelism: Int = this.streamEnv.getParallelism
+
+  def $getMaxParallelism: Int = this.streamEnv.getMaxParallelism
+
+  def $setBufferTimeout(timeoutMillis: Long): StreamExecutionEnvironment =
+    this.streamEnv.setBufferTimeout(timeoutMillis)
+
+  def $getBufferTimeout: Long = this.streamEnv.getBufferTimeout
+
+  def $disableOperatorChaining(): StreamExecutionEnvironment =
+    this.streamEnv.disableOperatorChaining()
+
+  def $getCheckpointConfig: CheckpointConfig =
+    this.streamEnv.getCheckpointConfig
+
+  def $enableCheckpointing(interval: Long, mode: CheckpointingMode): StreamExecutionEnvironment =
+    this.streamEnv.enableCheckpointing(interval, mode)
+
+  def $enableCheckpointing(interval: Long): StreamExecutionEnvironment =
+    this.streamEnv.enableCheckpointing(interval)
+
+  def $getCheckpointingMode: CheckpointingMode =
+    this.streamEnv.getCheckpointingMode
+
+  def $configure(configuration: ReadableConfig, classLoader: ClassLoader): Unit =
+    this.streamEnv.configure(configuration, classLoader)
+
+  def $fromSequence(from: Long, to: Long): DataStream[java.lang.Long] =
+    this.streamEnv.fromSequence(from, to)
+
+  // fromData with varargs removed in Flink 2.0
+  def $fromData[T](data: T): DataStream[T] =
+    this.streamEnv.fromData(data)
+
+  def $fromCollection[T](data: java.util.Collection[T]): DataStream[T] =
+    this.streamEnv.fromCollection(data)
+
+  def $fromParallelCollection[T](data: SplittableIterator[T], clazz: Class[T]): DataStream[T] =
+    this.streamEnv.fromParallelCollection(data, clazz)
+
+  def $readFile[T](inputFormat: FileInputFormat[T], filePath: String): DataStream[T] =
+    this.streamEnv.readFile(inputFormat, filePath)
+
+  def $readFile[T](
+      inputFormat: FileInputFormat[T],
+      filePath: String,
+      watchType: FileProcessingMode,
+      interval: Long): DataStream[T] =
+    this.streamEnv.readFile(inputFormat, filePath, watchType, interval)
+
+  def $socketTextStream(
+      hostname: String,
+      port: Int,
+      delimiter: Char,
+      maxRetry: Long): DataStream[String] =
+    this.streamEnv.socketTextStream(hostname, port, delimiter, maxRetry)
+
+  def $createInput[T](inputFormat: InputFormat[T, _]): DataStream[T] =
+    this.streamEnv.createInput(inputFormat)
+
+  def $fromSource[T](
+      source: Source[T, _ <: SourceSplit, _],
+      watermarkStrategy: WatermarkStrategy[T],
+      sourceName: String): DataStream[T] =
+    this.streamEnv.fromSource(source, watermarkStrategy, sourceName)
+
+  def $registerJobListener(jobListener: JobListener): Unit =
+    this.streamEnv.registerJobListener(jobListener)
+
+  def $clearJobListeners(): Unit = this.streamEnv.clearJobListeners()
+
+  def $executeAsync(): JobClient = this.streamEnv.executeAsync()
+
+  def $executeAsync(jobName: String): JobClient =
+    this.streamEnv.executeAsync(jobName)
+
+  def $getExecutionPlan: String = this.streamEnv.getExecutionPlan
+
+  def $getStreamGraph: StreamGraph = this.streamEnv.getStreamGraph
+
+  def $registerCachedFile(filePath: String, name: String): Unit =
+    this.streamEnv.registerCachedFile(filePath, name)
+
+  def $registerCachedFile(filePath: String, name: String, executable: Boolean): Unit =
+    this.streamEnv.registerCachedFile(filePath, name, executable)
+
+  def $isUnalignedCheckpointsEnabled: Boolean =
+    this.streamEnv.isUnalignedCheckpointsEnabled
+
+  def $isForceUnalignedCheckpoints: Boolean =
+    this.streamEnv.isForceUnalignedCheckpoints
+
+  @deprecated def $readFile[T](
+      inputFormat: FileInputFormat[T],
+      filePath: String,
+      watchType: FileProcessingMode,
+      interval: Long,
+      filter: FilePathFilter): DataStream[T] =
+    this.streamEnv.readFile(inputFormat, filePath, watchType, interval, filter)
+
+  // ...streamEnv api end...
+
+  override def fromDataStream[T](dataStream: DataStream[T]): Table =
+    tableEnv.fromDataStream(dataStream)
+
+  override def fromDataStream[T](dataStream: DataStream[T], schema: Schema): Table =
+    tableEnv.fromDataStream(dataStream, schema)
+
+  override def fromChangelogStream(dataStream: DataStream[Row]): Table =
+    tableEnv.fromChangelogStream(dataStream)
+
+  override def fromChangelogStream(dataStream: DataStream[Row], schema: Schema): Table =
+    tableEnv.fromChangelogStream(dataStream, schema)
+
+  override def fromChangelogStream(
+      dataStream: DataStream[Row],
+      schema: Schema,
+      changelogMode: org.apache.flink.table.connector.ChangelogMode): Table =
+    tableEnv.fromChangelogStream(dataStream, schema, changelogMode)
+
+  override def createTemporaryView[T](path: String, dataStream: DataStream[T]): Unit =
+    tableEnv.createTemporaryView(path, dataStream)
+
+  override def createTemporaryView[T](
+      path: String,
+      dataStream: DataStream[T],
+      schema: Schema): Unit =
+    tableEnv.createTemporaryView(path, dataStream, schema)
+
+  override def toDataStream(table: Table): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table)
+  }
+
+  override def toDataStream[T](table: Table, targetClass: Class[T]): DataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table, targetClass)
+  }
+
+  override def toDataStream[T](
+      table: Table,
+      targetDataType: org.apache.flink.table.types.AbstractDataType[_]): DataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table, targetDataType)
+  }
+
+  override def toChangelogStream(table: Table): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table)
+  }
+
+  override def toChangelogStream(table: Table, targetSchema: Schema): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema)
+  }
+
+  override def toChangelogStream(
+      table: Table,
+      targetSchema: Schema,
+      changelogMode: org.apache.flink.table.connector.ChangelogMode): DataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema, changelogMode)
+  }
+
+  override def createStatementSet(): org.apache.flink.table.api.bridge.java.StreamStatementSet =
+    tableEnv.createStatementSet()
+
+  // ...table env delegation...
+
+  override def fromValues(values: org.apache.flink.table.expressions.Expression*): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(
+      rowType: org.apache.flink.table.types.AbstractDataType[_],
+      values: org.apache.flink.table.expressions.Expression*): Table =
+    tableEnv.fromValues(rowType, values: _*)
+
+  override def fromValues(values: java.lang.Iterable[_]): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(
+      rowType: org.apache.flink.table.types.AbstractDataType[_],
+      values: java.lang.Iterable[_]): Table =
+    tableEnv.fromValues(rowType, values)
+
+  override def registerCatalog(catalogName: String, catalog: Catalog): Unit =
+    tableEnv.registerCatalog(catalogName, catalog)
+
+  override def getCatalog(catalogName: String): Optional[Catalog] =
+    tableEnv.getCatalog(catalogName)
+
+  override def loadModule(moduleName: String, module: Module): Unit =
+    tableEnv.loadModule(moduleName, module)
+
+  override def unloadModule(moduleName: String): Unit =
+    tableEnv.unloadModule(moduleName)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionClass)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionInstance)
+
+  override def dropTemporarySystemFunction(name: String): Boolean =
+    tableEnv.dropTemporarySystemFunction(name)
+
+  override def createFunction(path: String, functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def createFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def dropFunction(path: String): Boolean = tableEnv.dropFunction(path)
+
+  override def createTemporaryFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporaryFunction(path, functionClass)
+
+  override def createTemporaryFunction(path: String, functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporaryFunction(path, functionInstance)
+
+  override def dropTemporaryFunction(path: String): Boolean =
+    tableEnv.dropTemporaryFunction(path)
+
+  override def createTemporaryView(path: String, view: Table): Unit =
+    tableEnv.createTemporaryView(path, view)
+
+  override def from(path: String): Table = tableEnv.from(path)
+
+  override def listCatalogs(): Array[String] = tableEnv.listCatalogs()
+
+  override def listModules(): Array[String] = tableEnv.listModules()
+
+  override def listDatabases(): Array[String] = tableEnv.listDatabases()
+
+  override def listTables(): Array[String] = tableEnv.listTables()
+
+  override def listViews(): Array[String] = tableEnv.listViews()
+
+  override def listTemporaryTables(): Array[String] =
+    tableEnv.listTemporaryTables
+
+  override def listTemporaryViews(): Array[String] =
+    tableEnv.listTemporaryViews()
+
+  override def listUserDefinedFunctions(): Array[String] =
+    tableEnv.listUserDefinedFunctions()
+
+  override def listFunctions(): Array[String] = tableEnv.listFunctions()
+
+  override def dropTemporaryTable(path: String): Boolean =
+    tableEnv.dropTemporaryTable(path)
+
+  override def dropTemporaryView(path: String): Boolean =
+    tableEnv.dropTemporaryView(path)
+
+  override def explainSql(statement: String, extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, extraDetails: _*)
+
+  override def sqlQuery(query: String): Table = tableEnv.sqlQuery(query)
+
+  override def executeSql(statement: String): TableResult =
+    tableEnv.executeSql(statement)
+
+  override def getCurrentCatalog: String = tableEnv.getCurrentCatalog
+
+  override def useCatalog(catalogName: String): Unit =
+    tableEnv.useCatalog(catalogName)
+
+  override def getCurrentDatabase: String = tableEnv.getCurrentDatabase
+
+  override def useDatabase(databaseName: String): Unit =
+    tableEnv.useDatabase(databaseName)
+
+  override def getConfig: TableConfig = tableEnv.getConfig
+
+  @deprecated override def registerFunction(name: String, function: ScalarFunction): Unit =
+    tableEnv.registerFunction(name, function)
+
+  @deprecated override def registerTable(name: String, table: Table): Unit =
+    tableEnv.registerTable(name, table)
+
+  @deprecated override def scan(tablePath: String*): Table =
+    tableEnv.scan(tablePath: _*)
+
+  @deprecated override def getCompletionHints(statement: String, position: Int): Array[String] =
+    tableEnv.getCompletionHints(statement, position)
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializerV2.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkStreamingInitializerV2.scala
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys._
+import org.apache.streampark.common.enums.ApiType
+import org.apache.streampark.common.enums.ApiType.ApiType
+import org.apache.streampark.common.util._
+import org.apache.streampark.common.util.Implicits._
+import org.apache.streampark.flink.core.conf.FlinkConfiguration
+
+import collection.{mutable, Map}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.util.ParameterTool
+
+import java.io.File
+
+private[flink] object FlinkStreamingInitializerV2 {
+
+  def initialize(
+      args: Array[String],
+      config: (StreamExecutionEnvironment, ParameterTool) => Unit): (ParameterTool, StreamExecutionEnvironment) = {
+    val flinkInitializer = new FlinkStreamingInitializerV2(args, ApiType.SCALA)
+    flinkInitializer.streamEnvConfFunc = config
+    (flinkInitializer.configuration.parameter, flinkInitializer.streamEnv)
+  }
+
+  def initialize(args: StreamEnvConfig): (ParameterTool, StreamExecutionEnvironment) = {
+    val flinkInitializer =
+      new FlinkStreamingInitializerV2(args.args, ApiType.JAVA)
+    flinkInitializer.javaStreamEnvConfFunc = args.conf
+    (flinkInitializer.configuration.parameter, flinkInitializer.streamEnv)
+  }
+}
+
+private[flink] class FlinkStreamingInitializerV2(args: Array[String], apiType: ApiType)
+  extends Logger {
+
+  var streamEnvConfFunc: (StreamExecutionEnvironment, ParameterTool) => Unit = _
+
+  var tableConfFunc: (TableConfig, ParameterTool) => Unit = _
+
+  var javaStreamEnvConfFunc: StreamEnvConfigFunction = _
+
+  var javaTableEnvConfFunc: TableEnvConfigFunction = _
+
+  implicit private[flink] val parameter: ParameterTool = configuration.parameter
+
+  lazy val streamEnv: StreamExecutionEnvironment = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment(configuration.envConfig)
+
+    apiType match {
+      case ApiType.JAVA if javaStreamEnvConfFunc != null =>
+        javaStreamEnvConfFunc.configuration(env, configuration.parameter)
+      case ApiType.SCALA if streamEnvConfFunc != null =>
+        streamEnvConfFunc(env, configuration.parameter)
+      case _ =>
+    }
+    env.getConfig.setGlobalJobParameters(configuration.parameter)
+    env
+  }
+
+  lazy val configuration: FlinkConfiguration = initParameter()
+
+  def initParameter(): FlinkConfiguration = {
+    val argsMap = ParameterTool.fromArgs(args)
+    val config = argsMap.get(KEY_APP_CONF(), null) match {
+      case null | "" =>
+        throw new ExceptionInInitializerError(
+          "[StreamPark] Usage:can't find config,please set \"--conf $path \" in main arguments")
+      case file => file
+    }
+    val configMap = parseConfig(config)
+    val properConf = extractConfigByPrefix(configMap, KEY_FLINK_PROPERTY_PREFIX)
+    val appConf = extractConfigByPrefix(configMap, KEY_APP_PREFIX)
+
+    // config priority: explicitly specified priority > project profiles > system profiles
+    val parameter = ParameterTool
+      .fromSystemProperties()
+      .mergeWith(ParameterTool.fromMap(properConf))
+      .mergeWith(ParameterTool.fromMap(appConf))
+      .mergeWith(argsMap)
+
+    val envConfig = Configuration.fromMap(properConf)
+    FlinkConfiguration(parameter, envConfig, null)
+  }
+
+  def parseConfig(config: String): Map[String, String] = {
+
+    lazy val content = DeflaterUtils.unzipString(config.drop(7))
+
+    def readConfig(text: String): Map[String, String] = {
+      val format = config.split("\\.").last.toLowerCase
+      format match {
+        case "yml" | "yaml" => PropertiesUtils.fromYamlText(text)
+        case "conf" => PropertiesUtils.fromHoconText(text)
+        case "properties" => PropertiesUtils.fromPropertiesText(text)
+        case _ =>
+          throw new IllegalArgumentException(
+            "[StreamPark] Usage: application config file error,must be [yaml|conf|properties]")
+      }
+    }
+
+    val map = config match {
+      case x if x.startsWith("yaml://") => PropertiesUtils.fromYamlText(content)
+      case x if x.startsWith("conf://") =>
+        PropertiesUtils.fromHoconText(content)
+      case x if x.startsWith("prop://") =>
+        PropertiesUtils.fromPropertiesText(content)
+      case x if x.startsWith("hdfs://") =>
+        // If the configuration file with the hdfs, user will need to copy the hdfs-related configuration files under the resources dir
+        val text = HdfsUtils.read(x)
+        readConfig(text)
+      case _ =>
+        val configFile = new File(config)
+        require(
+          configFile.exists(),
+          s"[StreamPark] Usage: application config file: $configFile is not found!!!")
+        val text = FileUtils.readFile(configFile)
+        readConfig(text)
+    }
+    map.filter(_._2.nonEmpty)
+  }
+
+  def extractConfigByPrefix(configMap: Map[String, String], prefix: String): Map[String, String] = {
+    val map = mutable.Map[String, String]()
+    configMap.foreach(x =>
+      if (x._1.startsWith(prefix)) {
+        map += x._1.drop(prefix.length) -> x._2
+      })
+    map
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkTableInitializerV2.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkTableInitializerV2.scala
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys._
+import org.apache.streampark.common.enums.{ApiType, PlannerType}
+import org.apache.streampark.common.enums.ApiType.ApiType
+import org.apache.streampark.common.util.{DeflaterUtils, PropertiesUtils}
+import org.apache.streampark.common.util.Implicits._
+import org.apache.streampark.flink.core.EnhancerImplicit._
+import org.apache.streampark.flink.core.conf.FlinkConfiguration
+
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.{EnvironmentSettings, TableConfig, TableEnvironment}
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.util.ParameterTool
+
+import java.io.File
+
+import scala.collection.{mutable, Map}
+import scala.util.{Failure, Success, Try}
+
+private[flink] object FlinkTableInitializerV2 {
+
+  def initialize(
+      args: Array[String],
+      config: (TableConfig, ParameterTool) => Unit): (ParameterTool, TableEnvironment) = {
+    val flinkInitializer = new FlinkTableInitializerV2(args, ApiType.SCALA)
+    flinkInitializer.tableConfFunc = config
+    (flinkInitializer.configuration.parameter, flinkInitializer.tableEnv)
+  }
+
+  def initialize(args: TableEnvConfig): (ParameterTool, TableEnvironment) = {
+    val flinkInitializer = new FlinkTableInitializerV2(args.args, ApiType.JAVA)
+    flinkInitializer.javaTableEnvConfFunc = args.conf
+    (flinkInitializer.configuration.parameter, flinkInitializer.tableEnv)
+  }
+
+  def initialize(
+      args: Array[String],
+      configStream: (StreamExecutionEnvironment, ParameterTool) => Unit,
+      configTable: (TableConfig, ParameterTool) => Unit): (ParameterTool, StreamExecutionEnvironment, StreamTableEnvironment) = {
+
+    val flinkInitializer = new FlinkTableInitializerV2(args, ApiType.SCALA)
+    flinkInitializer.streamEnvConfFunc = configStream
+    flinkInitializer.tableConfFunc = configTable
+    (
+      flinkInitializer.configuration.parameter,
+      flinkInitializer.streamEnv,
+      flinkInitializer.streamTableEnv)
+  }
+
+  def initialize(
+      args: StreamTableEnvConfig): (ParameterTool, StreamExecutionEnvironment, StreamTableEnvironment) = {
+    val flinkInitializer = new FlinkTableInitializerV2(args.args, ApiType.JAVA)
+    flinkInitializer.javaStreamEnvConfFunc = args.streamConfig
+    flinkInitializer.javaTableEnvConfFunc = args.tableConfig
+    (
+      flinkInitializer.configuration.parameter,
+      flinkInitializer.streamEnv,
+      flinkInitializer.streamTableEnv)
+  }
+
+}
+
+private[flink] class FlinkTableInitializerV2(args: Array[String], apiType: ApiType)
+  extends FlinkStreamingInitializerV2(args, apiType) {
+
+  private[this] lazy val envSettings = {
+
+    val builder = EnvironmentSettings.newInstance()
+
+    Try(PlannerType.withName(parameter.get(KEY_FLINK_TABLE_PLANNER)))
+      .getOrElse(PlannerType.BLINK) match {
+      case PlannerType.BLINK =>
+        val useBlinkPlanner =
+          Try(builder.getClass.getDeclaredMethod("useBlinkPlanner"))
+            .getOrElse(null)
+        if (useBlinkPlanner == null) {
+          logWarn("useBlinkPlanner deprecated")
+        } else {
+          useBlinkPlanner.setAccessible(true)
+          useBlinkPlanner.invoke(builder)
+          logInfo("blinkPlanner will be used.")
+        }
+      case PlannerType.OLD =>
+        val useOldPlanner = Try(builder.getClass.getDeclaredMethod("useOldPlanner")).getOrElse(null)
+        if (useOldPlanner == null) {
+          logWarn("useOldPlanner deprecated")
+        } else {
+          useOldPlanner.setAccessible(true)
+          useOldPlanner.invoke(builder)
+          logInfo("useOldPlanner will be used.")
+        }
+      case PlannerType.ANY =>
+        val useAnyPlanner = Try(builder.getClass.getDeclaredMethod("useAnyPlanner")).getOrElse(null)
+        if (useAnyPlanner == null) {
+          logWarn("useAnyPlanner deprecated")
+        } else {
+          logInfo("useAnyPlanner will be used.")
+          useAnyPlanner.setAccessible(true)
+          useAnyPlanner.invoke(builder)
+        }
+    }
+
+    parameter.get(KEY_FLINK_CONF(), null) match {
+      case null | "" =>
+        throw new ExceptionInInitializerError(
+          "[StreamPark] Usage:can't find config,please set \"--flink.conf $conf \" in main arguments")
+      case conf => builder.withConfiguration(
+          Configuration.fromMap(PropertiesUtils.fromYamlText(DeflaterUtils.unzipString(conf))))
+    }
+    val buildWith =
+      (parameter.get(KEY_FLINK_TABLE_CATALOG), parameter.get(KEY_FLINK_TABLE_DATABASE))
+    buildWith match {
+      case (x: String, y: String) if x != null && y != null =>
+        logInfo(s"with built in catalog: $x")
+        logInfo(s"with built in database: $y")
+        builder.withBuiltInCatalogName(x)
+        builder.withBuiltInDatabaseName(y)
+      case (x: String, _) if x != null =>
+        logInfo(s"with built in catalog: $x")
+        builder.withBuiltInCatalogName(x)
+      case (_, y: String) if y != null =>
+        logInfo(s"with built in database: $y")
+        builder.withBuiltInDatabaseName(y)
+      case _ =>
+    }
+    builder
+  }
+
+  lazy val tableEnv: TableEnvironment = {
+    logInfo(s"job working in batch mode")
+    envSettings.inBatchMode()
+    val tableEnv = TableEnvironment.create(envSettings.build()).setAppName
+    apiType match {
+      case ApiType.JAVA if javaTableEnvConfFunc != null =>
+        javaTableEnvConfFunc.configuration(tableEnv.getConfig, parameter)
+      case ApiType.SCALA if tableConfFunc != null =>
+        tableConfFunc(tableEnv.getConfig, parameter)
+      case _ =>
+    }
+    tableEnv
+  }
+
+  lazy val streamTableEnv: StreamTableEnvironment = {
+    logInfo(s"components should work in streaming mode")
+    envSettings.inStreamingMode()
+    val setting = envSettings.build()
+
+    if (streamEnvConfFunc != null) {
+      streamEnvConfFunc(streamEnv, parameter)
+    }
+    if (javaStreamEnvConfFunc != null) {
+      javaStreamEnvConfFunc.configuration(streamEnv, parameter)
+    }
+    val streamTableEnv =
+      StreamTableEnvironment.create(streamEnv, setting).setAppName
+    apiType match {
+      case ApiType.JAVA if javaTableEnvConfFunc != null =>
+        javaTableEnvConfFunc.configuration(streamTableEnv.getConfig, parameter)
+      case ApiType.SCALA if tableConfFunc != null =>
+        tableConfFunc(streamTableEnv.getConfig, parameter)
+      case _ =>
+    }
+    streamTableEnv
+  }
+
+  /** In case of table SQL, the parameter conf is not required, it depends on the developer. */
+
+  override def initParameter(): FlinkConfiguration = {
+    val configuration = {
+      val argsMap = ParameterTool.fromArgs(args)
+      argsMap.get(KEY_APP_CONF(), null) match {
+        case null | "" =>
+          logWarn("Usage:can't find config,you can set \"--conf $path \" in main arguments")
+          val parameter =
+            ParameterTool.fromSystemProperties().mergeWith(argsMap)
+          FlinkConfiguration(parameter, new Configuration(), new Configuration())
+        case file =>
+          val configMap = parseConfig(file)
+          // set sql..
+          val sqlConf = mutable.Map[String, String]()
+          configMap.foreach(x => {
+            if (x._1.startsWith(KEY_SQL_PREFIX)) {
+              sqlConf += x._1.drop(KEY_SQL_PREFIX.length) -> x._2
+            }
+          })
+
+          // config priority: explicitly specified priority > project profiles > system profiles
+          val properConf =
+            extractConfigByPrefix(configMap, KEY_FLINK_PROPERTY_PREFIX)
+          val appConf = extractConfigByPrefix(configMap, KEY_APP_PREFIX)
+          val tableConf =
+            extractConfigByPrefix(configMap, KEY_FLINK_TABLE_PREFIX)
+
+          val tableConfig = Configuration.fromMap(tableConf)
+          val envConfig = Configuration.fromMap(properConf)
+
+          val parameter = ParameterTool
+            .fromSystemProperties()
+            .mergeWith(ParameterTool.fromMap(properConf))
+            .mergeWith(ParameterTool.fromMap(tableConf))
+            .mergeWith(ParameterTool.fromMap(appConf))
+            .mergeWith(ParameterTool.fromMap(sqlConf))
+            .mergeWith(argsMap)
+
+          FlinkConfiguration(parameter, envConfig, tableConfig)
+      }
+    }
+
+    configuration.parameter.get(KEY_FLINK_SQL()) match {
+      case null => configuration
+      case param =>
+        // for streampark-console
+        Try(DeflaterUtils.unzipString(param)) match {
+          case Success(value) =>
+            configuration.copy(parameter = configuration.parameter.mergeWith(
+              ParameterTool.fromMap(Map(KEY_FLINK_SQL() -> value))))
+          case Failure(_) =>
+            val sqlFile = new File(param)
+            Try(PropertiesUtils.fromYamlFile(sqlFile.getAbsolutePath)) match {
+              case Success(value) =>
+                configuration.copy(parameter =
+                  configuration.parameter.mergeWith(ParameterTool.fromMap(value)))
+              case Failure(e) =>
+                new IllegalArgumentException(s"[StreamPark] init sql error.$e")
+                configuration
+            }
+        }
+    }
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkTableTrait.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/FlinkTableTrait.scala
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Utils
+import org.apache.streampark.flink.core.EnhancerImplicit._
+
+import org.apache.flink.api.common.JobExecutionResult
+import org.apache.flink.table.api._
+import org.apache.flink.table.catalog.Catalog
+import org.apache.flink.table.expressions.Expression
+import org.apache.flink.table.functions._
+import org.apache.flink.table.module.Module
+import org.apache.flink.table.types.AbstractDataType
+import org.apache.flink.util.ParameterTool
+
+import java.lang
+import java.util.Optional
+
+abstract class FlinkTableTrait(val parameter: ParameterTool, private val tableEnv: TableEnvironment)
+  extends TableEnvironment {
+
+  def start(): JobExecutionResult = {
+    val appName = parameter.getAppName(required = true)
+    execute(appName)
+  }
+
+  def execute(jobName: String): JobExecutionResult = {
+    Utils.printLogo(s"FlinkTable $jobName Starting...")
+    null
+  }
+
+  def sql(sql: String = null): Unit =
+    FlinkSqlExecutor.executeSql(sql, parameter, this)
+
+  override def fromValues(values: Expression*): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(rowType: AbstractDataType[_], values: Expression*): Table =
+    tableEnv.fromValues(rowType, values: _*)
+
+  override def fromValues(values: lang.Iterable[_]): Table =
+    tableEnv.fromValues(values)
+
+  override def fromValues(rowType: AbstractDataType[_], values: lang.Iterable[_]): Table =
+    tableEnv.fromValues(rowType, values)
+
+  override def registerCatalog(catalogName: String, catalog: Catalog): Unit =
+    tableEnv.registerCatalog(catalogName, catalog)
+
+  override def getCatalog(catalogName: String): Optional[Catalog] =
+    tableEnv.getCatalog(catalogName)
+
+  override def loadModule(moduleName: String, module: Module): Unit =
+    tableEnv.loadModule(moduleName, module)
+
+  override def unloadModule(moduleName: String): Unit =
+    tableEnv.unloadModule(moduleName)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionClass)
+
+  override def createTemporarySystemFunction(
+      name: String,
+      functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporarySystemFunction(name, functionInstance)
+
+  override def dropTemporarySystemFunction(name: String): Boolean =
+    tableEnv.dropTemporarySystemFunction(name)
+
+  override def createFunction(path: String, functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def createFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, functionClass)
+
+  override def dropFunction(path: String): Boolean = tableEnv.dropFunction(path)
+
+  override def createTemporaryFunction(
+      path: String,
+      functionClass: Class[_ <: UserDefinedFunction]): Unit =
+    tableEnv.createTemporaryFunction(path, functionClass)
+
+  override def createTemporaryFunction(path: String, functionInstance: UserDefinedFunction): Unit =
+    tableEnv.createTemporaryFunction(path, functionInstance)
+
+  override def dropTemporaryFunction(path: String): Boolean =
+    tableEnv.dropTemporaryFunction(path)
+
+  override def createTemporaryView(path: String, view: Table): Unit =
+    tableEnv.createTemporaryView(path, view)
+
+  override def from(path: String): Table = tableEnv.from(path)
+
+  override def listCatalogs(): Array[String] = tableEnv.listCatalogs()
+
+  override def listModules(): Array[String] = tableEnv.listModules()
+
+  override def listDatabases(): Array[String] = tableEnv.listDatabases()
+
+  override def listTables(): Array[String] = tableEnv.listTables()
+
+  override def listViews(): Array[String] = tableEnv.listViews()
+
+  override def listTemporaryTables(): Array[String] =
+    tableEnv.listTemporaryTables
+
+  override def listTemporaryViews(): Array[String] =
+    tableEnv.listTemporaryViews()
+
+  override def listUserDefinedFunctions(): Array[String] =
+    tableEnv.listUserDefinedFunctions()
+
+  override def listFunctions(): Array[String] = tableEnv.listFunctions()
+
+  override def dropTemporaryTable(path: String): Boolean =
+    tableEnv.dropTemporaryTable(path)
+
+  override def dropTemporaryView(path: String): Boolean =
+    tableEnv.dropTemporaryView(path)
+
+  override def explainSql(statement: String, extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, extraDetails: _*)
+
+  override def sqlQuery(query: String): Table = tableEnv.sqlQuery(query)
+
+  override def executeSql(statement: String): TableResult =
+    tableEnv.executeSql(statement)
+
+  override def getCurrentCatalog: String = tableEnv.getCurrentCatalog
+
+  override def useCatalog(catalogName: String): Unit =
+    tableEnv.useCatalog(catalogName)
+
+  override def getCurrentDatabase: String = tableEnv.getCurrentDatabase
+
+  override def useDatabase(databaseName: String): Unit =
+    tableEnv.useDatabase(databaseName)
+
+  override def getConfig: TableConfig = tableEnv.getConfig
+
+  override def createStatementSet(): StatementSet =
+    tableEnv.createStatementSet()
+
+  @deprecated override def registerFunction(name: String, function: ScalarFunction): Unit =
+    tableEnv.registerFunction(name, function)
+
+  @deprecated override def registerTable(name: String, table: Table): Unit =
+    tableEnv.registerTable(name, table)
+
+  @deprecated override def scan(tablePath: String*): Table =
+    tableEnv.scan(tablePath: _*)
+
+  @deprecated override def getCompletionHints(statement: String, position: Int): Array[String] =
+    tableEnv.getCompletionHints(statement, position)
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/SqlCommandParser.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/SqlCommandParser.scala
@@ -1,0 +1,651 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.conf.ConfigKeys.PARAM_PREFIX
+import org.apache.streampark.common.enums.FlinkSqlValidationFailedType
+import org.apache.streampark.common.util.Logger
+
+import enumeratum.EnumEntry
+import org.apache.commons.lang3.StringUtils
+
+import java.lang.{Boolean => JavaBool}
+import java.util.Scanner
+import java.util.regex.{Matcher, Pattern}
+
+import scala.annotation.tailrec
+import scala.collection.{immutable, mutable}
+import scala.collection.mutable.ListBuffer
+import scala.util.control.Breaks.{break, breakable}
+
+object SqlCommandParser extends Logger {
+
+  def parseSQL(
+      sql: String,
+      validationCallback: FlinkSqlValidationResult => Unit = null): List[SqlCommandCall] = {
+    val sqlEmptyError = "verify failed: flink sql cannot be empty."
+    require(StringUtils.isNotBlank(sql), sqlEmptyError)
+    val sqlSegments = SqlSplitter.splitSql(sql)
+    sqlSegments match {
+      case s if s.isEmpty =>
+        if (validationCallback != null) {
+          validationCallback(
+            FlinkSqlValidationResult(
+              success = false,
+              failedType = FlinkSqlValidationFailedType.VERIFY_FAILED,
+              exception = sqlEmptyError))
+          null
+        } else {
+          throw new IllegalArgumentException(sqlEmptyError)
+        }
+      case segments =>
+        val calls = new ListBuffer[SqlCommandCall]
+        for (segment <- segments) {
+          parseLine(segment) match {
+            case Some(x) => calls += x
+            case _ =>
+              if (validationCallback != null) {
+                validationCallback(
+                  FlinkSqlValidationResult(
+                    success = false,
+                    failedType = FlinkSqlValidationFailedType.UNSUPPORTED_SQL,
+                    lineStart = segment.start,
+                    lineEnd = segment.end,
+                    exception = s"unsupported sql",
+                    sql = segment.sql))
+              } else {
+                throw new UnsupportedOperationException(s"unsupported sql: ${segment.sql}")
+              }
+          }
+        }
+
+        calls.toList match {
+          case c if c.isEmpty =>
+            if (validationCallback != null) {
+              validationCallback(
+                FlinkSqlValidationResult(
+                  success = false,
+                  failedType = FlinkSqlValidationFailedType.VERIFY_FAILED,
+                  exception = "flink sql syntax error, no executable sql"))
+              null
+            } else {
+              throw new UnsupportedOperationException("flink sql syntax error, no executable sql")
+            }
+          case r => r
+        }
+    }
+  }
+
+  private[this] def parseLine(sqlSegment: SqlSegment): Option[SqlCommandCall] = {
+    val sqlCommand = SqlCommand.get(sqlSegment.sql.trim)
+    if (sqlCommand == null) None
+    else {
+      val matcher = sqlCommand.matcher
+      val groups = new Array[String](matcher.groupCount)
+      for (i <- groups.indices) {
+        groups(i) = matcher.group(i + 1)
+      }
+      sqlCommand
+        .converter(groups)
+        .map(x =>
+          SqlCommandCall(sqlSegment.start, sqlSegment.end, sqlCommand, x, sqlSegment.sql.trim))
+    }
+  }
+
+}
+
+object Converters {
+  val NO_OPERANDS = (_: Array[String]) => Some(Array.empty[String])
+}
+
+sealed abstract class SqlCommand(
+    val name: String,
+    private val regex: String,
+    val converter: Array[String] => Option[Array[String]] = (x: Array[String]) =>
+      Some(Array[String](x.head)))
+  extends EnumEntry {
+  var matcher: Matcher = _
+
+  def matches(input: String): Boolean = {
+    if (StringUtils.isBlank(regex)) false
+    else {
+      val pattern =
+        Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL)
+      matcher = pattern.matcher(input)
+      matcher.matches()
+    }
+  }
+}
+
+object SqlCommand extends enumeratum.Enum[SqlCommand] {
+
+  def get(stmt: String): SqlCommand = {
+    var cmd: SqlCommand = null
+    breakable {
+      this.values.foreach(x => {
+        if (x.matches(stmt)) {
+          cmd = x
+          break()
+        }
+      })
+    }
+    cmd
+  }
+
+  val values: immutable.IndexedSeq[SqlCommand] = findValues
+
+  // ---- SELECT Statements--------------------------------------------------------------------------------------------------------------------------------
+  case object SELECT extends SqlCommand("select", "(SELECT\\s+.+)")
+
+  // ----CREATE Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * <pre> CREATE [TEMPORARY] TABLE [IF NOT EXISTS] [catalog_name.][db_name.]table_name ( {
+   * <physical_column_definition> | <metadata_column_definition> | <computed_column_definition> }[ ,
+   * ...n] [ <watermark_definition> ] [ <table_constraint> ][ , ...n] ) [COMMENT table_comment]
+   * [PARTITIONED BY (partition_column_name1, partition_column_name2, ...)] WITH (key1=val1,
+   * key2=val2, ...) [ LIKE source_table [( <like_options> )] ] </pre
+   */
+  case object CREATE_TABLE
+    extends SqlCommand("create table", "(CREATE\\s+(TEMPORARY\\s+|)TABLE\\s+.+)")
+
+  /** <pre> CREATE CATALOG catalog_name WITH (key1=val1, key2=val2, ...) </pre> */
+  case object CREATE_CATALOG extends SqlCommand("create catalog", "(CREATE\\s+CATALOG\\s+.+)")
+
+  /**
+   * <pre> CREATE DATABASE [IF NOT EXISTS] [catalog_name.]db_name<br> [COMMENT database_comment]<br>
+   * WITH (key1=val1, key2=val2, ...)<br> </pre>
+   */
+  case object CREATE_DATABASE extends SqlCommand("create database", "(CREATE\\s+DATABASE\\s+.+)")
+
+  /**
+   * <pre> CREATE [TEMPORARY] VIEW [IF NOT EXISTS] [catalog_name.][db_name.]view_name [( columnName
+   * [, columnName ]* )] [COMMENT view_comment] AS query_expression< </pre
+   */
+  case object CREATE_VIEW
+    extends SqlCommand(
+      "create view",
+      "(CREATE\\s+(TEMPORARY\\s+|)VIEW\\s+(IF\\s+NOT\\s+EXISTS\\s+|)(\\S+)\\s+AS\\s+SELECT\\s+.+)")
+
+  /**
+   * <pre> CREATE [TEMPORARY|TEMPORARY SYSTEM] FUNCTION [IF NOT EXISTS]
+   * [catalog_name.][db_name.]function_name AS identifier [LANGUAGE JAVA|SCALA|PYTHON] </pre
+   */
+  case object CREATE_FUNCTION
+    extends SqlCommand(
+      "create function",
+      "(CREATE\\s+(TEMPORARY\\s+|TEMPORARY\\s+SYSTEM\\s+|)FUNCTION\\s+(IF\\s+NOT\\s+EXISTS\\s+|)(\\S+)\\s+AS\\s+.*)")
+
+  // ----DROP Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * <pre> DROP statements are used to remove a catalog with the given catalog name or to remove a
+   * registered table/view/function from the current or specified Catalog.
+   *
+   * Flink SQL supports the following DROP statements for now: * DROP CATALOG * DROP TABLE * DROP
+   * DATABASE * DROP VIEW * DROP FUNCTION </pre>
+   */
+
+  /** <strong>DROP CATALOG [IF EXISTS] catalog_name</strong> */
+  case object DROP_CATALOG extends SqlCommand("drop catalog", "(DROP\\s+CATALOG\\s+.+)")
+
+  /** <strong>DROP [TEMPORARY] TABLE [IF EXISTS] [catalog_name.][db_name.]table_name</strong> */
+  case object DROP_TABLE extends SqlCommand("drop table", "(DROP\\s+(TEMPORARY\\s+|)TABLE\\s+.+)")
+
+  /** <strong>DROP DATABASE [IF EXISTS] [catalog_name.]db_name [ (RESTRICT | CASCADE) ]</strong> */
+  case object DROP_DATABASE extends SqlCommand("drop database", "(DROP\\s+DATABASE\\s+.+)")
+
+  /** <strong>DROP [TEMPORARY] VIEW [IF EXISTS] [catalog_name.][db_name.]view_name</strong> */
+  case object DROP_VIEW extends SqlCommand("drop view", "(DROP\\s+(TEMPORARY\\s+|)VIEW\\s+.+)")
+
+  /**
+   * <strong>DROP [TEMPORARY|TEMPORARY SYSTEM] FUNCTION [IF EXISTS]
+   * [catalog_name.][db_name.]function_name</strong>
+   */
+  case object DROP_FUNCTION
+    extends SqlCommand(
+      "drop function",
+      "(DROP\\s+(TEMPORARY\\s+|TEMPORARY\\s+SYSTEM\\s+|)FUNCTION\\s+.+)")
+
+  // ----ALTER Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * <strong>ALTER TABLE [catalog_name.][db_name.]table_name RENAME TO new_table_name</strong>
+   *
+   * <strong>ALTER TABLE [catalog_name.][db_name.]table_name SET (key1=val1, key2=val2,
+   * ...)</strong>
+   */
+  case object ALTER_TABLE extends SqlCommand("alter table", "(ALTER\\s+TABLE\\s+.+)")
+
+  /**
+   * <strong>ALTER VIEW [catalog_name.][db_name.]view_name RENAME TO new_view_name</strong>
+   *
+   * <strong>ALTER VIEW [catalog_name.][db_name.]view_name AS new_query_expression</strong>
+   */
+  case object ALTER_VIEW extends SqlCommand("alter view", "(ALTER\\s+VIEW\\s+.+)")
+
+  /** <strong>ALTER DATABASE [catalog_name.]db_name SET (key1=val1, key2=val2, ...)</strong> */
+  case object ALTER_DATABASE extends SqlCommand("alter database", "(ALTER\\s+DATABASE\\s+.+)")
+
+  /**
+   * <strong> ALTER [TEMPORARY|TEMPORARY SYSTEM] FUNCTION [IF EXISTS]
+   * [catalog_name.][db_name.]function_name AS identifier [LANGUAGE JAVA|SCALA|PYTHON] </strong>
+   */
+  case object ALTER_FUNCTION
+    extends SqlCommand(
+      "alter function",
+      "(ALTER\\s+(TEMPORARY\\s+|TEMPORARY\\s+SYSTEM\\s+|)FUNCTION\\s+.+)")
+
+  // ---- INSERT Statement--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * INSERT { INTO | OVERWRITE } [catalog_name.][db_name.]table_name [PARTITION part_spec]
+   * [column_list] select_statement INSERT { INTO | OVERWRITE } [catalog_name.][db_name.]table_name
+   * VALUES values_row [, values_row ...]
+   */
+  case object INSERT extends SqlCommand("insert", "(INSERT\\s+(INTO|OVERWRITE)\\s+.+)")
+
+  // ---- DESCRIBE Statement--------------------------------------------------------------------------------------------------------------------------------
+
+  /** { DESCRIBE | DESC } [catalog_name.][db_name.]table_name */
+  case object DESC extends SqlCommand("desc", "(DESC\\s+.+)")
+
+  /** { DESCRIBE | DESC } [catalog_name.][db_name.]table_name */
+  case object DESCRIBE extends SqlCommand("describe", "(DESCRIBE\\s+.+)")
+
+  // ---- EXPLAIN Statement--------------------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * For flink-1.13.x: EXPLAIN PLAN FOR `<query_statement_or_insert_statement>` <br> For
+   * flink-1.14.x: EXPLAIN ESTIMATED_COST, CHANGELOG_MODE, JSON_EXECUTION_PLAN
+   * `<query_statement_or_insert_statement>`<br> For flink-1.15.x: <br> <pre> EXPLAIN
+   * [([ExplainDetail[, ExplainDetail]*]) | PLAN FOR]
+   * <query_statement_or_insert_statement_or_statement_set>
+   *
+   * statement_set: EXECUTE STATEMENT SET BEGIN insert_statement; ... insert_statement; END; </pre>
+   * Recommended not to use the form of flink-1.15.x
+   */
+  case object EXPLAIN extends SqlCommand("explain", "(EXPLAIN\\s+.+)")
+
+  // ---- USE Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** USE CATALOG catalog_name */
+  case object USE_CATALOG extends SqlCommand("use catalog", "(USE\\s+CATALOG\\s+.+)")
+
+  /** USE MODULES module_name1[, module_name2, ...] */
+  case object USE_MODULES extends SqlCommand("use modules", "(USE\\s+MODULES\\s+.+)")
+
+  /** USE [catalog_name.]database_name */
+  case object USE_DATABASE extends SqlCommand("use database", "(USE\\s+(?!(CATALOG|MODULES)).+)")
+
+  // ----SHOW Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** SHOW CATALOGS */
+  case object SHOW_CATALOGS extends SqlCommand("show catalogs", "(SHOW\\s+CATALOGS\\s*)")
+
+  /** SHOW CURRENT CATALOG */
+  case object SHOW_CURRENT_CATALOG
+    extends SqlCommand("show current catalog", "(SHOW\\s+CURRENT\\s+CATALOG\\s*)")
+
+  /** SHOW DATABASES */
+  case object SHOW_DATABASES extends SqlCommand("show databases", "(SHOW\\s+DATABASES\\s*)")
+
+  /** SHOW CURRENT DATABASE */
+  case object SHOW_CURRENT_DATABASE
+    extends SqlCommand("show current database", "(SHOW\\s+CURRENT\\s+DATABASE\\s*)")
+
+  /**
+   * SHOW TABLES,support from flink-1.13.x<br> SHOW TABLES [ ( FROM | IN )
+   * [catalog_name.]database_name ] [ [NOT] LIKE `<sql_like_pattern`> ], support from flink-1.15.x
+   */
+  case object SHOW_TABLES extends SqlCommand("show tables", "(SHOW\\s+TABLES.*)")
+
+  /** SHOW CREATE TABLE, flink-1.14.x support. */
+  case object SHOW_CREATE_TABLE
+    extends SqlCommand("show create table", "(SHOW\\s+CREATE\\s+TABLE\\s+.+)")
+
+  /**
+   * SHOW COLUMNS ( FROM | IN ) [`[`catalog_name.]database.]`<table_name>` [ [NOT] LIKE
+   * `<sql_like_pattern>`],flink-1.15.x support.
+   */
+  case object SHOW_COLUMNS extends SqlCommand("show columns", "(SHOW\\s+COLUMNS\\s+.+)")
+
+  /** SHOW VIEWS */
+  case object SHOW_VIEWS extends SqlCommand("show views", "(SHOW\\s+VIEWS\\s*)")
+
+  /** SHOW CREATE VIEW */
+  case object SHOW_CREATE_VIEW
+    extends SqlCommand("show create view", "(SHOW\\s+CREATE\\s+VIEW\\s+.+)")
+
+  /** SHOW [USER] FUNCTIONS */
+  case object SHOW_FUNCTIONS
+    extends SqlCommand("show functions", "(SHOW\\s+(USER\\s+|)FUNCTIONS\\s*)")
+
+  /** SHOW [FULL] MODULES */
+  case object SHOW_MODULES extends SqlCommand("show modules", "(SHOW\\s+(FULL\\s+|)MODULES\\s*)")
+
+  // ----LOAD Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** LOAD MODULE module_name [WITH ('key1' = 'val1', 'key2' = 'val2', ...)] */
+  case object LOAD_MODULE extends SqlCommand("load module", "(LOAD\\s+MODULE\\s+.+)")
+
+  // ----UNLOAD Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** UNLOAD MODULE module_name */
+  case object UNLOAD_MODULE extends SqlCommand("unload module", "(UNLOAD\\s+MODULE\\s+.+)")
+
+  // ----SET Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** SET ('key' = 'value') */
+  case object SET
+    extends SqlCommand(
+      "set",
+      "SET(\\s+(\\S+)\\s*=(.*))?",
+      {
+        case a if a.length < 3 => None
+        case a if a.head == null => Some(Array[String](cleanUp(a.head)))
+        case a => Some(Array[String](cleanUp(a(1)), cleanUp(a(2))))
+      })
+
+  // ----RESET Statements--------------------------------------------------------------------------------------------------------------------------------
+
+  /** RESET ('key') */
+  case object RESET extends SqlCommand("reset", "RESET\\s+'(.*)'")
+
+  /** RESET */
+  case object RESET_ALL extends SqlCommand("reset all", "RESET", _ => Some(Array[String]("ALL")))
+
+  // ----INSERT SET Statements--------------------------------------------------------------------------------------------------------------------------------
+  /*
+   * <pre>
+   * SQL Client execute each INSERT INTO statement as a single Flink job. However,
+   * this is sometimes not optimal because some part of the pipeline can be reused.
+   * SQL Client supports STATEMENT SET syntax to execute a set of SQL statements.
+   * This is an equivalent feature with StatementSet in Table API.
+   * The STATEMENT SET syntax encloses one or more INSERT INTO statements.
+   * All statements in a STATEMENT SET block are holistically optimized and executed as a single Flink job.
+   * Joint optimization and execution allows for reusing common intermediate results and can therefore significantly
+   * improve the efficiency of executing multiple queries.
+   * </pre>
+   */
+  /** This is SQL Client's syntax, don't use in our platform. */
+  @deprecated
+  case object BEGIN_STATEMENT_SET
+    extends SqlCommand("begin statement set", "BEGIN\\s+STATEMENT\\s+SET", Converters.NO_OPERANDS)
+
+  /** This is SQL Client's syntax, don't use in our platform. */
+  @deprecated
+  case object END_STATEMENT_SET
+    extends SqlCommand("end statement set", "END", Converters.NO_OPERANDS)
+
+  // Since: 2.1.2 for flink 1.18
+  case object DELETE extends SqlCommand("delete", "(DELETE\\s+FROM\\s+.+)")
+
+  // Since: 2.1.2 for flink 1.18
+  case object UPDATE extends SqlCommand("update", "(UPDATE\\s+.+)")
+
+  private[this] def cleanUp(sql: String): String =
+    sql.trim.replaceAll("^(['\"])|(['\"])$", "")
+
+}
+
+/** Call of SQL command with operands and command type. */
+case class SqlCommandCall(
+    lineStart: Int,
+    lineEnd: Int,
+    command: SqlCommand,
+    operands: Array[String],
+    originSql: String) {}
+
+case class FlinkSqlValidationResult(
+    success: JavaBool = true,
+    failedType: FlinkSqlValidationFailedType = null,
+    lineStart: Int = 0,
+    lineEnd: Int = 0,
+    errorLine: Int = 0,
+    errorColumn: Int = 0,
+    sql: String = null,
+    exception: String = null)
+
+case class SqlSegment(start: Int, end: Int, sql: String)
+
+object SqlSplitter {
+
+  private lazy val singleLineCommentPrefixList = Set[String](PARAM_PREFIX)
+
+  /**
+   * Split whole text into multiple sql statements. Two Steps: Step 1, split the whole text into
+   * multiple sql statements. Step 2, refine the results. Replace the preceding sql statements with
+   * empty lines, so that we can get the correct line number in the parsing error message. e.g:
+   * select a from table_1; select a from table_2; select a from table_3; The above text will be
+   * splitted into: sql_1: select a from table_1 sql_2: \nselect a from table_2 sql_3: \n\nselect a
+   * from table_3
+   *
+   * @param sql
+   * @return
+   */
+  def splitSql(sql: String): List[SqlSegment] = {
+    val queries = ListBuffer[String]()
+    val lastIndex = if (StringUtils.isNotBlank(sql)) sql.length - 1 else 0
+    var query = new mutable.StringBuilder
+
+    var multiLineComment = false
+    var singleLineComment = false
+    var singleQuoteString = false
+    var doubleQuoteString = false
+    var lineNum: Int = 0
+    val lineNumMap = new collection.mutable.HashMap[Int, (Int, Int)]()
+
+    // Whether each line of the record is empty. If it is empty, it is false. If it is not empty, it is true
+    val lineDescriptor = {
+      val scanner = new Scanner(sql)
+      val descriptor = new collection.mutable.HashMap[Int, Boolean]
+      var lineNumber = 0
+      var startComment = false
+      var hasComment = false
+
+      while (scanner.hasNextLine) {
+        lineNumber += 1
+        val line = scanner.nextLine().trim
+        val nonEmpty =
+          StringUtils.isNotBlank(line) && !line.startsWith(PARAM_PREFIX)
+        if (line.startsWith("/*")) {
+          startComment = true
+          hasComment = true
+        }
+
+        descriptor += lineNumber -> (nonEmpty && !hasComment)
+
+        if (startComment && line.endsWith("*/")) {
+          startComment = false
+          hasComment = false
+        }
+      }
+      descriptor
+    }
+
+    @tailrec
+    def findStartLine(num: Int): Int =
+      if (num >= lineDescriptor.size || lineDescriptor(num)) num
+      else findStartLine(num + 1)
+
+    def markLineNumber(): Unit = {
+      val line = lineNum + 1
+      if (lineNumMap.isEmpty) {
+        lineNumMap += (0 -> (findStartLine(1) -> line))
+      } else {
+        val index = lineNumMap.size
+        val start = lineNumMap(lineNumMap.size - 1)._2 + 1
+        lineNumMap += (index -> (findStartLine(start) -> line))
+      }
+    }
+
+    for (idx <- 0 until sql.length) {
+
+      if (sql.charAt(idx) == '\n') lineNum += 1
+
+      breakable {
+        val ch = sql.charAt(idx)
+
+        // end of single line comment
+        if (singleLineComment && (ch == '\n')) {
+          singleLineComment = false
+          query += ch
+          if (idx == lastIndex && query.toString.trim.nonEmpty) {
+            // add query when it is the end of sql.
+            queries += query.toString
+          }
+          break()
+        }
+
+        // end of multiple line comment
+        if (multiLineComment && (idx - 1) >= 0 && sql.charAt(idx - 1) == '/'
+          && (idx - 2) >= 0 && sql.charAt(idx - 2) == '*') {
+          multiLineComment = false
+        }
+
+        // single quote start or end mark
+        if (ch == '\'' && !(singleLineComment || multiLineComment)) {
+          if (singleQuoteString) {
+            singleQuoteString = false
+          } else if (!doubleQuoteString) {
+            singleQuoteString = true
+          }
+        }
+
+        // double quote start or end mark
+        if (ch == '"' && !(singleLineComment || multiLineComment)) {
+          if (doubleQuoteString && idx > 0) {
+            doubleQuoteString = false
+          } else if (!singleQuoteString) {
+            doubleQuoteString = true
+          }
+        }
+
+        // single line comment or multiple line comment start mark
+        if (!singleQuoteString && !doubleQuoteString && !multiLineComment && !singleLineComment && idx < lastIndex) {
+          if (isSingleLineComment(sql.charAt(idx), sql.charAt(idx + 1))) {
+            singleLineComment = true
+          } else if (sql.charAt(idx) == '/' && sql.length > (idx + 2)
+            && sql.charAt(idx + 1) == '*' && sql.charAt(idx + 2) != '+') {
+            multiLineComment = true
+          }
+        }
+
+        if (ch == ';' && !singleQuoteString && !doubleQuoteString && !multiLineComment && !singleLineComment) {
+          markLineNumber()
+          // meet the end of semicolon
+          if (query.toString.trim.nonEmpty) {
+            queries += query.toString
+            query = new mutable.StringBuilder
+          }
+        } else if (idx == lastIndex) {
+          markLineNumber()
+
+          // meet the last character
+          if (!singleLineComment && !multiLineComment) {
+            query += ch
+          }
+
+          if (query.toString.trim.nonEmpty) {
+            queries += query.toString
+            query = new mutable.StringBuilder
+          }
+        } else if (!singleLineComment && !multiLineComment) {
+          // normal case, not in single line comment and not in multiple line comment
+          query += ch
+        } else if (ch == '\n') {
+          query += ch
+        }
+      }
+    }
+
+    val refinedQueries = new collection.mutable.HashMap[Int, String]()
+    for (i <- queries.indices) {
+      val currStatement = queries(i)
+      if (isSingleLineComment(currStatement) || isMultipleLineComment(currStatement)) {
+        // transform comment line as blank lines
+        if (refinedQueries.nonEmpty) {
+          val lastRefinedQuery = refinedQueries.last
+          refinedQueries(refinedQueries.size - 1) =
+            lastRefinedQuery + extractLineBreaks(currStatement)
+        }
+      } else {
+        var linesPlaceholder = ""
+        if (i > 0) {
+          linesPlaceholder = extractLineBreaks(refinedQueries(i - 1))
+        }
+        // add some blank lines before the statement to keep the original line number
+        val refinedQuery = linesPlaceholder + currStatement
+        refinedQueries += refinedQueries.size -> refinedQuery
+      }
+    }
+
+    val set = new ListBuffer[SqlSegment]
+    refinedQueries.foreach(x => {
+      val line = lineNumMap(x._1)
+      set += SqlSegment(line._1, line._2, x._2)
+    })
+    set.toList.sortWith((a, b) => a.start < b.start)
+  }
+
+  /**
+   * extract line breaks
+   *
+   * @param text
+   * @return
+   */
+  private[this] def extractLineBreaks(text: String): String = {
+    val builder = new mutable.StringBuilder
+    for (i <- 0 until text.length) {
+      if (text.charAt(i) == '\n') {
+        builder.append('\n')
+      }
+    }
+    builder.toString
+  }
+
+  private[this] def isSingleLineComment(text: String) =
+    text.trim.startsWith(PARAM_PREFIX)
+
+  private[this] def isMultipleLineComment(text: String) =
+    text.trim.startsWith("/*") && text.trim.endsWith("*/")
+
+  /**
+   * check single-line comment
+   *
+   * @param curChar
+   * @param nextChar
+   * @return
+   */
+  private[this] def isSingleLineComment(curChar: Char, nextChar: Char): Boolean = {
+    var flag = false
+    for (singleCommentPrefix <- singleLineCommentPrefixList) {
+      singleCommentPrefix.length match {
+        case 1 if curChar == singleCommentPrefix.charAt(0) => flag = true
+        case 2
+            if curChar == singleCommentPrefix.charAt(0) && nextChar == singleCommentPrefix.charAt(
+              1) =>
+          flag = true
+        case _ =>
+      }
+    }
+    flag
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/StreamEnvConfig.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/StreamEnvConfig.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+class StreamEnvConfig(val args: Array[String], val conf: StreamEnvConfigFunction)
+
+class StreamTableEnvConfig(
+    val args: Array[String],
+    val streamConfig: StreamEnvConfigFunction,
+    val tableConfig: TableEnvConfigFunction)
+
+class TableEnvConfig(val args: Array[String], val conf: TableEnvConfigFunction)

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/StreamTableContext.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/StreamTableContext.scala
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Implicits.JavaList
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.tuple
+import org.apache.flink.streaming.api.datastream.{DataStream => JavaDataStream}
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.ModelDescriptor
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.table.catalog.CatalogDescriptor
+import org.apache.flink.table.connector.ChangelogMode
+import org.apache.flink.table.expressions.Expression
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.module.ModuleEntry
+import org.apache.flink.table.resource.ResourceUri
+import org.apache.flink.table.types.AbstractDataType
+import org.apache.flink.types.Row
+import org.apache.flink.util.ParameterTool
+
+class StreamTableContext(
+    override val parameter: ParameterTool,
+    private val streamEnv: StreamExecutionEnvironment,
+    private val tableEnv: StreamTableEnvironment)
+  extends FlinkStreamTableTraitV2(parameter, streamEnv, tableEnv) {
+
+  def this(args: (ParameterTool, StreamExecutionEnvironment, StreamTableEnvironment)) =
+    this(args._1, args._2, args._3)
+
+  def this(args: StreamTableEnvConfig) =
+    this(FlinkTableInitializerV2.initialize(args))
+
+  override def fromDataStream[T](dataStream: JavaDataStream[T], schema: Schema): Table =
+    tableEnv.fromDataStream[T](dataStream, schema)
+
+  /** @deprecated old API */
+  override def fromDataStream[T](dataStream: JavaDataStream[T], expressions: Expression*): Table =
+    tableEnv.fromDataStream(dataStream, expressions: _*)
+
+  override def fromChangelogStream(dataStream: JavaDataStream[Row]): Table =
+    tableEnv.fromChangelogStream(dataStream)
+
+  override def fromChangelogStream(dataStream: JavaDataStream[Row], schema: Schema): Table =
+    tableEnv.fromChangelogStream(dataStream, schema)
+
+  override def fromChangelogStream(
+      dataStream: JavaDataStream[Row],
+      schema: Schema,
+      changelogMode: ChangelogMode): Table =
+    tableEnv.fromChangelogStream(dataStream, schema, changelogMode)
+
+  override def createTemporaryView[T](
+      path: String,
+      dataStream: JavaDataStream[T],
+      schema: Schema): Unit =
+    tableEnv.createTemporaryView[T](path, dataStream, schema)
+
+  /** @deprecated old API */
+  @deprecated override def createTemporaryView[T](
+      path: String,
+      dataStream: JavaDataStream[T],
+      expressions: Expression*): Unit =
+    tableEnv.createTemporaryView(path, dataStream, expressions: _*)
+
+  override def toDataStream(table: Table): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream(table)
+  }
+
+  override def toDataStream[T](table: Table, targetClass: Class[T]): JavaDataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream[T](table, targetClass)
+  }
+
+  override def toDataStream[T](table: Table, targetDataType: AbstractDataType[_]): JavaDataStream[T] = {
+    isConvertedToDataStream = true
+    tableEnv.toDataStream[T](table, targetDataType)
+  }
+
+  override def toChangelogStream(table: Table): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table)
+  }
+
+  override def toChangelogStream(table: Table, targetSchema: Schema): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema)
+  }
+
+  override def toChangelogStream(
+      table: Table,
+      targetSchema: Schema,
+      changelogMode: ChangelogMode): JavaDataStream[Row] = {
+    isConvertedToDataStream = true
+    tableEnv.toChangelogStream(table, targetSchema, changelogMode)
+  }
+
+  override def createStatementSet(): org.apache.flink.table.api.bridge.java.StreamStatementSet =
+    tableEnv.createStatementSet()
+
+  override def useModules(strings: String*): Unit =
+    tableEnv.useModules(strings: _*)
+
+  override def createTemporaryTable(path: String, descriptor: TableDescriptor): Unit =
+    tableEnv.createTemporaryTable(path, descriptor)
+
+  override def createTable(path: String, descriptor: TableDescriptor): Unit =
+    tableEnv.createTable(path, descriptor)
+
+  override def from(descriptor: TableDescriptor): Table =
+    tableEnv.from(descriptor)
+
+  override def listFullModules(): Array[ModuleEntry] =
+    tableEnv.listFullModules()
+
+  /** @since 1.15 */
+  override def listTables(s: String, s1: String): Array[String] =
+    tableEnv.listTables(s, s1)
+
+  /** @since 1.15 */
+  override def loadPlan(planReference: PlanReference): CompiledPlan =
+    tableEnv.loadPlan(planReference)
+
+  /** @since 1.15 */
+  override def compilePlanSql(s: String): CompiledPlan =
+    tableEnv.compilePlanSql(s)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, className, resourceUris, ignoreIfExists)
+
+  /** @since 1.17 */
+  override def createTemporaryFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporaryFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createTemporarySystemFunction(
+      name: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporarySystemFunction(name, className, resourceUris)
+
+  /** @since 1.17 */
+  override def explainSql(
+      statement: String,
+      format: ExplainFormat,
+      extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, format, extraDetails: _*)
+
+  /** @since 1.18 */
+  override def createCatalog(catalog: String, catalogDescriptor: CatalogDescriptor): Unit = {
+    tableEnv.createCatalog(catalog, catalogDescriptor)
+  }
+
+  /** @deprecated old API */
+  @deprecated override def toAppendStream[T](
+      table: Table,
+      typeInformation: TypeInformation[T]): JavaDataStream[T] =
+    tableEnv.toAppendStream(table, typeInformation)
+
+  /** @deprecated old API */
+  @deprecated override def toRetractStream[T](
+      table: Table,
+      typeInformation: TypeInformation[T]): JavaDataStream[tuple.Tuple2[java.lang.Boolean, T]] =
+    tableEnv.toRetractStream(table, typeInformation)
+
+  /** since Flink 2.0 */
+  override def toAppendStream[T](table: Table, clazz: Class[T]): JavaDataStream[T] =
+    tableEnv.toAppendStream(table, clazz)
+
+  /** since Flink 2.0 */
+  override def toRetractStream[T](table: Table, clazz: Class[T]): JavaDataStream[tuple.Tuple2[java.lang.Boolean, T]] =
+    tableEnv.toRetractStream(table, clazz)
+
+  /** since Flink 2.0 */
+  override def createTable(path: String, descriptor: TableDescriptor, ignoreIfExists: Boolean): Boolean =
+    tableEnv.createTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createTemporaryTable(
+      path: String,
+      descriptor: TableDescriptor,
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createTemporaryTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table, ignoreIfExists: Boolean): Boolean =
+    tableEnv.createView(path, view, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table): Unit =
+    tableEnv.createView(path, view)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropTable(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String): Boolean =
+    tableEnv.dropTable(path)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropView(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String): Boolean =
+    tableEnv.dropView(path)
+
+  /** since Flink 2.1 */
+  override def createModel(path: String, descriptor: ModelDescriptor, ignoreIfExists: Boolean): Unit =
+    tableEnv.createModel(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.1 */
+  override def createModel(path: String, descriptor: ModelDescriptor): Unit =
+    tableEnv.createModel(path, descriptor)
+
+  /** since Flink 2.1 */
+  override def createTemporaryModel(path: String, descriptor: ModelDescriptor, ignoreIfExists: Boolean): Unit =
+    tableEnv.createTemporaryModel(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.1 */
+  override def createTemporaryModel(path: String, descriptor: ModelDescriptor): Unit =
+    tableEnv.createTemporaryModel(path, descriptor)
+
+  /** since Flink 2.1 */
+  override def dropModel(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropModel(path, ignoreIfNotExists)
+
+  /** since Flink 2.1 */
+  override def dropModel(path: String): Boolean =
+    tableEnv.dropModel(path)
+
+  /** since Flink 2.1 */
+  override def dropTemporaryModel(path: String): Boolean =
+    tableEnv.dropTemporaryModel(path)
+
+  /** since Flink 2.1 */
+  override def fromCall(functionClass: Class[_ <: UserDefinedFunction], arguments: Object*): Table =
+    tableEnv.fromCall(functionClass, arguments: _*)
+
+  /** since Flink 2.1 */
+  override def fromCall(functionName: String, arguments: Object*): Table =
+    tableEnv.fromCall(functionName, arguments: _*)
+
+  /** since Flink 2.1 */
+  override def listModels(): Array[String] =
+    tableEnv.listModels()
+
+  /** since Flink 2.1 */
+  override def listTemporaryModels(): Array[String] =
+    tableEnv.listTemporaryModels()
+
+  /** since Flink 2.2 */
+  override def createFunction(
+      path: String,
+      descriptor: FunctionDescriptor,
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.2 */
+  override def createFunction(path: String, descriptor: FunctionDescriptor): Unit =
+    tableEnv.createFunction(path, descriptor)
+
+  /** since Flink 2.2 */
+  override def createTemporaryFunction(path: String, descriptor: FunctionDescriptor): Unit =
+    tableEnv.createTemporaryFunction(path, descriptor)
+
+  /** since Flink 2.2 */
+  override def createTemporarySystemFunction(name: String, descriptor: FunctionDescriptor): Unit =
+    tableEnv.createTemporarySystemFunction(name, descriptor)
+
+  /** since Flink 2.2 */
+  override def fromModel(descriptor: ModelDescriptor): Model =
+    tableEnv.fromModel(descriptor)
+
+  /** since Flink 2.2 */
+  override def fromModel(path: String): Model =
+    tableEnv.fromModel(path)
+
+  /** since Flink 2.2 */
+  override def listMaterializedTables(): Array[String] =
+    tableEnv.listMaterializedTables()
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/TableContext.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/TableContext.scala
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.streampark.common.util.Implicits.JavaList
+
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.ModelDescriptor
+import org.apache.flink.table.catalog.CatalogDescriptor
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.module.ModuleEntry
+import org.apache.flink.table.resource.ResourceUri
+import org.apache.flink.util.ParameterTool
+
+class TableContext(override val parameter: ParameterTool, private val tableEnv: TableEnvironment)
+  extends FlinkTableTrait(parameter, tableEnv) {
+
+  def this(args: (ParameterTool, TableEnvironment)) = this(args._1, args._2)
+
+  def this(args: TableEnvConfig) = this(FlinkTableInitializerV2.initialize(args))
+
+  override def useModules(strings: String*): Unit =
+    tableEnv.useModules(strings: _*)
+
+  override def createTemporaryTable(path: String, descriptor: TableDescriptor): Unit = {
+    tableEnv.createTemporaryTable(path, descriptor)
+  }
+
+  override def createTable(path: String, descriptor: TableDescriptor): Unit = {
+    tableEnv.createTable(path, descriptor)
+  }
+
+  override def from(tableDescriptor: TableDescriptor): Table = {
+    tableEnv.from(tableDescriptor)
+  }
+
+  override def listFullModules(): Array[ModuleEntry] =
+    tableEnv.listFullModules()
+
+  /** @since 1.15 */
+  override def listTables(catalogName: String, databaseName: String): Array[String] =
+    tableEnv.listTables(catalogName, databaseName)
+
+  /** @since 1.15 */
+  override def loadPlan(planReference: PlanReference): CompiledPlan =
+    tableEnv.loadPlan(planReference)
+
+  /** @since 1.15 */
+  override def compilePlanSql(stmt: String): CompiledPlan =
+    tableEnv.compilePlanSql(stmt)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri],
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, className, resourceUris, ignoreIfExists)
+
+  /** @since 1.17 */
+  override def createTemporaryFunction(
+      path: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporaryFunction(path, className, resourceUris)
+
+  /** @since 1.17 */
+  override def createTemporarySystemFunction(
+      name: String,
+      className: String,
+      resourceUris: JavaList[ResourceUri]): Unit =
+    tableEnv.createTemporarySystemFunction(name, className, resourceUris)
+
+  /** @since 1.17 */
+  override def explainSql(
+      statement: String,
+      format: ExplainFormat,
+      extraDetails: ExplainDetail*): String =
+    tableEnv.explainSql(statement, format, extraDetails: _*)
+
+  /** @since 1.18 */
+  override def createCatalog(catalog: String, catalogDescriptor: CatalogDescriptor): Unit = {
+    tableEnv.createCatalog(catalog, catalogDescriptor)
+  }
+
+  /** since Flink 2.0 */
+  override def createTable(
+      path: String,
+      descriptor: TableDescriptor,
+      ignoreIfExists: Boolean): Boolean =
+    tableEnv.createTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createTemporaryTable(
+      path: String,
+      descriptor: TableDescriptor,
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createTemporaryTable(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table, ignoreIfExists: Boolean): Boolean =
+    tableEnv.createView(path, view, ignoreIfExists)
+
+  /** since Flink 2.0 */
+  override def createView(path: String, view: Table): Unit =
+    tableEnv.createView(path, view)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropTable(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropTable(path: String): Boolean =
+    tableEnv.dropTable(path)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropView(path, ignoreIfNotExists)
+
+  /** since Flink 2.0 */
+  override def dropView(path: String): Boolean =
+    tableEnv.dropView(path)
+
+  /** since Flink 2.1 */
+  override def createModel(path: String, descriptor: ModelDescriptor, ignoreIfExists: Boolean): Unit =
+    tableEnv.createModel(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.1 */
+  override def createModel(path: String, descriptor: ModelDescriptor): Unit =
+    tableEnv.createModel(path, descriptor)
+
+  /** since Flink 2.1 */
+  override def createTemporaryModel(path: String, descriptor: ModelDescriptor, ignoreIfExists: Boolean): Unit =
+    tableEnv.createTemporaryModel(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.1 */
+  override def createTemporaryModel(path: String, descriptor: ModelDescriptor): Unit =
+    tableEnv.createTemporaryModel(path, descriptor)
+
+  /** since Flink 2.1 */
+  override def dropModel(path: String, ignoreIfNotExists: Boolean): Boolean =
+    tableEnv.dropModel(path, ignoreIfNotExists)
+
+  /** since Flink 2.1 */
+  override def dropModel(path: String): Boolean =
+    tableEnv.dropModel(path)
+
+  /** since Flink 2.1 */
+  override def dropTemporaryModel(path: String): Boolean =
+    tableEnv.dropTemporaryModel(path)
+
+  /** since Flink 2.1 */
+  override def fromCall(functionClass: Class[_ <: UserDefinedFunction], arguments: Object*): Table =
+    tableEnv.fromCall(functionClass, arguments: _*)
+
+  /** since Flink 2.1 */
+  override def fromCall(functionName: String, arguments: Object*): Table =
+    tableEnv.fromCall(functionName, arguments: _*)
+
+  /** since Flink 2.1 */
+  override def listModels(): Array[String] =
+    tableEnv.listModels()
+
+  /** since Flink 2.1 */
+  override def listTemporaryModels(): Array[String] =
+    tableEnv.listTemporaryModels()
+
+  /** since Flink 2.2 */
+  override def createFunction(
+      path: String,
+      descriptor: FunctionDescriptor,
+      ignoreIfExists: Boolean): Unit =
+    tableEnv.createFunction(path, descriptor, ignoreIfExists)
+
+  /** since Flink 2.2 */
+  override def createFunction(path: String, descriptor: FunctionDescriptor): Unit =
+    tableEnv.createFunction(path, descriptor)
+
+  /** since Flink 2.2 */
+  override def createTemporaryFunction(path: String, descriptor: FunctionDescriptor): Unit =
+    tableEnv.createTemporaryFunction(path, descriptor)
+
+  /** since Flink 2.2 */
+  override def createTemporarySystemFunction(name: String, descriptor: FunctionDescriptor): Unit =
+    tableEnv.createTemporarySystemFunction(name, descriptor)
+
+  /** since Flink 2.2 */
+  override def fromModel(descriptor: ModelDescriptor): Model =
+    tableEnv.fromModel(descriptor)
+
+  /** since Flink 2.2 */
+  override def fromModel(path: String): Model =
+    tableEnv.fromModel(path)
+
+  /** since Flink 2.2 */
+  override def listMaterializedTables(): Array[String] =
+    tableEnv.listMaterializedTables()
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/TableExt.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/TableExt.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core
+
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.api.{Table => FlinkTable}
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
+import org.apache.flink.types.Row
+
+object TableExt {
+
+  class Table(val table: FlinkTable) {
+    def ->(field: String, fields: String*): FlinkTable =
+      table.as(field, fields: _*)
+  }
+
+  class TableConversions(
+      table: FlinkTable,
+      streamTableEnv: StreamTableEnvironment) {
+
+    def \\ : DataStream[Row] = streamTableEnv.toDataStream(table)
+  }
+
+}

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/conf/FlinkConfiguration.scala
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-2.2/src/main/scala/org/apache/streampark/flink/core/conf/FlinkConfiguration.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.core.conf
+
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.util.ParameterTool
+
+case class FlinkConfiguration(
+    parameter: ParameterTool,
+    envConfig: Configuration,
+    tableConfig: Configuration)


### PR DESCRIPTION
### What

Add an `AGENTS.md` file to the project root, following the same pattern as Apache Iceberg's [AGENTS.md](https://github.com/apache/iceberg/blob/main/AGENTS.md). This file serves as agent instructions, documenting:

- **Module Boundaries**: Clear responsibility boundaries for `streampark-common`, `streampark-flink`, `streampark-spark`, `streampark-console`
- **High-Sensitivity Areas**: `FlinkShimsProxy`, `FlinkStreaming` lifecycle, `ConfigKeys`, K8s integration, SQL dialect conversion, auth
- **Design Patterns**: Lifecycle trait pattern, Shims/Proxy pattern, Service layer separation, implicit enrichment, MyBatis-Plus entity pattern
- **Coding Conventions**: Java (Spotless/Checkstyle/JUnit 5), Scala (Scalafmt/ScalaTest), TypeScript/Vue (ESLint/Prettier)
- **Commands**: Build, test, format, lint commands for all layers
- **PR & Commit Conventions**: `[Module]` prefix format, dual database upgrade requirements
- **AI-Generated PR Disclosure**: Standardized template following ASF generative tooling guidelines
- **Boundaries**: "Never" and "Ask first" rules for contributors and AI agents

### Why

As AI-assisted development becomes more common in open-source projects, having a canonical `AGENTS.md` helps both human contributors and AI tools understand the project's unique conventions, sensitive areas, and boundaries. This reduces review burden and improves contribution quality.