### PR TITLE
[Console] Add missing RBAC checks on cluster and variable endpoints

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/FlinkClusterController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/FlinkClusterController.java
@@ -26,6 +26,7 @@ import org.apache.streampark.console.core.entity.FlinkCluster;
 import org.apache.streampark.console.core.service.FlinkClusterService;
 import org.apache.streampark.console.core.util.ServiceHelper;
 
+import org.apache.shiro.authz.annotation.Logical;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
@@ -48,30 +49,35 @@ public class FlinkClusterController {
     private FlinkClusterService flinkClusterService;
 
     @PostMapping("page")
+    @RequiresPermissions(value = {"cluster:create", "cluster:update"}, logical = Logical.OR)
     public RestResponse findPage(FlinkCluster flinkCluster, RestRequest restRequest) {
         IPage<FlinkCluster> flinkClusters = flinkClusterService.findPage(flinkCluster, restRequest);
         return RestResponse.success(flinkClusters);
     }
 
     @PostMapping("alive")
+    @RequiresPermissions(value = {"cluster:create", "cluster:update", "app:add", "app:update"}, logical = Logical.OR)
     public RestResponse listAvailableCluster() {
         List<FlinkCluster> flinkClusters = flinkClusterService.listAvailableCluster();
         return RestResponse.success(flinkClusters);
     }
 
     @PostMapping("list")
+    @RequiresPermissions(value = {"cluster:create", "cluster:update", "app:add", "app:update"}, logical = Logical.OR)
     public RestResponse list() {
         List<FlinkCluster> flinkClusters = flinkClusterService.list();
         return RestResponse.success(flinkClusters);
     }
 
     @PostMapping("remote_url")
+    @RequiresPermissions(value = {"cluster:create", "cluster:update"}, logical = Logical.OR)
     public RestResponse remoteUrl(Long id) {
         FlinkCluster cluster = flinkClusterService.getById(id);
         return RestResponse.success(cluster.getAddress());
     }
 
     @PostMapping("check")
+    @RequiresPermissions(value = {"cluster:create", "cluster:update"}, logical = Logical.OR)
     public RestResponse check(FlinkCluster cluster) {
         ResponseResult checkResult = flinkClusterService.check(cluster);
         return RestResponse.success(checkResult);
@@ -93,12 +99,14 @@ public class FlinkClusterController {
     }
 
     @PostMapping("get")
+    @RequiresPermissions(value = {"cluster:create", "cluster:update"}, logical = Logical.OR)
     public RestResponse get(Long id) throws InternalException {
         FlinkCluster cluster = flinkClusterService.getById(id);
         return RestResponse.success(cluster);
     }
 
     @PostMapping("start")
+    @RequiresPermissions("cluster:update")
     public RestResponse start(FlinkCluster cluster) {
         flinkClusterService.updateClusterState(cluster.getId(), ClusterState.STARTING);
         flinkClusterService.start(cluster);
@@ -106,6 +114,7 @@ public class FlinkClusterController {
     }
 
     @PostMapping("shutdown")
+    @RequiresPermissions("cluster:update")
     public RestResponse shutdown(FlinkCluster cluster) {
         if (flinkClusterService.allowShutdownCluster(cluster)) {
             flinkClusterService.updateClusterState(cluster.getId(), ClusterState.CANCELLING);
@@ -115,6 +124,7 @@ public class FlinkClusterController {
     }
 
     @PostMapping("delete")
+    @RequiresPermissions("cluster:update")
     public RestResponse delete(FlinkCluster cluster) {
         flinkClusterService.remove(cluster.getId());
         return RestResponse.success();

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/VariableController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/VariableController.java
@@ -23,6 +23,7 @@ import org.apache.streampark.console.core.entity.FlinkApplication;
 import org.apache.streampark.console.core.entity.Variable;
 import org.apache.streampark.console.core.service.VariableService;
 
+import org.apache.shiro.authz.annotation.Logical;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
@@ -75,6 +76,7 @@ public class VariableController {
      * @return
      */
     @PostMapping("list")
+    @RequiresPermissions("variable:view")
     public RestResponse variableList(@RequestParam Long teamId, String keyword) {
         List<Variable> variableList = variableService.listByTeamId(teamId, keyword);
         for (Variable v : variableList) {
@@ -119,6 +121,7 @@ public class VariableController {
     }
 
     @PostMapping("check/code")
+    @RequiresPermissions(value = {"variable:view", "variable:add", "variable:update"}, logical = Logical.OR)
     public RestResponse checkVariableCode(
                                           @RequestParam Long teamId,
                                           @NotBlank(message = "{required}") String variableCode) {


### PR DESCRIPTION
## Summary

- Add `@RequiresPermissions` to unprotected `FlinkClusterController` endpoints (`page`, `list`, `alive`, `get`, `start`, `shutdown`, `delete`, etc.).
- Add `@RequiresPermissions("variable:view")` to `VariableController.list` and guard `check/code` with variable permissions.
- Use `Logical.OR` on cluster `list`/`alive` so app create/edit flows (`app:add`/`app:update`) can still load cluster options.

Closes #4380

## Test plan

- [ ] User without `cluster:update` cannot start/shutdown/delete clusters
- [ ] User with `app:add` can still load cluster list in Flink app form
- [ ] User without `variable:view` cannot list variables by teamId

Made with [Cursor](https://cursor.com)