### PR TITLE
[Console] Add missing RBAC on SettingController get and checkHadoop

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/SettingController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/SettingController.java
@@ -56,6 +56,7 @@ public class SettingController {
     }
 
     @PostMapping("get")
+    @RequiresPermissions("setting:view")
     public RestResponse get(String key) {
         Setting setting = settingService.get(key);
         return RestResponse.success(setting);
@@ -111,6 +112,7 @@ public class SettingController {
     }
 
     @PostMapping("check/hadoop")
+    @RequiresPermissions("setting:view")
     public RestResponse checkHadoop() throws IOException {
         HadoopUtils.hdfs().getStatus();
         return RestResponse.success(true);


### PR DESCRIPTION
## Summary
- Add `@RequiresPermissions("setting:view")` to `SettingController.get`
- Add `@RequiresPermissions("setting:view")` to `SettingController.checkHadoop`

Fixes #4392

## Test plan
- [ ] User without `setting:view` cannot call `/setting/get`
- [ ] User without `setting:view` cannot call `/setting/check/hadoop`

---
**AI Disclosure**
- Model: Claude Opus 4.6
- Platform/Tool: Cursor
- Human Oversight: partially reviewed
- Prompt Summary: Close SettingController RBAC gap from dev branch scan


Made with [Cursor](https://cursor.com)