### PR TITLE
[Console] Require authentication for actuator/metrics and warn on H2 default credentials

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/SecurityStartupRunner.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/SecurityStartupRunner.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.console.core.runner;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Order(1)
+@Component
+public class SecurityStartupRunner implements ApplicationRunner {
+
+    @Value("${spring.datasource.url:}")
+    private String datasourceUrl;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (datasourceUrl != null && datasourceUrl.toLowerCase().contains("jdbc:h2:")) {
+            log.warn(
+                "[StreamPark][Security] H2 embedded database is enabled for development. "
+                    + "Change the default admin password (streampark/streampark) before exposing "
+                    + "this instance to a network.");
+        }
+    }
+}

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/authentication/ShiroConfig.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/authentication/ShiroConfig.java
@@ -42,8 +42,11 @@ public class ShiroConfig {
         shiroFilterFactoryBean.setFilters(filters);
 
         LinkedHashMap<String, String> filterChainDefinitionMap = new LinkedHashMap<>();
-        filterChainDefinitionMap.put("/actuator/**", "anon");
-        filterChainDefinitionMap.put("/h2-console/**", "anon");
+        filterChainDefinitionMap.put("/actuator/health", "anon");
+        filterChainDefinitionMap.put("/actuator/health/**", "anon");
+        filterChainDefinitionMap.put("/actuator/info", "anon");
+        filterChainDefinitionMap.put("/actuator/**", "jwt");
+        filterChainDefinitionMap.put("/h2-console/**", "jwt");
 
         filterChainDefinitionMap.put("/doc.html", "anon");
         filterChainDefinitionMap.put("/swagger-ui.html", "anon");
@@ -58,7 +61,7 @@ public class ShiroConfig {
         filterChainDefinitionMap.put("/user/check/**", "anon");
         filterChainDefinitionMap.put("/user/initTeam", "anon");
         filterChainDefinitionMap.put("/websocket/**", "anon");
-        filterChainDefinitionMap.put("/metrics/**", "anon");
+        filterChainDefinitionMap.put("/metrics/**", "jwt");
 
         filterChainDefinitionMap.put("/index.html", "anon");
         filterChainDefinitionMap.put("/assets/**", "anon");


### PR DESCRIPTION
## Summary
- Require JWT for `/actuator/**` (except health/info), `/h2-console/**`, and `/metrics/**`
- Keep `/actuator/health` and `/actuator/info` anonymous for health probes
- Add `SecurityStartupRunner` to warn when H2 embedded DB is used with default credentials

Fixes #4388

## Test plan
- [ ] Unauthenticated `/actuator/health` returns 200
- [ ] Unauthenticated `/actuator/env` returns 401
- [ ] Startup log shows H2 security warning when using embedded database

---
**AI Disclosure**
- Model: Claude Opus 4.6
- Platform/Tool: Cursor
- Human Oversight: partially reviewed
- Prompt Summary: Harden default security from dev branch optimization scan


Made with [Cursor](https://cursor.com)