### PR TITLE
[Bug] Revert FlinkEnv config path persistence regression

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/FlinkEnv.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/FlinkEnv.java
@@ -23,6 +23,7 @@ import org.apache.streampark.common.util.PropertiesUtils;
 import org.apache.streampark.console.base.exception.ApiAlertException;
 import org.apache.streampark.console.base.exception.ApiDetailException;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.baomidou.mybatisplus.annotation.IdType;
@@ -34,6 +35,7 @@ import lombok.Setter;
 
 import java.io.File;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
 
@@ -74,7 +76,14 @@ public class FlinkEnv implements Serializable {
   public void doSetFlinkConf() throws ApiDetailException {
     Float version = getVersionNumber();
     File configFile = resolveConfigFile(version);
-    this.flinkConf = configFile.getAbsolutePath();
+
+    try {
+      String flinkConf = FileUtils.readFileToString(configFile, StandardCharsets.UTF_8);
+      this.flinkConf = DeflaterUtils.zipString(flinkConf);
+    } catch (Exception e) {
+      throw new ApiDetailException(
+          "Failed to read Flink configuration file: " + configFile.getAbsolutePath(), e);
+    }
   }
 
   private File resolveConfigFile(Float version) throws ApiAlertException {


### PR DESCRIPTION
### What is the purpose of the change
  Issue Number: close #4316

  This PR reverts the regression introduced by 81b8161be29dde828febe10ff4b050dde5448c0b from v2.1.7.

  That commit changed `FlinkEnv.doSetFlinkConf()` to persist the absolute Flink config file path into `t_flink_env.flink_conf`.

  However, existing read paths still expect `flink_conf` to be compressed Base64 content and call `DeflaterUtils.unzipString(...)`, for example:

  - `/flink/env/get`
  - `FlinkEnv.convertFlinkYamlAsMap()`
  - `FlinkEnvServiceImpl.getFlinkConfig(...)`

  When `flink_conf` contains a path such as:

```text
  /data/flink/flink-1.20.5/conf/config.yaml

  Base64 decoding fails with:

  IllegalArgumentException: Illegal base64 character 2d

  This causes Flink Env view/edit and Application edit to return HTTP 500.
```

### Brief change log

  - Revert FlinkEnv.doSetFlinkConf() to persist compressed config content.
  - Read the resolved Flink config file content.
  - Store t_flink_env.flink_conf as DeflaterUtils.zipString(...).

### Verifying this change

  Manually verified with Flink 1.20.5:

  1. Create a Flink Env with flink_home=/data/flink/flink-1.20.5.
  2. Confirm t_flink_env.flink_conf stores compressed Base64 content, not the config file path.
  3. Call /flink/env/get.
  4. Open the Application edit page.
  5. No Illegal base64 character 2d error occurs.

### Does this pull request potentially affect one of the following parts

  - Dependencies: no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The behavior of t_flink_env.flink_conf: yes, restores the expected behavior used by existing read paths