### PR TITLE
[CI] Fix Yarn E2E Docker builds after CentOS 7 mirror retirement

### DIFF
--- a/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/EnvironmentTest.java
+++ b/streampark-e2e/streampark-e2e-case/src/test/java/org/apache/streampark/e2e/cases/EnvironmentTest.java
@@ -150,8 +150,6 @@ public class EnvironmentTest {
                 .password(emailPassword)
                 .ok();
 
-        emailSettingForm.buttonOk.click();
-
         Awaitility.await()
             .untilAsserted(
                 () -> assertThat(environmentPage.settingList)

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/Dockerfile
@@ -17,6 +17,7 @@
 
 FROM apache/streampark:ci as base-image
 FROM flink:1.16.3-scala_2.12-java8 as flink-image
+FROM eclipse-temurin:8-jdk-jammy as jdk8-image
 
 # Install streampark
 FROM sbloodys/hadoop:3.3.6
@@ -28,21 +29,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.16.3
 RUN sudo chown -R hadoop.hadoop /flink-1.16.3
 
-# Install javac (CentOS 7 mirrors were retired; use vault archive)
-ARG TARGETPLATFORM
-RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
-RUN \
-    if [ "$TARGETPLATFORM" = "linux/arm64" ];then \
-        sudo rm -f /etc/yum.repos.d/*.repo; \
-        sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
-    elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
-        sudo sed -i 's/^mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/*.repo; \
-        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
-    else \
-        echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \
-        exit 2;  \
-    fi
+# Bundled JDK 8 from Eclipse Temurin (avoid CentOS 7 yum mirror retirement)
+COPY --from=jdk8-image /opt/java/openjdk /usr/lib/jvm/jdk8
+ENV JAVA_HOME=/usr/lib/jvm/jdk8
+ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.16-on-yarn/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.16.3
 RUN sudo chown -R hadoop.hadoop /flink-1.16.3
 
-# Install javac
+# Install javac (CentOS 7 mirrors were retired; use vault archive)
 ARG TARGETPLATFORM
 RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
 RUN \
@@ -36,8 +36,11 @@ RUN \
         sudo rm -f /etc/yum.repos.d/*.repo; \
         sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
         sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
         sudo yum install -y java-1.8.0-openjdk-devel; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
+        sudo sed -i 's/^mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/*.repo; \
+        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
         sudo yum install -y java-1.8.0-openjdk-devel; \
     else \
         echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.17.2
 RUN sudo chown -R hadoop.hadoop /flink-1.17.2
 
-# Install javac
+# Install javac (CentOS 7 mirrors were retired; use vault archive)
 ARG TARGETPLATFORM
 RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
 RUN \
@@ -36,8 +36,11 @@ RUN \
         sudo rm -f /etc/yum.repos.d/*.repo; \
         sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
         sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
         sudo yum install -y java-1.8.0-openjdk-devel; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
+        sudo sed -i 's/^mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/*.repo; \
+        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
         sudo yum install -y java-1.8.0-openjdk-devel; \
     else \
         echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.17-on-yarn/Dockerfile
@@ -17,6 +17,7 @@
 
 FROM apache/streampark:ci as base-image
 FROM flink:1.17.2-scala_2.12-java8 as flink-image
+FROM eclipse-temurin:8-jdk-jammy as jdk8-image
 
 # Install streampark
 FROM sbloodys/hadoop:3.3.6
@@ -28,21 +29,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.17.2
 RUN sudo chown -R hadoop.hadoop /flink-1.17.2
 
-# Install javac (CentOS 7 mirrors were retired; use vault archive)
-ARG TARGETPLATFORM
-RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
-RUN \
-    if [ "$TARGETPLATFORM" = "linux/arm64" ];then \
-        sudo rm -f /etc/yum.repos.d/*.repo; \
-        sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
-    elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
-        sudo sed -i 's/^mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/*.repo; \
-        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
-    else \
-        echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \
-        exit 2;  \
-    fi
+# Bundled JDK 8 from Eclipse Temurin (avoid CentOS 7 yum mirror retirement)
+COPY --from=jdk8-image /opt/java/openjdk /usr/lib/jvm/jdk8
+ENV JAVA_HOME=/usr/lib/jvm/jdk8
+ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/Dockerfile
@@ -17,6 +17,7 @@
 
 FROM apache/streampark:ci as base-image
 FROM flink:1.18.1-scala_2.12-java8 as flink-image
+FROM eclipse-temurin:8-jdk-jammy as jdk8-image
 
 # Install streampark
 FROM sbloodys/hadoop:3.3.6
@@ -28,21 +29,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.18.1
 RUN sudo chown -R hadoop.hadoop /flink-1.18.1
 
-# Install javac (CentOS 7 mirrors were retired; use vault archive)
-ARG TARGETPLATFORM
-RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
-RUN \
-    if [ "$TARGETPLATFORM" = "linux/arm64" ];then \
-        sudo rm -f /etc/yum.repos.d/*.repo; \
-        sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
-    elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
-        sudo sed -i 's/^mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/*.repo; \
-        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
-    else \
-        echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \
-        exit 2;  \
-    fi
+# Bundled JDK 8 from Eclipse Temurin (avoid CentOS 7 yum mirror retirement)
+COPY --from=jdk8-image /opt/java/openjdk /usr/lib/jvm/jdk8
+ENV JAVA_HOME=/usr/lib/jvm/jdk8
+ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.18-on-yarn/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.18.1
 RUN sudo chown -R hadoop.hadoop /flink-1.18.1
 
-# Install javac
+# Install javac (CentOS 7 mirrors were retired; use vault archive)
 ARG TARGETPLATFORM
 RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
 RUN \
@@ -36,8 +36,11 @@ RUN \
         sudo rm -f /etc/yum.repos.d/*.repo; \
         sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
         sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
         sudo yum install -y java-1.8.0-openjdk-devel; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
+        sudo sed -i 's/^mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/*.repo; \
+        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
         sudo yum install -y java-1.8.0-openjdk-devel; \
     else \
         echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.20-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.20-on-yarn/Dockerfile
@@ -17,6 +17,7 @@
 
 FROM apache/streampark:ci as base-image
 FROM flink:1.20.1-scala_2.12-java8 as flink-image
+FROM eclipse-temurin:8-jdk-jammy as jdk8-image
 
 # Install streampark
 FROM sbloodys/hadoop:3.3.6
@@ -28,21 +29,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.20.1
 RUN sudo chown -R hadoop.hadoop /flink-1.20.1
 
-# Install javac (CentOS 7 mirrors were retired; use vault archive)
-ARG TARGETPLATFORM
-RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
-RUN \
-    if [ "$TARGETPLATFORM" = "linux/arm64" ];then \
-        sudo rm -f /etc/yum.repos.d/*.repo; \
-        sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
-        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
-    elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
-        sudo sed -i 's/^mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/*.repo; \
-        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
-        sudo yum install -y java-1.8.0-openjdk-devel; \
-    else \
-        echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \
-        exit 2;  \
-    fi
+# Bundled JDK 8 from Eclipse Temurin (avoid CentOS 7 yum mirror retirement)
+COPY --from=jdk8-image /opt/java/openjdk /usr/lib/jvm/jdk8
+ENV JAVA_HOME=/usr/lib/jvm/jdk8
+ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.20-on-yarn/Dockerfile
+++ b/streampark-e2e/streampark-e2e-case/src/test/resources/docker/flink-1.20-on-yarn/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo chown -R hadoop.hadoop /streampark \
 COPY --from=flink-image /opt/flink /flink-1.20.1
 RUN sudo chown -R hadoop.hadoop /flink-1.20.1
 
-# Install javac
+# Install javac (CentOS 7 mirrors were retired; use vault archive)
 ARG TARGETPLATFORM
 RUN echo "TARGETPLATFORM: $TARGETPLATFORM"
 RUN \
@@ -36,8 +36,11 @@ RUN \
         sudo rm -f /etc/yum.repos.d/*.repo; \
         sudo wget http://mirrors.aliyun.com/repo/Centos-altarch-7.repo -O /etc/yum.repos.d/CentOS-Base.repo; \
         sudo sed -i "s/http:\/\//https:\/\//g" /etc/yum.repos.d/CentOS-Base.repo; \
+        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
         sudo yum install -y java-1.8.0-openjdk-devel; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ];then \
+        sudo sed -i 's/^mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/*.repo; \
+        sudo sed -i 's|http://mirror.centos.org|http://vault.centos.org|g' /etc/yum.repos.d/*.repo; \
         sudo yum install -y java-1.8.0-openjdk-devel; \
     else \
         echo "unknown TARGETPLATFORM: $TARGETPLATFORM"; \


### PR DESCRIPTION
## Summary

Fix Yarn E2E Docker image build failures caused by retired CentOS 7 mirror URLs, and stabilize a flaky UI test.

Closes #4433.

## Changes

- Point Yarn E2E Dockerfiles to `vault.centos.org` before yum install
- Bundle JDK 8 from `eclipse-temurin:8-jdk-jammy` via multi-stage `COPY` (no yum Java install)
- Remove duplicate OK click in `EnvironmentTest` (`ElementClickInterceptedException`)

## Non-goals

- Maven `${revision}` / 3.0.0-SNAPSHOT work remains in #4425 / #4426

## Test plan

- [ ] Yarn E2E workflow builds all `flink-*-on-yarn` Docker images successfully
- [ ] `EnvironmentTest` passes consistently in E2E pipeline

Made with [Cursor](https://cursor.com)