### PR TITLE
[Console] Deduplicate Flink/Spark HTTP watcher polling per application

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkAppHttpWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkAppHttpWatcher.java
@@ -70,6 +70,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 /** This implementation is currently used for tracing flink job on yarn,standalone,remote mode */
@@ -130,6 +131,9 @@ public class FlinkAppHttpWatcher {
 
     /** tracking task list */
     private static final Map<Long, FlinkApplication> WATCHING_APPS = new ConcurrentHashMap<>(0);
+
+    /** Skip scheduling a new watch while a previous watch for the same app is still running. */
+    private static final Map<Long, AtomicBoolean> WATCH_IN_FLIGHT = new ConcurrentHashMap<>(0);
 
     /**
      *
@@ -215,6 +219,10 @@ public class FlinkAppHttpWatcher {
     }
 
     private void watch(Long id, FlinkApplication application) {
+        AtomicBoolean inFlight = WATCH_IN_FLIGHT.computeIfAbsent(id, ignored -> new AtomicBoolean(false));
+        if (!inFlight.compareAndSet(false, true)) {
+            return;
+        }
         watchExecutor.execute(
             () -> {
                 try {
@@ -229,6 +237,8 @@ public class FlinkAppHttpWatcher {
                     } catch (Exception yarnException) {
                         doStateFailed(application);
                     }
+                } finally {
+                    inFlight.set(false);
                 }
             });
     }
@@ -700,6 +710,7 @@ public class FlinkAppHttpWatcher {
         }
         log.info("[StreamPark][FlinkAppHttpWatcher] stop app,appId:{}", appId);
         WATCHING_APPS.remove(appId);
+        WATCH_IN_FLIGHT.remove(appId);
     }
 
     public static void stopCanceledJob(Long appId) {

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/SparkAppHttpWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/SparkAppHttpWatcher.java
@@ -62,6 +62,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 @Component
@@ -100,6 +101,8 @@ public class SparkAppHttpWatcher {
 
     /** tracking task list */
     private static final Map<Long, SparkApplication> WATCHING_APPS = new ConcurrentHashMap<>(0);
+
+    private static final Map<Long, AtomicBoolean> WATCH_IN_FLIGHT = new ConcurrentHashMap<>(0);
 
     /**
      *
@@ -172,12 +175,21 @@ public class SparkAppHttpWatcher {
     }
 
     private void watch(Long id, SparkApplication application) {
+        AtomicBoolean inFlight = WATCH_IN_FLIGHT.computeIfAbsent(id, ignored -> new AtomicBoolean(false));
+        if (!inFlight.compareAndSet(false, true)) {
+            return;
+        }
         executorService.execute(
             () -> {
                 try {
                     getStateFromYarn(application);
                 } catch (Exception e) {
-                    throw new RuntimeException(e);
+                    log.warn(
+                        "[StreamPark][SparkAppHttpWatcher] Failed to watch application id={}",
+                        application.getId(),
+                        e);
+                } finally {
+                    inFlight.set(false);
                 }
             });
     }
@@ -296,6 +308,7 @@ public class SparkAppHttpWatcher {
     public static void unWatching(Long appId) {
         log.info("[StreamPark][SparkAppHttpWatcher] stop app, appId:{}", appId);
         WATCHING_APPS.remove(appId);
+        WATCH_IN_FLIGHT.remove(appId);
     }
 
     public static void addCanceledApp(Long appId, Long userId) {


### PR DESCRIPTION
## Summary
- Add per-application `WATCH_IN_FLIGHT` single-flight guard in Flink and Spark HTTP watchers
- Skip enqueueing a new watch task when the previous poll is still running
- Remove in-flight markers when an app stops being watched

Fixes #4386

## Test plan
- [ ] Start a Flink app and verify state updates still work
- [ ] Under slow REST responses, confirm watcher does not pile up executor tasks

---
**AI Disclosure**
- Model: Claude Opus 4.6
- Platform/Tool: Cursor
- Human Oversight: partially reviewed
- Prompt Summary: Implement watcher deduplication from dev branch optimization scan


Made with [Cursor](https://cursor.com)