### PR TITLE
[Console] Reduce watcher poll frequency and deduplicate in-flight polls

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkAppHttpWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkAppHttpWatcher.java
@@ -70,6 +70,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 /** This implementation is currently used for tracing flink job on yarn,standalone,remote mode */
@@ -130,6 +131,8 @@ public class FlinkAppHttpWatcher {
 
     /** tracking task list */
     private static final Map<Long, FlinkApplication> WATCHING_APPS = new ConcurrentHashMap<>(0);
+
+    private static final Map<Long, AtomicBoolean> WATCH_IN_FLIGHT = new ConcurrentHashMap<>(0);
 
     /**
      *
@@ -202,19 +205,32 @@ public class FlinkAppHttpWatcher {
      *
      * <p><strong>2) Normal information obtain, once every 5 seconds</strong>
      */
-    @Scheduled(fixedDelay = 1, initialDelay = 5, timeUnit = TimeUnit.SECONDS)
-    public void start() {
-        Long timeMillis = System.currentTimeMillis();
-        if (lastWatchTime == null
-            || !OPTIONING.isEmpty()
-            || timeMillis - lastOptionTime <= OPTION_INTERVAL.toMillis()
-            || timeMillis - lastWatchTime >= WATCHING_INTERVAL.toMillis()) {
-            lastWatchTime = timeMillis;
-            WATCHING_APPS.forEach(this::watch);
+    @Scheduled(fixedDelay = 5, initialDelay = 5, timeUnit = TimeUnit.SECONDS)
+    public void scheduledWatch() {
+        if (WATCHING_APPS.isEmpty()) {
+            return;
         }
+        lastWatchTime = System.currentTimeMillis();
+        WATCHING_APPS.forEach(this::watch);
+    }
+
+    @Scheduled(fixedDelay = 1, initialDelay = 5, timeUnit = TimeUnit.SECONDS)
+    public void fastWatchDuringOption() {
+        if (WATCHING_APPS.isEmpty()) {
+            return;
+        }
+        long timeMillis = System.currentTimeMillis();
+        if (OPTIONING.isEmpty() && timeMillis - lastOptionTime > OPTION_INTERVAL.toMillis()) {
+            return;
+        }
+        WATCHING_APPS.forEach(this::watch);
     }
 
     private void watch(Long id, FlinkApplication application) {
+        AtomicBoolean inFlight = WATCH_IN_FLIGHT.computeIfAbsent(id, ignored -> new AtomicBoolean(false));
+        if (!inFlight.compareAndSet(false, true)) {
+            return;
+        }
         watchExecutor.execute(
             () -> {
                 try {
@@ -229,6 +245,8 @@ public class FlinkAppHttpWatcher {
                     } catch (Exception yarnException) {
                         doStateFailed(application);
                     }
+                } finally {
+                    inFlight.set(false);
                 }
             });
     }
@@ -700,6 +718,7 @@ public class FlinkAppHttpWatcher {
         }
         log.info("[StreamPark][FlinkAppHttpWatcher] stop app,appId:{}", appId);
         WATCHING_APPS.remove(appId);
+        WATCH_IN_FLIGHT.remove(appId);
     }
 
     public static void stopCanceledJob(Long appId) {

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkClusterWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkClusterWatcher.java
@@ -103,7 +103,7 @@ public class FlinkClusterWatcher {
         flinkClusters.forEach(cluster -> WATCHER_CLUSTERS.put(cluster.getId(), cluster));
     }
 
-    @Scheduled(fixedDelay = 1, initialDelay = 5, timeUnit = TimeUnit.SECONDS)
+    @Scheduled(fixedDelay = 30, initialDelay = 5, timeUnit = TimeUnit.SECONDS)
     private void start() {
         Long timeMillis = System.currentTimeMillis();
         if (immediateWatch || timeMillis - lastWatchTime >= WATCHER_INTERVAL.toMillis()) {

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/SparkAppHttpWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/SparkAppHttpWatcher.java
@@ -62,6 +62,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 @Component
@@ -100,6 +101,8 @@ public class SparkAppHttpWatcher {
 
     /** tracking task list */
     private static final Map<Long, SparkApplication> WATCHING_APPS = new ConcurrentHashMap<>(0);
+
+    private static final Map<Long, AtomicBoolean> WATCH_IN_FLIGHT = new ConcurrentHashMap<>(0);
 
     /**
      *
@@ -153,16 +156,25 @@ public class SparkAppHttpWatcher {
      *
      * <p><strong>2) Normal information obtain, once every 5 seconds</strong>
      */
-    @Scheduled(fixedDelay = 1, initialDelay = 5, timeUnit = TimeUnit.SECONDS)
-    public void start() {
-        Long timeMillis = System.currentTimeMillis();
-        if (lastWatchTime == null
-            || !OPTIONING.isEmpty()
-            || timeMillis - lastOptionTime <= OPTION_INTERVAL.toMillis()
-            || timeMillis - lastWatchTime >= WATCHING_INTERVAL.toMillis()) {
-            lastWatchTime = timeMillis;
-            WATCHING_APPS.forEach(this::watch);
+    @Scheduled(fixedDelay = 5, initialDelay = 5, timeUnit = TimeUnit.SECONDS)
+    public void scheduledWatch() {
+        if (WATCHING_APPS.isEmpty()) {
+            return;
         }
+        lastWatchTime = System.currentTimeMillis();
+        WATCHING_APPS.forEach(this::watch);
+    }
+
+    @Scheduled(fixedDelay = 1, initialDelay = 5, timeUnit = TimeUnit.SECONDS)
+    public void fastWatchDuringOption() {
+        if (WATCHING_APPS.isEmpty()) {
+            return;
+        }
+        long timeMillis = System.currentTimeMillis();
+        if (OPTIONING.isEmpty() && timeMillis - lastOptionTime > OPTION_INTERVAL.toMillis()) {
+            return;
+        }
+        WATCHING_APPS.forEach(this::watch);
     }
 
     @VisibleForTesting
@@ -172,12 +184,21 @@ public class SparkAppHttpWatcher {
     }
 
     private void watch(Long id, SparkApplication application) {
+        AtomicBoolean inFlight = WATCH_IN_FLIGHT.computeIfAbsent(id, ignored -> new AtomicBoolean(false));
+        if (!inFlight.compareAndSet(false, true)) {
+            return;
+        }
         executorService.execute(
             () -> {
                 try {
                     getStateFromYarn(application);
                 } catch (Exception e) {
-                    throw new RuntimeException(e);
+                    log.warn(
+                        "[StreamPark][SparkAppHttpWatcher] Failed to watch application id={}",
+                        application.getId(),
+                        e);
+                } finally {
+                    inFlight.set(false);
                 }
             });
     }
@@ -296,6 +317,7 @@ public class SparkAppHttpWatcher {
     public static void unWatching(Long appId) {
         log.info("[StreamPark][SparkAppHttpWatcher] stop app, appId:{}", appId);
         WATCHING_APPS.remove(appId);
+        WATCH_IN_FLIGHT.remove(appId);
     }
 
     public static void addCanceledApp(Long appId, Long userId) {


### PR DESCRIPTION
## Summary
- Split Flink/Spark app watchers into 5s steady-state and 1s fast polling during operations
- Add per-app single-flight guards to avoid overlapping REST polls
- Align `FlinkClusterWatcher` schedule with its 30-second interval

Fixes #4396

## Test plan
- [ ] Start/stop Flink app — state updates within ~10s
- [ ] Running apps still refresh about every 5s
- [ ] Cluster health monitoring continues to work

---
**AI Disclosure**
- Model: Claude Opus 4.6
- Platform/Tool: Cursor
- Human Oversight: partially reviewed
- Prompt Summary: Watcher poll interval optimization from dev branch scan


Made with [Cursor](https://cursor.com)