### PR TITLE
[K8s] Add TTL and size limit to Flink K8s MetricCache

### DIFF
--- a/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/FlinkK8sWatchController.scala
+++ b/streampark-flink/streampark-flink-kubernetes/src/main/scala/org/apache/streampark/flink/kubernetes/FlinkK8sWatchController.scala
@@ -228,7 +228,11 @@ object K8sDeploymentEventCache {
 class MetricCache {
 
   private[this] lazy val cache: Cache[ClusterKey, FlinkMetricCV] =
-    Caffeine.newBuilder().build()
+    Caffeine
+      .newBuilder()
+      .expireAfterWrite(6, TimeUnit.HOURS)
+      .maximumSize(10_000)
+      .build()
 
   def put(k: ClusterKey, v: FlinkMetricCV): Unit = cache.put(k, v)
 


### PR DESCRIPTION
## Summary
- Add 6-hour `expireAfterWrite` TTL to `MetricCache`
- Cap cache at 10,000 entries via `maximumSize`

Fixes #4402

## Test plan
- [ ] K8s Flink job metrics still update while running
- [ ] Stale metrics are eventually evicted after TTL

---
**AI Disclosure**
- Model: Claude Opus 4.6
- Platform/Tool: Cursor
- Human Oversight: partially reviewed
- Prompt Summary: Add MetricCache TTL from dev branch scan


Made with [Cursor](https://cursor.com)