### PR TITLE
[Common] Fix ClassLoaderUtils dynamic classpath on JDK 9+

### DIFF
--- a/streampark-common/pom.xml
+++ b/streampark-common/pom.xml
@@ -197,4 +197,24 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk9-plus-test-opens</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/streampark-common/src/main/scala/org/apache/streampark/common/util/ClassLoaderUtils.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/util/ClassLoaderUtils.scala
@@ -146,9 +146,20 @@ object ClassLoaderUtils extends Logger {
         addURL.setAccessible(true)
         addURL.invoke(c, file.toURI.toURL)
       case _ =>
-        val field = classLoader.getClass.getDeclaredField("ucp")
-        field.setAccessible(true)
-        val ucp = field.get(classLoader)
+        var clazz: Class[_] = classLoader.getClass
+        var ucpField: java.lang.reflect.Field = null
+        while (clazz != null && ucpField == null) {
+          try {
+            ucpField = clazz.getDeclaredField("ucp")
+          } catch {
+            case _: NoSuchFieldException => clazz = clazz.getSuperclass
+          }
+        }
+        require(
+          ucpField != null,
+          "[StreamPark] ClassLoaderUtils.addURL: cannot locate ucp field on classloader chain")
+        ucpField.setAccessible(true)
+        val ucp = ucpField.get(classLoader)
         val addURL =
           ucp.getClass.getDeclaredMethod("addURL", Array(classOf[URL]): _*)
         addURL.setAccessible(true)

--- a/streampark-common/src/test/scala/org/apache/streampark/common/util/ClassLoaderUtilsTest.scala
+++ b/streampark-common/src/test/scala/org/apache/streampark/common/util/ClassLoaderUtilsTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.common.util
+
+import org.junit.jupiter.api.{Assertions, Test}
+
+import java.io.{File, FileOutputStream}
+import java.util.jar.{JarEntry, JarOutputStream}
+
+class ClassLoaderUtilsTest {
+
+  @Test def loadJarShouldAppendJarToSystemClassloader(): Unit = {
+    val jarFile = File.createTempFile("streampark-classloader-test", ".jar")
+    jarFile.deleteOnExit()
+    try {
+      val jarOut = new JarOutputStream(new FileOutputStream(jarFile))
+      try {
+        jarOut.putNextEntry(new JarEntry("META-INF/MANIFEST.MF"))
+        jarOut.write("Manifest-Version: 1.0\n".getBytes("UTF-8"))
+        jarOut.closeEntry()
+      } finally {
+        jarOut.close()
+      }
+      ClassLoaderUtils.loadJar(jarFile.getAbsolutePath)
+    } finally {
+      jarFile.delete()
+    }
+  }
+
+  @Test def loadResourceShouldAppendDirectoryToSystemClassloader(): Unit = {
+    val dir = FileUtils.createTempDir()
+    try {
+      ClassLoaderUtils.loadResource(dir.getAbsolutePath)
+    } finally {
+      Assertions.assertTrue(dir.delete())
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Walk the class hierarchy to locate the `ucp` field on JDK 11+ application classloaders
- Add JUnit tests for dynamic JAR/directory classpath loading
- Enable `--add-opens` in surefire for JDK 9+ test runs on `streampark-common`

## Test plan

- [x] `./mvnw test -pl streampark-common -Dtest=org.apache.streampark.common.util.ClassLoaderUtilsTest -Dspotless.check.skip=true`

## Merge order

**1/3** — merge this PR first. Part of JDK 11 migration (#4409, #4410).

---
**AI Disclosure**
- Model: Claude (Cursor Agent)
- Platform/Tool: Cursor
- Human Oversight: partially reviewed
- Prompt Summary: Split JDK 11 migration into reviewable PRs; Common ClassLoaderUtils fix

Made with [Cursor](https://cursor.com)