### PR TITLE
[Console] Fix Maven local repo directory initialization on startup

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvInitializer.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvInitializer.java
@@ -156,9 +156,7 @@ public class EnvInitializer implements ApplicationRunner {
 
     private static void createMvnLocalRepoDir() {
         String localMavenRepo = Workspace.MAVEN_LOCAL_PATH();
-        if (FsOperator.lfs().exists(localMavenRepo)) {
-            FsOperator.lfs().mkdirs(localMavenRepo);
-        }
+        FsOperator.lfs().mkdirsIfNotExists(localMavenRepo);
     }
 
     private void uploadClientJar(Workspace workspace, FsOperator fsOperator) {


### PR DESCRIPTION
## Summary

- Fix inverted directory existence check in `EnvInitializer.createMvnLocalRepoDir()` by using `mkdirsIfNotExists`.

Closes #4378

## Test plan

- [x] Code review: logic now matches other workspace directory initialization in `EnvInitializer`
- [ ] Start StreamPark with a fresh `app.home` and verify Maven local repo directory is created

Made with [Cursor](https://cursor.com)