### PR TITLE
[CI] Fail workflow when E2E tests fail

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -232,5 +232,5 @@ jobs:
           fi
           if [[ ${{ needs.e2e.result }} != 'success' ]]; then
             echo "E2E Failed!"
-            exit 0
+            exit 1
           fi


### PR DESCRIPTION
## Summary

- Change the `E2E - Result` job to `exit 1` when `needs.e2e.result` is not `success`, so E2E failures block PR merges.

Closes #4376

## Test plan

- [ ] Verify a failing E2E run marks the result job as failed
- [ ] Verify skipped E2E (paths-filter) still exits 0

Made with [Cursor](https://cursor.com)