### PR TITLE
[Build] Raise StreamPark compile and CI baseline to JDK 11

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8 , 11 ]
+        java: [ 11 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,6 +28,7 @@ on:
       - 'deploy/**'
       - 'script/**'
       - 'streampark-console/streampark-console-webapp/**'
+      - 'streampark-console/streampark-console-webapp-v2/**'
   pull_request:
 
 
@@ -43,7 +44,7 @@ jobs:
       not-ignore: ${{ steps.filter.outputs.not-ignore }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Java and Scala
         uses: olafurpg/setup-scala@v13
         with:
-          java-version: adopt@1.8
+          java-version: adopt@11
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
       not-ignore: ${{ steps.filter.outputs.not-ignore }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,10 +77,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'adopt'
       - name: Cache local Maven repository
         uses: actions/cache@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
       not-ignore: ${{ steps.filter.outputs.not-ignore }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |
@@ -232,5 +232,5 @@ jobs:
           fi
           if [[ ${{ needs.e2e.result }} != 'success' ]]; then
             echo "E2E Failed!"
-            exit 0
+            exit 1
           fi

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8 , 11 ]
+        java: [ 11 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,6 +28,7 @@ on:
       - 'deploy/**'
       - 'script/**'
       - 'streampark-console/streampark-console-webapp/**'
+      - 'streampark-console/streampark-console-webapp-v2/**'
   pull_request:
 
 
@@ -43,7 +44,7 @@ jobs:
       not-ignore: ${{ steps.filter.outputs.not-ignore }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |

--- a/build.sh
+++ b/build.sh
@@ -163,7 +163,7 @@ print_logo() {
   printf '      %s  ___/ / /_/ /  /  __/ /_/ / / / / / / /_/ / /_/ / /  / ,<        %s\n'          $PRIMARY $RESET
   printf '      %s /____/\__/_/   \___/\__,_/_/ /_/ /_/ ____/\__,_/_/  /_/|_|       %s\n'          $PRIMARY $RESET
   printf '      %s                                   /_/                            %s\n\n'        $PRIMARY $RESET
-  printf '      %s   Version:  3.0.0-preview %s\n'                                                $BLUE   $RESET
+  printf '      %s   Version:  3.0.0-SNAPSHOT %s\n'                                                $BLUE   $RESET
   printf '      %s   WebSite:  https://streampark.apache.org%s\n'                                  $BLUE   $RESET
   printf '      %s   GitHub :  http://github.com/apache/streampark%s\n\n'                          $BLUE   $RESET
   printf '      %s   ──────── Apache StreamPark, Make stream processing easier ô~ô!%s\n\n'         $PRIMARY  $RESET

--- a/build.sh
+++ b/build.sh
@@ -163,7 +163,7 @@ print_logo() {
   printf '      %s  ___/ / /_/ /  /  __/ /_/ / / / / / / /_/ / /_/ / /  / ,<        %s\n'          $PRIMARY $RESET
   printf '      %s /____/\__/_/   \___/\__,_/_/ /_/ /_/ ____/\__,_/_/  /_/|_|       %s\n'          $PRIMARY $RESET
   printf '      %s                                   /_/                            %s\n\n'        $PRIMARY $RESET
-  printf '      %s   Version:  2.2.0-SNAPSHOT %s\n'                                                $BLUE   $RESET
+  printf '      %s   Version:  3.0.0-preview %s\n'                                                $BLUE   $RESET
   printf '      %s   WebSite:  https://streampark.apache.org%s\n'                                  $BLUE   $RESET
   printf '      %s   GitHub :  http://github.com/apache/streampark%s\n\n'                          $BLUE   $RESET
   printf '      %s   ──────── Apache StreamPark, Make stream processing easier ô~ô!%s\n\n'         $PRIMARY  $RESET

--- a/dist-material/release-docs/LICENSE
+++ b/dist-material/release-docs/LICENSE
@@ -667,6 +667,7 @@ The following components are provided under the CDDL 1.1 License. See project li
 The text of each license is also included in licenses/LICENSE-[project].txt.
 
     https://mvnrepository.com/artifact/com.sun.jersey.contribs/jersey-guice/1.9 CDDL 1.1
+    https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api/1.3.2 CDDL-1.1
     https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api/2.3.1 CDDL-1.1
 
 

--- a/dist-material/release-docs/licenses/license-javax.annotation-javax.annotation-api.txt
+++ b/dist-material/release-docs/licenses/license-javax.annotation-javax.annotation-api.txt
@@ -1,0 +1,274 @@
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)Version 1.1
+
+1. Definitions.
+
+     1.1. "Contributor" means each individual or entity that creates or contributes to the creation of Modifications.
+
+     1.2. "Contributor Version" means the combination of the Original Software, prior Modifications used by a Contributor (if any), and the Modifications made by that particular Contributor.
+
+     1.3. "Covered Software" means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.
+
+     1.4. "Executable" means the Covered Software in any form other than Source Code.
+
+     1.5. "Initial Developer" means the individual or entity that first makes Original Software available under this License.
+
+     1.6. "Larger Work" means a work which combines Covered Software or portions thereof with code not governed by the terms of this License.
+
+     1.7. "License" means this document.
+
+     1.8. "Licensable" means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently acquired, any and all of the rights conveyed herein.
+
+     1.9. "Modifications" means the Source Code and Executable form of any of the following:
+
+     A. Any file that results from an addition to, deletion from or modification of the contents of a file containing Original Software or previous Modifications;
+
+     B. Any new file that contains any part of the Original Software or previous Modification; or
+
+     C. Any new file that is contributed or otherwise made available under the terms of this License.
+
+     1.10. "Original Software" means the Source Code and Executable form of computer software code that is originally released under this License.
+
+     1.11. "Patent Claims" means any patent claim(s), now owned or hereafter acquired, including without limitation, method, process, and apparatus claims, in any patent Licensable by grantor.
+
+     1.12. "Source Code" means (a) the common form of computer software code in which modifications are made and (b) associated documentation included in or with such code.
+
+     1.13. "You" (or "Your") means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, "You" includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+2. License Grants.
+
+     2.1. The Initial Developer Grant.
+
+     Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, the Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+     (a) under intellectual property rights (other than patent or trademark) Licensable by Initial Developer, to use, reproduce, modify, display, perform, sublicense and distribute the Original Software (or portions thereof), with or without Modifications, and/or as part of a Larger Work; and
+
+     (b) under Patent Claims infringed by the making, using or selling of Original Software, to make, have made, use, practice, sell, and offer for sale, and/or otherwise dispose of the Original Software (or portions thereof).
+
+     (c) The licenses granted in Sections 2.1(a) and (b) are effective on the date Initial Developer first distributes or otherwise makes the Original Software available to a third party under the terms of this License.
+
+     (d) Notwithstanding Section 2.1(b) above, no patent license is granted: (1) for code that You delete from the Original Software, or (2) for infringements caused by: (i) the modification of the Original Software, or (ii) the combination of the Original Software with other software or devices.
+
+     2.2. Contributor Grant.
+
+     Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+     (a) under intellectual property rights (other than patent or trademark) Licensable by Contributor to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof), either on an unmodified basis, with other Modifications, as Covered Software and/or as part of a Larger Work; and
+
+     (b) under Patent Claims infringed by the making, using, or selling of Modifications made by that Contributor either alone and/or in combination with its Contributor Version (or portions of such combination), to make, use, sell, offer for sale, have made, and/or otherwise dispose of: (1) Modifications made by that Contributor (or portions thereof); and (2) the combination of Modifications made by that Contributor with its Contributor Version (or portions of such combination).
+
+     (c) The licenses granted in Sections 2.2(a) and 2.2(b) are effective on the date Contributor first distributes or otherwise makes the Modifications available to a third party.
+
+     (d) Notwithstanding Section 2.2(b) above, no patent license is granted: (1) for any code that Contributor has deleted from the Contributor Version; (2) for infringements caused by: (i) third party modifications of Contributor Version, or (ii) the combination of Modifications made by that Contributor with other software (except as part of the Contributor Version) or other devices; or (3) under Patent Claims infringed by Covered Software in the absence of Modifications made by that Contributor.
+
+3. Distribution Obligations.
+
+     3.1. Availability of Source Code.
+
+     Any Covered Software that You distribute or otherwise make available in Executable form must also be made available in Source Code form and that Source Code form must be distributed only under the terms of this License. You must include a copy of this License with every copy of the Source Code form of the Covered Software You distribute or otherwise make available. You must inform recipients of any such Covered Software in Executable form as to how they can obtain such Covered Software in Source Code form in a reasonable manner on or through a medium customarily used for software exchange.
+
+     3.2. Modifications.
+
+     The Modifications that You create or to which You contribute are governed by the terms of this License. You represent that You believe Your Modifications are Your original creation(s) and/or You have sufficient rights to grant the rights conveyed by this License.
+
+     3.3. Required Notices.
+
+     You must include a notice in each of Your Modifications that identifies You as the Contributor of the Modification. You may not remove or alter any copyright, patent or trademark notices contained within the Covered Software, or any notices of licensing or any descriptive text giving attribution to any Contributor or the Initial Developer.
+
+     3.4. Application of Additional Terms.
+
+     You may not offer or impose any terms on any Covered Software in Source Code form that alters or restricts the applicable version of this License or the recipients' rights hereunder. You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, you may do so only on Your own behalf, and not on behalf of the Initial Developer or any Contributor. You must make it absolutely clear that any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of warranty, support, indemnity or liability terms You offer.
+
+     3.5. Distribution of Executable Versions.
+
+     You may distribute the Executable form of the Covered Software under the terms of this License or under the terms of a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable form does not attempt to limit or alter the recipient's rights in the Source Code form from the rights set forth in this License. If You distribute the Covered Software in Executable form under a different license, You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.
+
+     3.6. Larger Works.
+
+     You may create a Larger Work by combining Covered Software with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Software.
+
+4. Versions of the License.
+
+     4.1. New Versions.
+
+     Oracle is the initial license steward and may publish revised and/or new versions of this License from time to time. Each version will be given a distinguishing version number. Except as provided in Section 4.3, no one other than the license steward has the right to modify this License.
+
+     4.2. Effect of New Versions.
+
+     You may always continue to use, distribute or otherwise make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. If the Initial Developer includes a notice in the Original Software prohibiting it from being distributed or otherwise made available under any subsequent version of the License, You must distribute and make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. Otherwise, You may also choose to use, distribute or otherwise make the Covered Software available under the terms of any subsequent version of the License published by the license steward.
+
+     4.3. Modified Versions.
+
+     When You are an Initial Developer and You want to create a new license for Your Original Software, You may create and use a modified version of this License if You: (a) rename the license and remove any references to the name of the license steward (except to note that the license differs from this License); and (b) otherwise make it clear that the license contains terms which differ from this License.
+
+5. DISCLAIMER OF WARRANTY.
+
+     COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+6. TERMINATION.
+
+     6.1. This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.
+
+     6.2. If You assert a patent infringement claim (excluding declaratory judgment actions) against Initial Developer or a Contributor (the Initial Developer or Contributor against whom You assert such claim is referred to as "Participant") alleging that the Participant Software (meaning the Contributor Version where the Participant is a Contributor or the Original Software where the Participant is the Initial Developer) directly or indirectly infringes any patent, then any and all rights granted directly or indirectly to You by such Participant, the Initial Developer (if the Initial Developer is not the Participant) and all Contributors under Sections 2.1 and/or 2.2 of this License shall, upon 60 days notice from Participant terminate prospectively and automatically at the expiration of such 60 day notice period, unless if within such 60 day period You withdraw Your claim with respect to the Participant Software against such Participant either unilaterally or pursuant to a written agreement with Participant.
+
+     6.3. If You assert a patent infringement claim against Participant alleging that the Participant Software directly or indirectly infringes any patent where such claim is resolved (such as by license or settlement) prior to the initiation of patent infringement litigation, then the reasonable value of the licenses granted by such Participant under Sections 2.1 or 2.2 shall be taken into account in determining the amount or value of any payment or license.
+
+     6.4. In the event of termination under Sections 6.1 or 6.2 above, all end user licenses that have been validly granted by You or any distributor hereunder prior to termination (excluding licenses granted to You by any distributor) shall survive termination.
+
+7. LIMITATION OF LIABILITY.
+
+     UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+8. U.S. GOVERNMENT END USERS.
+
+     The Covered Software is a "commercial item," as that term is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial computer software" (as that term is defined at 48 C.F.R. ? 252.227-7014(a)(1)) and "commercial computer software documentation" as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all U.S. Government End Users acquire Covered Software with only those rights set forth herein. This U.S. Government Rights clause is in lieu of, and supersedes, any other FAR, DFAR, or other clause or provision that addresses Government rights in computer software under this License.
+
+9. MISCELLANEOUS.
+
+     This License represents the complete agreement concerning subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. This License shall be governed by the law of the jurisdiction specified in a notice contained within the Original Software (except to the extent applicable law, if any, provides otherwise), excluding such jurisdiction's conflict-of-law provisions. Any litigation relating to this License shall be subject to the jurisdiction of the courts located in the jurisdiction and venue specified in a notice contained within the Original Software, with the losing party responsible for costs, including, without limitation, court costs and reasonable attorneys' fees and expenses. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not apply to this License. You agree that You alone are responsible for compliance with the United States export administration regulations (and the export control laws and regulation of any other countries) when You use, distribute or otherwise make available any Covered Software.
+
+10. RESPONSIBILITY FOR CLAIMS.
+
+     As between Initial Developer and the Contributors, each party is responsible for claims and damages arising, directly or indirectly, out of its utilization of rights under this License and You agree to work with Initial Developer and Contributors to distribute such responsibility on an equitable basis. Nothing herein is intended or shall be deemed to constitute any admission of liability.
+
+----------
+NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)
+The code released under the CDDL shall be governed by the laws of the State of California (excluding conflict-of-law provisions). Any litigation relating to this License shall be subject to the jurisdiction of the Federal Courts of the Northern District of California and the state courts of the State of California, with venue lying in Santa Clara County, California.
+
+
+
+
+The GNU General Public License (GPL) Version 2, June 1991
+
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc. 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users. This General Public License applies to most of the Free Software Foundation's software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is covered by the GNU Library General Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that everyone understands that there is no warranty for this free software. If the software is modified by someone else and passed on, we want its recipients to know that what they have is not the original, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors of a free program will individually obtain patent licenses, in effect making the program proprietary. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice placed by the copyright holder saying it may be distributed under the terms of this General Public License. The "Program", below, refers to any such program or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that is to say, a work containing the Program or a portion of it, either verbatim or with modifications and/or translated into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+   a) You must cause the modified files to carry prominent notices stating that you changed the files and the date of any change.
+
+   b) You must cause any work that you distribute or publish, that in whole or in part contains or is derived from the Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this License.
+
+   c) If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you also do one of the following:
+
+   a) Accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+   b) Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more than your cost of physically performing source distribution, a complete machine-readable copy of the corresponding source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+   c) Accompany it with the information you received as to the offer to distribute corresponding source code. (This alternative is allowed only for noncommercial distribution and only if you received the program in object code or executable form with such an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the executable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place counts as distribution of the source code, even though third parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a license from the original licensor to copy, distribute or modify the Program subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system, which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+   One line to give the program's name and a brief idea of what it does.
+
+   Copyright (C)
+
+   This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it starts in an interactive mode:
+
+   Gnomovision version 69, Copyright (C) year name of author
+   Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'. This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than `show w' and `show c'; they could even be mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the program, if necessary. Here is a sample; alter the names:
+
+   Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+   signature of Ty Coon, 1 April 1989
+   Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Library General Public License instead of this License.
+
+
+"CLASSPATH" EXCEPTION TO THE GPL VERSION 2
+
+Certain source files distributed by Oracle are subject to the following clarification and special exception to the GPL Version 2, but only where Oracle has expressly included in the particular source file's header the words "Oracle designates this particular file as subject to the "Classpath" exception as provided by Oracle in the License file that accompanied this code."
+
+Linking this library statically or dynamically with other modules is making a combined work based on this library.  Thus, the terms and conditions of the GNU General Public License Version 2 cover the whole combination.
+
+As a special exception, the copyright holders of this library give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module.  An independent module is a module which is not derived from or based on this library.  If you modify this library, you may extend this exception to your version of the library, but you are not obligated to do so.  If you do not wish to do so, delete this exception statement from your version.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,10 +19,10 @@ FROM ubuntu:22.04
 USER root
 
 ENV LANG=C.UTF-8 \
-    JAVA_HOME=/usr/lib/jvm/jdk8
+    JAVA_HOME=/usr/lib/jvm/jdk11
 
 # Build arguments for version management
-ARG JAVA_MAJOR_VERSION=8
+ARG JAVA_MAJOR_VERSION=11
 ARG TINI_VERSION=v0.19.0
 
 # Base system setup

--- a/mvnw
+++ b/mvnw
@@ -201,7 +201,7 @@ if [ ! -e "$javaSource" ]; then
 fi
 
 log " - Compiling $javaSource starting ..."
-"$JAVA_HOME/bin/javac" "$javaSource"
+"$JAVA_HOME/bin/javac" --release 11 "$javaSource"
 
 if [ -r "$wrapperJarPath" ]; then
   log "Found $wrapperJarPath"

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     </issueManagement>
 
     <properties>
-        <project.build.jdk>1.8</project.build.jdk>
+        <project.build.jdk>11</project.build.jdk>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -697,8 +697,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <source>${project.build.jdk}</source>
-                        <target>${project.build.jdk}</target>
+                        <release>${project.build.jdk}</release>
                         <encoding>UTF-8</encoding>
                         <!-- The semantics of this option are reversed, see MCOMPILER-209. -->
                         <useIncrementalCompilation>false</useIncrementalCompilation>
@@ -715,7 +714,7 @@
                     <artifactId>scala-maven-plugin</artifactId>
                     <version>${scala-maven-plugin.version}</version>
                     <configuration>
-                        <addScalacArgs>-target:jvm-${project.build.jdk}</addScalacArgs>
+                        <addScalacArgs>-target:${project.build.jdk}</addScalacArgs>
                         <target>${project.build.jdk}</target>
                         <source>${project.build.jdk}</source>
                         <args>
@@ -1008,6 +1007,24 @@
                 <owasp.skip>true</owasp.skip>
                 <spotless.skip>true</spotless.skip>
             </properties>
+        </profile>
+
+        <profile>
+            <id>jdk9-plus-test-opens</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.apache.streampark</groupId>
     <artifactId>streampark</artifactId>
-    <version>3.0.0-preview</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>StreamPark Project Parent POM</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.apache.streampark</groupId>
     <artifactId>streampark</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-preview</version>
     <packaging>pom</packaging>
     <name>StreamPark Project Parent POM</name>
 

--- a/streampark-common/pom.xml
+++ b/streampark-common/pom.xml
@@ -197,4 +197,24 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk9-plus-test-opens</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/streampark-common/pom.xml
+++ b/streampark-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-common_${scala.binary.version}</artifactId>

--- a/streampark-common/src/main/scala/org/apache/streampark/common/util/ClassLoaderUtils.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/util/ClassLoaderUtils.scala
@@ -146,9 +146,20 @@ object ClassLoaderUtils extends Logger {
         addURL.setAccessible(true)
         addURL.invoke(c, file.toURI.toURL)
       case _ =>
-        val field = classLoader.getClass.getDeclaredField("ucp")
-        field.setAccessible(true)
-        val ucp = field.get(classLoader)
+        var clazz: Class[_] = classLoader.getClass
+        var ucpField: java.lang.reflect.Field = null
+        while (clazz != null && ucpField == null) {
+          try {
+            ucpField = clazz.getDeclaredField("ucp")
+          } catch {
+            case _: NoSuchFieldException => clazz = clazz.getSuperclass
+          }
+        }
+        require(
+          ucpField != null,
+          "[StreamPark] ClassLoaderUtils.addURL: cannot locate ucp field on classloader chain")
+        ucpField.setAccessible(true)
+        val ucp = ucpField.get(classLoader)
         val addURL =
           ucp.getClass.getDeclaredMethod("addURL", Array(classOf[URL]): _*)
         addURL.setAccessible(true)

--- a/streampark-common/src/main/scala/org/apache/streampark/common/util/Utils.scala
+++ b/streampark-common/src/main/scala/org/apache/streampark/common/util/Utils.scala
@@ -163,7 +163,7 @@ object Utils extends Logger {
     println("      ___/ / /_/ /  /  __/ /_/ / / / / / / /_/ / /_/ / /  / ,<        ")
     println("     /____/\\__/_/   \\___/\\__,_/_/ /_/ /_/ ____/\\__,_/_/  /_/|_|   ")
     println("                                       /_/                        \n\n")
-    println("    Version:  2.2.0-SNAPSHOT                                          ")
+    println("    Version:  3.0.0-SNAPSHOT                                          ")
     println("    WebSite:  https://streampark.apache.org                           ")
     println("    GitHub :  https://github.com/apache/streampark                    ")
     println(s"    Info   :  $info                                 ")

--- a/streampark-common/src/test/scala/org/apache/streampark/common/util/ClassLoaderUtilsTest.scala
+++ b/streampark-common/src/test/scala/org/apache/streampark/common/util/ClassLoaderUtilsTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.common.util
+
+import org.junit.jupiter.api.{Assertions, Test}
+
+import java.io.{File, FileOutputStream}
+import java.util.jar.{JarEntry, JarOutputStream}
+
+class ClassLoaderUtilsTest {
+
+  @Test def loadJarShouldAppendJarToSystemClassloader(): Unit = {
+    val jarFile = File.createTempFile("streampark-classloader-test", ".jar")
+    jarFile.deleteOnExit()
+    try {
+      val jarOut = new JarOutputStream(new FileOutputStream(jarFile))
+      try {
+        jarOut.putNextEntry(new JarEntry("META-INF/MANIFEST.MF"))
+        jarOut.write("Manifest-Version: 1.0\n".getBytes("UTF-8"))
+        jarOut.closeEntry()
+      } finally {
+        jarOut.close()
+      }
+      ClassLoaderUtils.loadJar(jarFile.getAbsolutePath)
+    } finally {
+      jarFile.delete()
+    }
+  }
+
+  @Test def loadResourceShouldAppendDirectoryToSystemClassloader(): Unit = {
+    val dir = FileUtils.createTempDir()
+    try {
+      ClassLoaderUtils.loadResource(dir.getAbsolutePath)
+    } finally {
+      Assertions.assertTrue(dir.delete())
+    }
+  }
+}

--- a/streampark-console/pom.xml
+++ b/streampark-console/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-console</artifactId>

--- a/streampark-console/streampark-console-service/pom.xml
+++ b/streampark-console/streampark-console-service/pom.xml
@@ -37,8 +37,6 @@
         <mybatis-plus.version>3.5.3.1</mybatis-plus.version>
         <streampark.flink.shims.version>1.14</streampark.flink.shims.version>
         <frontend.project.name>streampark-console-webapp</frontend.project.name>
-        <PermGen>64m</PermGen>
-        <MaxPermGen>512m</MaxPermGen>
         <CodeCacheSize>512m</CodeCacheSize>
 
         <commons-compress.version>1.21</commons-compress.version>
@@ -305,6 +303,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- JSR-250 annotations removed from JDK 11 module path -->
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
@@ -497,7 +502,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Dfile.encoding=utf-8</argLine>
+                    <argLine>-Dfile.encoding=utf-8 --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
 

--- a/streampark-console/streampark-console-service/pom.xml
+++ b/streampark-console/streampark-console-service/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-console</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-console-service</artifactId>

--- a/streampark-console/streampark-console-service/src/main/assembly/assembly.xml
+++ b/streampark-console/streampark-console-service/src/main/assembly/assembly.xml
@@ -49,6 +49,9 @@
             <directory>${project.build.directory}/../../../.mvn</directory>
             <outputDirectory>bin/.mvn</outputDirectory>
             <fileMode>0755</fileMode>
+            <excludes>
+                <exclude>**/*.class</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}/../src/main/assembly/bin</directory>

--- a/streampark-console/streampark-console-service/src/main/assembly/bin/jvm_opts.sh
+++ b/streampark-console/streampark-console-service/src/main/assembly/bin/jvm_opts.sh
@@ -1,21 +1,19 @@
 #!/bin/bash
 #
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
 #
 #    http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 -server
 -Xms1g
@@ -26,13 +24,6 @@
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:+IgnoreUnrecognizedVMOptions
 
--XX:+PrintGCDateStamps
--XX:+PrintGCDetails
--XX:+PrintGC
-
--XX:+UseGCLogFileRotation
--XX:GCLogFileSize=50M
--XX:NumberOfGCLogFiles=10
-
-# solved jdk1.8+ dynamic loading of resources to the classpath issue, if jdk > 1.8, you can enable this parameter
-#--add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED
+# Required for dynamic classpath (ClassLoaderUtils) on JDK 9+. Ignored on JDK 8.
+--add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+--add-opens jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED

--- a/streampark-console/streampark-console-service/src/main/assembly/bin/mvnw
+++ b/streampark-console/streampark-console-service/src/main/assembly/bin/mvnw
@@ -202,9 +202,9 @@ if [ ! -e "$javaSource" ]; then
   exit 1
 fi
 
-if [ ! -e "$javaClass" ]; then
+if [ ! -e "$javaClass" ] || [ "$javaSource" -nt "$javaClass" ]; then
   log " - Compiling $javaClass starting ..."
-  ("$JAVA_HOME/bin/javac" "$javaSource")
+  ("$JAVA_HOME/bin/javac" --release 11 "$javaSource")
 fi
 
 if [ -r "$wrapperJarPath" ]; then

--- a/streampark-console/streampark-console-service/src/main/assembly/bin/setclasspath.sh
+++ b/streampark-console/streampark-console-service/src/main/assembly/bin/setclasspath.sh
@@ -104,3 +104,12 @@ fi
 if [[ -z "$JAVA_HOME" ]]; then
   echo "Warning: JAVA_HOME environment variable is not set."
 fi
+
+REQUIRED_JAVA_MAJOR=11
+# shellcheck disable=SC2006
+java_version=`"$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}'`
+java_major=$(echo "$java_version" | awk -F '.' '{if ($1 == 1) {print $2} else {print $1}}')
+if [[ "$java_major" -lt "$REQUIRED_JAVA_MAJOR" ]]; then
+  echo "Error: StreamPark requires JDK ${REQUIRED_JAVA_MAJOR} or later (current: ${java_version})." >&2
+  exit 1
+fi

--- a/streampark-console/streampark-console-service/src/main/assembly/bin/streampark.sh
+++ b/streampark-console/streampark-console-service/src/main/assembly/bin/streampark.sh
@@ -270,7 +270,11 @@ fi
 
 JVM_OPTS=${JVM_OPTS:-"${JVM_ARGS}"}
 JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=${APP_HOME}/logs/dump.hprof"
-JVM_OPTS="$JVM_OPTS -Xloggc:${APP_HOME}/logs/gc.log"
+JVM_OPTS="$JVM_OPTS -Xlog:gc*:file=${APP_HOME}/logs/gc.log:time,uptime,level,tags:filecount=10,filesize=50M"
+
+build_java_classpath_prefix() {
+  echo ".:${JAVA_HOME}/lib"
+}
 
 # ----- Execute The Requested Command -----------------------------------------
 
@@ -370,13 +374,13 @@ start() {
     echo_w "Using HADOOP_HOME:   ${HADOOP_HOME}"
   fi
 
-  #
   # classpath options:
-  # 1): java env (lib and jre/lib)
+  # 1): java lib (JDK 11+ layout)
   # 2): StreamPark
   # 3): hadoop conf
   # shellcheck disable=SC2091
-  local APP_CLASSPATH=".:${JAVA_HOME}/lib:${JAVA_HOME}/jre/lib"
+  local APP_CLASSPATH
+  APP_CLASSPATH=$(build_java_classpath_prefix)
   # shellcheck disable=SC2206
   # shellcheck disable=SC2010
   local JARS=$(ls "$APP_LIB"/*.jar | grep -v "$APP_LIB/streampark-flink-shims_.*.jar$")
@@ -437,11 +441,12 @@ start_docker() {
   fi
 
   # classpath options:
-  # 1): java env (lib and jre/lib)
+  # 1): java lib (JDK 11+ layout)
   # 2): StreamPark
   # 3): hadoop conf
   # shellcheck disable=SC2091
-  local APP_CLASSPATH=".:${JAVA_HOME}/lib:${JAVA_HOME}/jre/lib"
+  local APP_CLASSPATH
+  APP_CLASSPATH=$(build_java_classpath_prefix)
   # shellcheck disable=SC2206
   # shellcheck disable=SC2155
   # shellcheck disable=SC2010

--- a/streampark-console/streampark-console-service/src/main/assembly/bin/streampark.sh
+++ b/streampark-console/streampark-console-service/src/main/assembly/bin/streampark.sh
@@ -286,7 +286,7 @@ print_logo() {
   printf '      %s  ___/ / /_/ /  /  __/ /_/ / / / / / / /_/ / /_/ / /  / ,<        %s\n'          $PRIMARY $RESET
   printf '      %s /____/\__/_/   \___/\__,_/_/ /_/ /_/ ____/\__,_/_/  /_/|_|       %s\n'          $PRIMARY $RESET
   printf '      %s                                   /_/                            %s\n\n'        $PRIMARY $RESET
-  printf '      %s   Version:  2.2.0 %s\n'                                                         $BLUE    $RESET
+  printf '      %s   Version:  3.0.0-SNAPSHOT %s\n'                                                         $BLUE    $RESET
   printf '      %s   WebSite:  https://streampark.apache.org%s\n'                                  $BLUE    $RESET
   printf '      %s   GitHub :  http://github.com/apache/streampark%s\n\n'                          $BLUE    $RESET
   printf '      %s   ──────── Apache StreamPark, Make stream processing easier ô~ô!%s\n\n'         $PRIMARY $RESET

--- a/streampark-console/streampark-console-service/src/main/assembly/conf/streampark-env.sh
+++ b/streampark-console/streampark-console-service/src/main/assembly/conf/streampark-env.sh
@@ -31,6 +31,8 @@
 ###
 
 # Technically, the only required environment variable is JAVA_HOME.
+# StreamPark 3.0 requires JDK 11 or later for the Console process.
+# Flink/Spark job JDK is configured separately via flink-env.sh / spark-env.sh.
 # All others are optional.  However, the defaults are probably not
 # preferred.  Many sites configure these options outside of streampark,
 # such as in /etc/profile.d

--- a/streampark-console/streampark-console-service/src/main/assembly/script/JDK_UPGRADE_GUIDE.md
+++ b/streampark-console/streampark-console-service/src/main/assembly/script/JDK_UPGRADE_GUIDE.md
@@ -1,0 +1,82 @@
+# StreamPark JDK Upgrade Guide
+
+StreamPark 3.0 requires **JDK 11 or later** to run the Console process.
+
+## Console JDK vs Job JDK
+
+| Component | JDK requirement | Configuration |
+|-----------|-----------------|---------------|
+| StreamPark Console | **JDK 11+** | `JAVA_HOME` in `streampark-env.sh` or system environment |
+| Flink jobs | Depends on Flink version | `$FLINK_HOME/conf/flink-env.sh` → `JAVA_HOME` |
+| Spark jobs | Depends on Spark version | `$SPARK_HOME/conf/spark-env.sh` → `JAVA_HOME` |
+
+Upgrading the Console to JDK 11 **does not require** upgrading Flink/Spark cluster JDK at the same time.
+
+## Compatibility Matrix
+
+| Engine | Minimum job JDK | Recommended job JDK |
+|--------|-----------------|---------------------|
+| Flink 1.17–1.20 | 8 | 11 |
+| Flink 2.x | 11 | 11 or 17 |
+| Spark 3.5+ | 11 | 11 or 17 |
+
+## Upgrade Steps
+
+### 1. Standalone deployment
+
+1. Install JDK 11 (e.g. OpenJDK 11, Amazon Corretto 11).
+2. Set `JAVA_HOME` in `conf/streampark-env.sh`:
+   ```bash
+   export JAVA_HOME=/path/to/jdk-11
+   ```
+3. Restart Console:
+   ```bash
+   ./bin/streampark.sh restart
+   ```
+4. Verify:
+   ```bash
+   ./bin/streampark.sh status
+   java -version   # should show 11+
+   ```
+
+### 2. Docker deployment
+
+Official StreamPark Docker images from 3.0 onward use JDK 11 internally. Pull the latest image:
+
+```bash
+docker pull apache/streampark:latest
+```
+
+### 3. Build from source
+
+JDK 11+ is required to build StreamPark 3.0:
+
+```bash
+export JAVA_HOME=/path/to/jdk-11
+./build.sh
+```
+
+## JVM Options
+
+StreamPark enables the following JVM options by default (see `bin/jvm_opts.sh`):
+
+```
+--add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+--add-opens jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED
+```
+
+These are required for dynamic classpath loading (Flink shims, user JARs). Do not remove them unless you know the impact.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `StreamPark requires JDK 11 or later` on start | Console running on JDK 8 | Upgrade `JAVA_HOME` to JDK 11+ |
+| `NoSuchFieldException: ucp` | Missing `--add-opens` | Ensure `jvm_opts.sh` is not overridden incorrectly |
+| `javax.annotation.PostConstruct` not found | Missing annotation API | Use StreamPark 3.0+ distribution (includes dependency) |
+| Hadoop/YARN connection issues on JDK 11 | Jersey classpath | Verify Hadoop 3.3.x; check Hadoop client compatibility |
+
+## Related Issues
+
+- #4409 — JDK 11 migration proposal
+- #4410 — StreamPark 3.0 roadmap

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/runner/StartedUpRunner.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/system/runner/StartedUpRunner.java
@@ -48,7 +48,7 @@ public class StartedUpRunner implements ApplicationRunner {
             System.out.println("      ___/ / /_/ /  /  __/ /_/ / / / / / / /_/ / /_/ / /  / ,<        ");
             System.out.println("     /____/\\__/_/   \\___/\\__,_/_/ /_/ /_/ ____/\\__,_/_/  /_/|_|   ");
             System.out.println("                                       /_/                        \n\n");
-            System.out.println("    Version:  2.2.0                                                   ");
+            System.out.println("    Version:  3.0.0-SNAPSHOT                                                   ");
             System.out.println("    WebSite:  https://streampark.apache.org                           ");
             System.out.println("    GitHub :  https://github.com/apache/streampark          ");
             System.out.println("    Info   :  streampark-console start successful                     ");

--- a/streampark-console/streampark-console-webapp/package.json
+++ b/streampark-console/streampark-console-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streampark-webapp",
-  "version": "2.2.0-SNAPSHOT",
+  "version": "3.0.0-SNAPSHOT",
   "author": {
     "name": "streampark",
     "url": "https://streampark.apache.org"

--- a/streampark-e2e/pom.xml
+++ b/streampark-e2e/pom.xml
@@ -30,8 +30,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <junit.version>5.8.1</junit.version>

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ProjectsManagementTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/ProjectsManagementTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.PageFactory;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import java.time.Duration;
@@ -36,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @StreamPark(composeFiles = "docker/basic/docker-compose.yaml")
 public class ProjectsManagementTest {
 
-    private final Duration PROJECT_BUILD_TIMEOUT_MINUTES = Duration.ofMinutes(5);
+    private final Duration PROJECT_BUILD_TIMEOUT_MINUTES = Duration.ofMinutes(15);
 
     public static RemoteWebDriver browser;
 
@@ -98,10 +99,14 @@ public class ProjectsManagementTest {
 
         Awaitility.await().timeout(PROJECT_BUILD_TIMEOUT_MINUTES)
             .untilAsserted(
-                () -> assertThat(projectsPage.projectList)
-                    .as("Projects list should contain build success project")
-                    .extracting(WebElement::getText)
-                    .anyMatch(it -> it.contains("SUCCESSFUL")));
+                () -> {
+                    browser.navigate().refresh();
+                    PageFactory.initElements(projectsPage.driver, projectsPage);
+                    assertThat(projectsPage.projectList)
+                        .as("Projects list should contain build success project")
+                        .extracting(WebElement::getText)
+                        .anyMatch(it -> it.contains("SUCCESSFUL"));
+                });
 
     }
 

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/common/CommonFactory.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/common/CommonFactory.java
@@ -18,7 +18,10 @@
 package org.apache.streampark.e2e.pages.common;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.ElementClickInterceptedException;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -33,15 +36,34 @@ public class CommonFactory {
         element.sendKeys(value);
     }
 
+    public static void WebElementDeleteAndInput(WebDriver driver, WebElement element, String value) {
+        new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
+            .until(ExpectedConditions.visibilityOf(element));
+        new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
+            .until(ExpectedConditions.elementToBeClickable(element));
+        WebElementDelete(element);
+        element.sendKeys(value);
+    }
+
     public static void WebElementDelete(WebElement element) {
-        element.sendKeys(Keys.CONTROL + "a");
+        element.sendKeys(Keys.chord(selectAllKey(), "a"));
         element.sendKeys(Keys.BACK_SPACE);
     }
 
     public static void WebElementClick(WebDriver driver, WebElement clickableElement) {
         new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
             .until(ExpectedConditions.elementToBeClickable(clickableElement));
-        clickableElement.click();
+        try {
+            clickableElement.click();
+        } catch (ElementClickInterceptedException ex) {
+            JavascriptExecutor executor = (JavascriptExecutor) driver;
+            executor.executeScript("arguments[0].scrollIntoView({block: 'center'});", clickableElement);
+            executor.executeScript("arguments[0].click();", clickableElement);
+        }
+    }
+
+    private static CharSequence selectAllKey() {
+        return Platform.getCurrent().is(Platform.MAC) ? Keys.COMMAND : Keys.CONTROL;
     }
 
     public static void WebDriverWaitForElementVisibilityAndInvisibility(WebDriver driver, String msg) {

--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/resource/ProjectsPage.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/pages/resource/ProjectsPage.java
@@ -23,7 +23,6 @@ import org.apache.streampark.e2e.pages.common.NavBarPage;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.FindBy;
@@ -33,6 +32,9 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.util.List;
+
+import static org.apache.streampark.e2e.pages.common.CommonFactory.WebElementClick;
+import static org.apache.streampark.e2e.pages.common.CommonFactory.WebElementDeleteAndInput;
 
 @Getter
 public class ProjectsPage extends NavBarPage implements ResourcePage.Tab {
@@ -67,14 +69,12 @@ public class ProjectsPage extends NavBarPage implements ResourcePage.Tab {
                                       String projectDescription) {
         waitForPageLoading();
 
-        new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
-            .until(ExpectedConditions.elementToBeClickable(buttonCreateProject));
-
-        buttonCreateProject.click();
+        WebElementClick(driver, buttonCreateProject);
 
         new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
             .until(ExpectedConditions.urlContains("/project/add"));
 
+        createProjectForm = new CreateProjectForm();
         createProjectForm.inputProjectName.sendKeys(projectName);
 
         createProjectForm.selectCveDropdown.click();
@@ -103,6 +103,7 @@ public class ProjectsPage extends NavBarPage implements ResourcePage.Tab {
         createProjectForm.inputDescription.sendKeys(projectDescription);
         createProjectForm.buttonSubmit.click();
 
+        waitForListPageAfterSubmit();
         return this;
     }
 
@@ -111,7 +112,7 @@ public class ProjectsPage extends NavBarPage implements ResourcePage.Tab {
                                     String newProjectName) {
         waitForPageLoading();
 
-        projectList.stream()
+        WebElement editButton = projectList.stream()
             .filter(it -> it.getText().contains(projectName))
             .flatMap(
                 it -> it.findElements(
@@ -119,17 +120,17 @@ public class ProjectsPage extends NavBarPage implements ResourcePage.Tab {
                     .stream())
             .filter(WebElement::isDisplayed)
             .findFirst()
-            .orElseThrow(() -> new RuntimeException("No edit button in project list"))
-            .click();
+            .orElseThrow(() -> new RuntimeException("No edit button in project list"));
+        WebElementClick(driver, editButton);
 
         new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
             .until(ExpectedConditions.urlContains("/project/edit"));
 
-        createProjectForm.inputProjectName.sendKeys(Keys.CONTROL + "a");
-        createProjectForm.inputProjectName.sendKeys(Keys.BACK_SPACE);
-        createProjectForm.inputProjectName.sendKeys(newProjectName);
+        createProjectForm = new CreateProjectForm();
+        WebElementDeleteAndInput(driver, createProjectForm.inputProjectName, newProjectName);
         createProjectForm.buttonSubmit.click();
 
+        waitForListPageAfterSubmit();
         return this;
     }
 
@@ -137,14 +138,14 @@ public class ProjectsPage extends NavBarPage implements ResourcePage.Tab {
     public ProjectsPage buildProject(String projectName) {
         waitForPageLoading();
 
-        projectList.stream()
+        WebElement buildBtn = projectList.stream()
             .filter(it -> it.getText().contains(projectName))
             .flatMap(
                 it -> it.findElements(By.className("e2e-project-build-btn")).stream())
             .filter(WebElement::isDisplayed)
             .findFirst()
-            .orElseThrow(() -> new RuntimeException("No build button in project list"))
-            .click();
+            .orElseThrow(() -> new RuntimeException("No build button in project list"));
+        WebElementClick(driver, buildBtn);
 
         new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
             .until(ExpectedConditions.elementToBeClickable(buildConfirmButton));
@@ -157,7 +158,7 @@ public class ProjectsPage extends NavBarPage implements ResourcePage.Tab {
     @SneakyThrows
     public ProjectsPage deleteProject(String projectName) {
         waitForPageLoading();
-        projectList.stream()
+        WebElement deleteBtn = projectList.stream()
             .filter(it -> it.getText().contains(projectName))
             .flatMap(
                 it -> it
@@ -165,19 +166,38 @@ public class ProjectsPage extends NavBarPage implements ResourcePage.Tab {
                     .stream())
             .filter(WebElement::isDisplayed)
             .findFirst()
-            .orElseThrow(() -> new RuntimeException("No delete button in project list"))
-            .click();
+            .orElseThrow(() -> new RuntimeException("No delete button in project list"));
+        WebElementClick(driver, deleteBtn);
 
         new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
             .until(ExpectedConditions.elementToBeClickable(deleteConfirmButton));
 
         deleteConfirmButton.click();
+        PageFactory.initElements(driver, this);
         return this;
     }
 
     private void waitForPageLoading() {
         new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
-            .until(ExpectedConditions.urlContains("/resource/project"));
+            .until(d -> isProjectListPage(d.getCurrentUrl()));
+        PageFactory.initElements(driver, this);
+        new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
+            .until(ExpectedConditions.elementToBeClickable(buttonCreateProject));
+        createProjectForm = new CreateProjectForm();
+    }
+
+    private void waitForListPageAfterSubmit() {
+        new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
+            .until(d -> isProjectListPage(d.getCurrentUrl()));
+        PageFactory.initElements(driver, this);
+        new WebDriverWait(driver, Constants.DEFAULT_WEBDRIVER_WAIT_DURATION)
+            .until(ExpectedConditions.elementToBeClickable(buttonCreateProject));
+        createProjectForm = new CreateProjectForm();
+    }
+
+    private boolean isProjectListPage(String url) {
+        return url.contains("/resource/project")
+            || (url.contains("/project") && !url.contains("/project/add") && !url.contains("/project/edit"));
     }
 
     @Getter

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/basic/gitconfig
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/basic/gitconfig
@@ -15,32 +15,5 @@
 # limitations under the License.
 #
 
-services:
-  streampark:
-    image: apache/streampark:ci-basic
-    command: bash bin/streampark.sh start_docker
-    build:
-      context: ./
-      dockerfile: ./Dockerfile
-    ports:
-      - 10000:10000
-      - 10030:10030
-    environment:
-      - SPRING_PROFILES_ACTIVE=h2
-      - TZ=Asia/Shanghai
-    privileged: true
-    restart: unless-stopped
-    networks:
-      - e2e
-    volumes:
-      - ${HOME}/streampark_build_logs:/tmp/streampark/logs/build_logs/
-      - ${HOME}/.m2:/root/.m2
-      - ./gitconfig:/root/.gitconfig:ro
-    healthcheck:
-      test: [ "CMD", "curl", "http://localhost:10000" ]
-      interval: 5s
-      timeout: 5s
-      retries: 120
-
-networks:
-  e2e:
+[http]
+	sslVerify = false

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.16.3
 RUN sudo chown -R hadoop.hadoop /flink-1.16.3
 
-# Install javac
+# Install JDK 11 for StreamPark Console (Flink distribution is copied separately above)
 ARG TARGETPLATFORM
 RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
 RUN \
@@ -36,10 +36,14 @@ RUN \
         sudo rm -f /etc/yum.repos.d/*.repo; \
         sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
         sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
+        sudo yum install -y java-11-openjdk-devel; \
+        sudo ln -sfn /usr/lib/jvm/java-11-openjdk.aarch64 /usr/lib/jvm/java-11-openjdk; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
+        sudo yum install -y java-11-openjdk-devel; \
     else \
         echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \
         exit 2;  \
     fi
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.17.2
 RUN sudo chown -R hadoop.hadoop /flink-1.17.2
 
-# Install javac
+# Install JDK 11 for StreamPark Console (Flink distribution is copied separately above)
 ARG TARGETPLATFORM
 RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
 RUN \
@@ -36,10 +36,14 @@ RUN \
         sudo rm -f /etc/yum.repos.d/*.repo; \
         sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
         sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
+        sudo yum install -y java-11-openjdk-devel; \
+        sudo ln -sfn /usr/lib/jvm/java-11-openjdk.aarch64 /usr/lib/jvm/java-11-openjdk; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
+        sudo yum install -y java-11-openjdk-devel; \
     else \
         echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \
         exit 2;  \
     fi
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.18.1
 RUN sudo chown -R hadoop.hadoop /flink-1.18.1
 
-# Install javac
+# Install JDK 11 for StreamPark Console (Flink distribution is copied separately above)
 ARG TARGETPLATFORM
 RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
 RUN \
@@ -36,10 +36,14 @@ RUN \
         sudo rm -f /etc/yum.repos.d/*.repo; \
         sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
         sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
+        sudo yum install -y java-11-openjdk-devel; \
+        sudo ln -sfn /usr/lib/jvm/java-11-openjdk.aarch64 /usr/lib/jvm/java-11-openjdk; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
+        sudo yum install -y java-11-openjdk-devel; \
     else \
         echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \
         exit 2;  \
     fi
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.20-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.20-on-yarn/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.20.1
 RUN sudo chown -R hadoop.hadoop /flink-1.20.1
 
-# Install javac
+# Install JDK 11 for StreamPark Console (Flink distribution is copied separately above)
 ARG TARGETPLATFORM
 RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
 RUN \
@@ -36,10 +36,14 @@ RUN \
         sudo rm -f /etc/yum.repos.d/*.repo; \
         sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
         sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
+        sudo yum install -y java-11-openjdk-devel; \
+        sudo ln -sfn /usr/lib/jvm/java-11-openjdk.aarch64 /usr/lib/jvm/java-11-openjdk; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
+        sudo yum install -y java-11-openjdk-devel; \
     else \
         echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \
         exit 2;  \
     fi
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/streampark-e2e/streampark-e2e-core/src/main/java/org/apache/streampark/e2e/core/StreamParkExtension.java
+++ b/streampark-e2e/streampark-e2e-core/src/main/java/org/apache/streampark/e2e/core/StreamParkExtension.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.Testcontainers;
@@ -59,6 +60,8 @@ final class StreamParkExtension implements BeforeAllCallback, AfterAllCallback, 
 
     private final boolean M1_CHIP_FLAG = Objects.equals(System.getProperty("m1_chip"), "true");
 
+    private final boolean LOCAL_BROWSER = Objects.equals(System.getProperty("local_browser"), "true");
+
     private final int LOCAL_PORT = 10001;
 
     private final int DOCKER_PORT = 10000;
@@ -87,15 +90,19 @@ final class StreamParkExtension implements BeforeAllCallback, AfterAllCallback, 
             runInDockerContainer(context);
         }
 
-        setBrowserContainerByOsName();
+        if (LOCAL_BROWSER) {
+            driver = new ChromeDriver(new ChromeOptions());
+        } else {
+            setBrowserContainerByOsName();
 
-        if (compose != null) {
-            Testcontainers.exposeHostPorts(compose.getServicePort(serviceName, DOCKER_PORT));
-            browser.withAccessToHost(true);
+            if (compose != null) {
+                Testcontainers.exposeHostPorts(compose.getServicePort(serviceName, DOCKER_PORT));
+                browser.withAccessToHost(true);
+            }
+            browser.start();
+
+            driver = new RemoteWebDriver(browser.getSeleniumAddress(), new ChromeOptions());
         }
-        browser.start();
-
-        driver = new RemoteWebDriver(browser.getSeleniumAddress(), new ChromeOptions());
 
         driver
             .manage()
@@ -106,7 +113,9 @@ final class StreamParkExtension implements BeforeAllCallback, AfterAllCallback, 
 
         driver.get(new URL("http", address.getHost(), address.getPort(), rootPath).toString());
 
-        browser.beforeTest(new TestDescription(context));
+        if (!LOCAL_BROWSER) {
+            browser.beforeTest(new TestDescription(context));
+        }
 
         final Class<?> clazz = context.getRequiredTestClass();
         Stream.of(clazz.getDeclaredFields())
@@ -117,7 +126,7 @@ final class StreamParkExtension implements BeforeAllCallback, AfterAllCallback, 
 
     private void runInLocal() {
         Testcontainers.exposeHostPorts(LOCAL_PORT);
-        address = HostAndPort.fromParts("host.testcontainers.internal", LOCAL_PORT);
+        address = HostAndPort.fromParts(browserHost(), LOCAL_PORT);
         rootPath = "/";
     }
 
@@ -126,8 +135,12 @@ final class StreamParkExtension implements BeforeAllCallback, AfterAllCallback, 
         compose.start();
 
         address = HostAndPort.fromParts(
-            "host.testcontainers.internal", compose.getServicePort(serviceName, DOCKER_PORT));
+            browserHost(), compose.getServicePort(serviceName, DOCKER_PORT));
         rootPath = "/";
+    }
+
+    private String browserHost() {
+        return LOCAL_BROWSER ? "localhost" : "host.testcontainers.internal";
     }
 
     private void setBrowserContainerByOsName() {
@@ -172,8 +185,13 @@ final class StreamParkExtension implements BeforeAllCallback, AfterAllCallback, 
 
     @Override
     public void afterAll(ExtensionContext context) {
-        browser.afterTest(new TestDescription(context), Optional.empty());
-        browser.stop();
+        if (driver != null) {
+            driver.quit();
+        }
+        if (!LOCAL_BROWSER && browser != null) {
+            browser.afterTest(new TestDescription(context), Optional.empty());
+            browser.stop();
+        }
         if (compose != null) {
             compose.stop();
         }

--- a/streampark-e2e/streampark-e2e-core/src/main/resources/docker-java.properties
+++ b/streampark-e2e/streampark-e2e-core/src/main/resources/docker-java.properties
@@ -6,7 +6,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,32 +15,6 @@
 # limitations under the License.
 #
 
-services:
-  streampark:
-    image: apache/streampark:ci-basic
-    command: bash bin/streampark.sh start_docker
-    build:
-      context: ./
-      dockerfile: ./Dockerfile
-    ports:
-      - 10000:10000
-      - 10030:10030
-    environment:
-      - SPRING_PROFILES_ACTIVE=h2
-      - TZ=Asia/Shanghai
-    privileged: true
-    restart: unless-stopped
-    networks:
-      - e2e
-    volumes:
-      - ${HOME}/streampark_build_logs:/tmp/streampark/logs/build_logs/
-      - ${HOME}/.m2:/root/.m2
-      - ./gitconfig:/root/.gitconfig:ro
-    healthcheck:
-      test: [ "CMD", "curl", "http://localhost:10000" ]
-      interval: 5s
-      timeout: 5s
-      retries: 120
-
-networks:
-  e2e:
+# Docker Engine 29+ requires API version 1.44 or later.
+# Testcontainers 1.19.x defaults to 1.32 via docker-java, which is rejected by the daemon.
+api.version=1.44

--- a/streampark-flink/pom.xml
+++ b/streampark-flink/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink</artifactId>

--- a/streampark-flink/streampark-flink-client/pom.xml
+++ b/streampark-flink/streampark-flink-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-client</artifactId>

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-api/pom.xml
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-client</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-client-api_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/pom.xml
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-client</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-client-core_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/pom.xml
+++ b/streampark-flink/streampark-flink-connector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-base/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-base_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-clickhouse/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-clickhouse/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-clickhouse_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-doris/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-doris/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-doris_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-elasticsearch</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch5/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch5/pom.xml
@@ -30,8 +30,8 @@
     <name>StreamPark : Flink Connector Elasticsearch5</name>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <flink.version>1.14.0</flink.version>
     </properties>
 

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch5/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch5/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector-elasticsearch</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-elasticsearch5_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch6/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch6/pom.xml
@@ -30,8 +30,8 @@
     <name>StreamPark : Flink Connector Elasticsearch6</name>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch6/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch6/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector-elasticsearch</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-elasticsearch6_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch7/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch7/pom.xml
@@ -29,8 +29,8 @@
     <name>StreamPark : Flink Connector Elasticsearch7</name>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch7/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-elasticsearch/streampark-flink-connector-elasticsearch7/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>streampark-flink-connector-elasticsearch</artifactId>
         <groupId>org.apache.streampark</groupId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-elasticsearch7_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-hbase/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-hbase/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-hbase_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-http/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-http/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-http_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-influx/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-influx/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-influx_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-jdbc/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-jdbc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-jdbc_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-kafka/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-kafka/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-kafka_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-mongo/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-mongo_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-connector/streampark-flink-connector-redis/pom.xml
+++ b/streampark-flink/streampark-flink-connector/streampark-flink-connector-redis/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-connector</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-connector-redis_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-core/pom.xml
+++ b/streampark-flink/streampark-flink-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-core_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-kubernetes/pom.xml
+++ b/streampark-flink/streampark-flink-kubernetes/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-kubernetes_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-packer/pom.xml
+++ b/streampark-flink/streampark-flink-packer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-packer_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-proxy/pom.xml
+++ b/streampark-flink/streampark-flink-proxy/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-proxy_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/pom.xml
+++ b/streampark-flink/streampark-flink-shims/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims-base_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims-test/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims-test_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.12/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.12/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims_flink-1.12_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.13/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.13/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims_flink-1.13_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.14/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.14/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims_flink-1.14_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.15/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.15/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims_flink-1.15_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.16/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.16/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims_flink-1.16_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.17/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.17/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims_flink-1.17_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.18/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.18/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims_flink-1.18_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.19/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.19/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims_flink-1.19_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.20/pom.xml
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims_flink-1.20/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink-shims</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-shims_flink-1.20_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-sqlclient/pom.xml
+++ b/streampark-flink/streampark-flink-sqlclient/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-sqlclient_${scala.binary.version}</artifactId>

--- a/streampark-flink/streampark-flink-udf/pom.xml
+++ b/streampark-flink/streampark-flink-udf/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-flink</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-flink-udf_${scala.binary.version}</artifactId>

--- a/streampark-shaded/pom.xml
+++ b/streampark-shaded/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-shaded</artifactId>

--- a/streampark-spark/pom.xml
+++ b/streampark-spark/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-spark</artifactId>

--- a/streampark-spark/streampark-spark-cli/create_app.sh
+++ b/streampark-spark/streampark-spark-cli/create_app.sh
@@ -281,7 +281,7 @@ cat > $name/pom.xml <<EOF
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <project.build.jdk>1.8</project.build.jdk>
+        <project.build.jdk>11</project.build.jdk>
 
 
         <PermGen>64m</PermGen>

--- a/streampark-spark/streampark-spark-cli/pom.xml
+++ b/streampark-spark/streampark-spark-cli/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-spark</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-spark-cli</artifactId>

--- a/streampark-spark/streampark-spark-client/pom.xml
+++ b/streampark-spark/streampark-spark-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-spark</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-spark-client</artifactId>

--- a/streampark-spark/streampark-spark-client/streampark-spark-client-api/pom.xml
+++ b/streampark-spark/streampark-spark-client/streampark-spark-client-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-spark-client</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-spark-client-api_${scala.binary.version}</artifactId>

--- a/streampark-spark/streampark-spark-client/streampark-spark-client-core/pom.xml
+++ b/streampark-spark/streampark-spark-client/streampark-spark-client-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-spark-client</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-spark-client-core_${scala.binary.version}</artifactId>

--- a/streampark-spark/streampark-spark-connector/pom.xml
+++ b/streampark-spark/streampark-spark-connector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-spark</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-spark-connector_2.12</artifactId>

--- a/streampark-spark/streampark-spark-connector/streampark-spark-connector-base/pom.xml
+++ b/streampark-spark/streampark-spark-connector/streampark-spark-connector-base/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-spark-connector_2.12</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-spark-connector-base_2.12</artifactId>

--- a/streampark-spark/streampark-spark-connector/streampark-spark-connector-kafka/pom.xml
+++ b/streampark-spark/streampark-spark-connector/streampark-spark-connector-kafka/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-spark-connector_2.12</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-spark-connector-kafka_2.12</artifactId>

--- a/streampark-spark/streampark-spark-core/pom.xml
+++ b/streampark-spark/streampark-spark-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-spark</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-spark-core_2.12</artifactId>

--- a/streampark-spark/streampark-spark-sqlclient/pom.xml
+++ b/streampark-spark/streampark-spark-sqlclient/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streampark</groupId>
         <artifactId>streampark-spark</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>streampark-spark-sqlclient_${scala.binary.version}</artifactId>

--- a/tools/checkstyle/spotless_streampark_formatter.xml
+++ b/tools/checkstyle/spotless_streampark_formatter.xml
@@ -20,9 +20,9 @@
 -->
 <profiles version="22">
     <profile kind="CodeFormatterProfile" name="'StreamPark Apache Current'" version="13">
-        <setting id="org.eclipse.jdt.core.compiler.source" value="1.8" />
-        <setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8" />
-        <setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8" />
+        <setting id="org.eclipse.jdt.core.compiler.source" value="11" />
+        <setting id="org.eclipse.jdt.core.compiler.compliance" value="11" />
+        <setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="11" />
         <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false" />
         <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4" />
         <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120" />

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -144,6 +144,7 @@ janino-3.1.9.jar
 java-jwt-4.0.0.jar
 javassist-3.24.0-GA.jar
 javax.activation-api-1.2.0.jar
+javax.annotation-api-1.3.2.jar
 javax.mail-1.5.6.jar
 jaxb-api-2.3.1.jar
 jboss-logging-3.4.3.Final.jar


### PR DESCRIPTION
## Summary

Raise StreamPark 3.0 compile and runtime baseline to **JDK 11**:

- Set `project.build.jdk=11` and update CI workflows (backend, unit-test, E2E)
- Fix `ClassLoaderUtils` dynamic classpath on JDK 9+ (`--add-opens` / module path)
- Console JDK 11 startup readiness (`streampark-env.sh`, assembly scripts, upgrade guide)
- Maven Wrapper and basic E2E stabilization on JDK 11

## Related issues

- **Design proposal:** [#4409 [Proposal] Migrate StreamPark Console baseline from JDK 8 to JDK 11](https://github.com/apache/streampark/issues/4409)
- **Roadmap:** [#4410 StreamPark 3.0](https://github.com/apache/streampark/issues/4410)

Closes #4409.

## Test plan

- [x] `./mvnw clean install -Pfast -pl streampark-console/streampark-console-service -am -DskipTests` on JDK 11
- [ ] CI backend / unit-test / E2E workflows green
- [ ] Manual Console start on JDK 11

---
**AI Disclosure**
- Model: Claude (Cursor Agent)
- Platform/Tool: Cursor
- Human Oversight: partially reviewed
- Prompt Summary: Split JDK 11 upgrade into dedicated PR for StreamPark 3.0

Made with [Cursor](https://cursor.com)
