### PR TITLE
[Improve] validate module name before file resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@
 [![Total Downloads](https://img.shields.io/github/downloads/apache/streampark/total.svg?style=for-the-badge&label=downloads)](https://streampark.apache.org/download)
 [![Twitter Follow](https://img.shields.io/twitter/follow/ASFStreamPark?label=follow&logo=x&style=for-the-badge)](https://twitter.com/ASFStreamPark)
 
-**[Website](https://streampark.apache.org)**&nbsp;&nbsp;|&nbsp;&nbsp;
-**[Official Documentation](https://streampark.apache.org/docs/get-started/intro)**&nbsp;&nbsp;|&nbsp;&nbsp;
-**[FAQ](https://github.com/apache/streampark/issues/507)**
 
 ![](https://streampark.apache.org/image/dashboard-preview.png)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,4 +20,3 @@ docker-compose up -d
 
 http://localhost:10000
 
-#### [more detail](https://streampark.apache.org/docs/get-started/docker-deployment)

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/util/PathUtils.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/base/util/PathUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.console.base.util;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Filesystem path containment utilities.
+ *
+ * <p>All checks resolve the canonical (absolute, normalized, symlink-resolved) paths before
+ * comparison, so the supplied name is always confined to the expected directory.
+ */
+public final class PathUtils {
+
+  private PathUtils() {}
+
+  /**
+   * Returns {@code true} only when the canonical path of {@code child} is strictly located
+   * somewhere <em>inside</em> {@code parent} (at any depth). A {@code child} that equals {@code
+   * parent} is NOT considered a descendant.
+   *
+   * @param parent the allowed root directory
+   * @param child the path to check
+   * @return {@code true} if {@code child} is strictly under {@code parent}
+   * @throws IOException if canonical path resolution fails
+   */
+  public static boolean isDescendantPath(File parent, File child) throws IOException {
+    String parentPath = parent.getCanonicalPath();
+    String childPath = child.getCanonicalPath();
+    return childPath.startsWith(parentPath.concat(File.separator));
+  }
+
+  /**
+   * Returns {@code true} only when the canonical parent directory of {@code child} is exactly
+   * {@code parent}, i.e. {@code child} is a <em>direct</em> (first-level) entry of {@code parent}.
+   * This is stricter than {@link #isDescendantPath(File, File)} and is used to confine a supplied
+   * name (e.g. a module archive) to a single level under the expected directory.
+   *
+   * @param parent the allowed root directory
+   * @param child the path to check
+   * @return {@code true} if {@code child} sits directly under {@code parent}
+   * @throws IOException if canonical path resolution fails
+   */
+  public static boolean isDirectChildPath(File parent, File child) throws IOException {
+    File childParent = child.getCanonicalFile().getParentFile();
+    return childParent != null && parent.getCanonicalFile().equals(childParent.getCanonicalFile());
+  }
+}

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/ApplicationController.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/controller/ApplicationController.java
@@ -17,7 +17,6 @@
 
 package org.apache.streampark.console.core.controller;
 
-import org.apache.streampark.common.util.Utils;
 import org.apache.streampark.common.util.YarnUtils;
 import org.apache.streampark.console.base.domain.RestRequest;
 import org.apache.streampark.console.base.domain.RestResponse;
@@ -43,7 +42,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
@@ -238,17 +236,6 @@ public class ApplicationController {
   public RestResponse deleteBak(ApplicationBackUp backUp) throws InternalException {
     Boolean deleted = backUpService.delete(backUp.getId());
     return RestResponse.success(deleted);
-  }
-
-  @PostMapping("checkjar")
-  public RestResponse checkjar(String jar) {
-    File file = new File(jar);
-    try {
-      Utils.checkJarFile(file.toURI().toURL());
-      return RestResponse.success(true);
-    } catch (IOException e) {
-      return RestResponse.success(file).message(e.getLocalizedMessage());
-    }
   }
 
   @PostMapping("upload")

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ApplicationServiceImpl.java
@@ -42,6 +42,7 @@ import org.apache.streampark.console.base.exception.ApplicationException;
 import org.apache.streampark.console.base.mybatis.pager.MybatisPager;
 import org.apache.streampark.console.base.util.CommonUtils;
 import org.apache.streampark.console.base.util.ObjectUtils;
+import org.apache.streampark.console.base.util.PathUtils;
 import org.apache.streampark.console.base.util.WebUtils;
 import org.apache.streampark.console.core.bean.AppControl;
 import org.apache.streampark.console.core.bean.MavenDependency;
@@ -1243,31 +1244,22 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
         new File(StringUtils.removeEnd(moduleArchive.getAbsolutePath(), ".tar.gz"))
             .getCanonicalFile();
     ApiAlertException.throwIfFalse(
-        isDirectChildPath(projectDistHome, moduleArchive), "Invalid module.");
+        PathUtils.isDirectChildPath(projectDistHome, moduleArchive), "Invalid module.");
     ApiAlertException.throwIfFalse(
-        isDirectChildPath(projectDistHome, moduleHome), "Invalid module.");
+        PathUtils.isDirectChildPath(projectDistHome, moduleHome), "Invalid module.");
     ApiAlertException.throwIfFalse(moduleHome.isDirectory(), "Invalid module.");
 
     File confHome = new File(moduleHome, "conf").getCanonicalFile();
-    ApiAlertException.throwIfFalse(isDescendantPath(moduleHome, confHome), "Invalid config.");
+    ApiAlertException.throwIfFalse(
+        PathUtils.isDescendantPath(moduleHome, confHome), "Invalid config.");
     ApiAlertException.throwIfFalse(confHome.isDirectory(), "Invalid config.");
 
     File configFile = new File(application.getConfig()).getCanonicalFile();
 
     ApiAlertException.throwIfFalse(configFile.isFile(), "Invalid config.");
-    ApiAlertException.throwIfFalse(isDescendantPath(confHome, configFile), "Invalid config.");
+    ApiAlertException.throwIfFalse(
+        PathUtils.isDescendantPath(confHome, configFile), "Invalid config.");
     return configFile;
-  }
-
-  private boolean isDescendantPath(File parent, File child) throws IOException {
-    String parentPath = parent.getCanonicalPath();
-    String childPath = child.getCanonicalPath();
-    return childPath.startsWith(parentPath.concat(File.separator));
-  }
-
-  private boolean isDirectChildPath(File parent, File child) throws IOException {
-    File childParent = child.getCanonicalFile().getParentFile();
-    return childParent != null && parent.getCanonicalFile().equals(childParent.getCanonicalFile());
   }
 
   @Override

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ProjectServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/ProjectServiceImpl.java
@@ -34,6 +34,7 @@ import org.apache.streampark.console.base.util.FileUtils;
 import org.apache.streampark.console.base.util.GZipUtils;
 import org.apache.streampark.console.base.util.GitUtils;
 import org.apache.streampark.console.base.util.ObjectUtils;
+import org.apache.streampark.console.base.util.PathUtils;
 import org.apache.streampark.console.core.entity.Application;
 import org.apache.streampark.console.core.entity.Project;
 import org.apache.streampark.console.core.enums.BuildState;
@@ -45,6 +46,7 @@ import org.apache.streampark.console.core.service.ProjectService;
 import org.apache.streampark.console.core.task.FlinkAppHttpWatcher;
 import org.apache.streampark.console.core.task.ProjectBuildTask;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.MemorySize;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
@@ -270,9 +272,7 @@ public class ProjectServiceImpl extends ServiceImpl<ProjectMapper, Project>
   @Override
   public List<String> jars(Project project) {
     List<String> list = new ArrayList<>(0);
-    ApiAlertException.throwIfNull(
-        project.getModule(), "Project module can't be null, please check.");
-    File apps = new File(project.getDistHome(), project.getModule());
+    File apps = resolveModuleDir(project);
     for (File file : Objects.requireNonNull(apps.listFiles())) {
       if (file.getName().endsWith(".jar")) {
         list.add(file.getName());
@@ -283,6 +283,8 @@ public class ProjectServiceImpl extends ServiceImpl<ProjectMapper, Project>
 
   @Override
   public String getAppConfPath(Long id, String module) {
+    ApiAlertException.throwIfTrue(StringUtils.isBlank(module), "Invalid module.");
+    ApiAlertException.throwIfTrue(StringUtils.containsAny(module, '/', '\\'), "Invalid module.");
     Project project = getById(id);
     File appHome = project.getDistHome();
     File[] files = appHome.listFiles();
@@ -365,8 +367,10 @@ public class ProjectServiceImpl extends ServiceImpl<ProjectMapper, Project>
 
   @Override
   public List<Map<String, Object>> listConf(Project project) {
+    // Validate the module name BEFORE entering the try-block, so an invalid name is rejected
+    // with ApiAlertException instead of being swallowed by the file-operation catch below.
+    File file = resolveModuleDir(project);
     try {
-      File file = new File(project.getDistHome(), project.getModule());
       File unzipFile = new File(file.getAbsolutePath().replaceAll(".tar.gz", ""));
       if (!unzipFile.exists()) {
         GZipUtils.decompress(file.getAbsolutePath(), file.getParentFile().getAbsolutePath());
@@ -383,6 +387,29 @@ public class ProjectServiceImpl extends ServiceImpl<ProjectMapper, Project>
       log.error(e.getMessage());
     }
     return null;
+  }
+
+  /**
+   * Resolves the module directory/file after validating that the module name is a single-level
+   * entry located directly under the project distribution home.
+   *
+   * @param project the project whose module directory to resolve
+   * @return the canonical module file
+   */
+  private File resolveModuleDir(Project project) {
+    ApiAlertException.throwIfTrue(
+        StringUtils.isBlank(project.getModule()), "Project module can't be null, please check.");
+    ApiAlertException.throwIfTrue(
+        StringUtils.containsAny(project.getModule(), '/', '\\'), "Invalid module.");
+    try {
+      File projectDistHome = project.getDistHome().getCanonicalFile();
+      File moduleDir = new File(projectDistHome, project.getModule()).getCanonicalFile();
+      ApiAlertException.throwIfFalse(
+          PathUtils.isDirectChildPath(projectDistHome, moduleDir), "Invalid module.");
+      return moduleDir;
+    } catch (IOException e) {
+      throw new ApiAlertException("Invalid module.", e);
+    }
   }
 
   private void eachFile(File file, List<Map<String, Object>> list, Boolean isRoot) {

--- a/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/impl/ProjectServiceImplTest.java
+++ b/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/service/impl/ProjectServiceImplTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.console.core.service.impl;
+
+import org.apache.streampark.console.base.exception.ApiAlertException;
+import org.apache.streampark.console.core.entity.Project;
+import org.apache.streampark.console.core.mapper.ProjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ProjectServiceImpl} module-name validation on the {@code jars}, {@code
+ * listConf} and {@code getAppConfPath} methods.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceImplTest {
+
+  @Mock private ProjectMapper projectMapper;
+
+  private final ProjectServiceImpl projectService = new ProjectServiceImpl();
+
+  @TempDir private Path tempDir;
+
+  @BeforeEach
+  void setUp() {
+    // ServiceImpl#getById delegates to baseMapper.selectById(...).
+    ReflectionTestUtils.setField(projectService, "baseMapper", projectMapper);
+  }
+
+  @Test
+  void jarsShouldListJarFilesUnderProjectModule() throws Exception {
+    Path distHome = Files.createDirectory(tempDir.resolve("dist"));
+    Path moduleDir = Files.createDirectory(distHome.resolve("app"));
+    Files.createFile(moduleDir.resolve("foo.jar"));
+    Files.createFile(moduleDir.resolve("README.txt"));
+
+    List<String> jars = projectService.jars(project(1L, distHome, "app"));
+
+    // Only direct children ending with .jar are returned.
+    assertThat(jars).containsExactly("foo.jar");
+  }
+
+  @Test
+  void jarsShouldRejectRelativeModule() throws Exception {
+    Files.createDirectories(tempDir.resolve("outside"));
+
+    assertThatThrownBy(() -> projectService.jars(project(1L, tempDir, "../outside")))
+        .isInstanceOf(ApiAlertException.class)
+        .hasMessage("Invalid module.");
+  }
+
+  @Test
+  void jarsShouldRejectModuleWithPathSeparator() throws Exception {
+    assertThatThrownBy(() -> projectService.jars(project(1L, tempDir, "a/b")))
+        .isInstanceOf(ApiAlertException.class)
+        .hasMessage("Invalid module.");
+  }
+
+  @Test
+  void listConfShouldRejectRelativeModule() {
+    assertThatThrownBy(() -> projectService.listConf(project(1L, tempDir, "../../etc")))
+        .isInstanceOf(ApiAlertException.class)
+        .hasMessage("Invalid module.");
+  }
+
+  @Test
+  void getAppConfPathShouldRejectModuleWithPathSeparator() {
+    assertThatThrownBy(() -> projectService.getAppConfPath(1L, "../etc"))
+        .isInstanceOf(ApiAlertException.class)
+        .hasMessage("Invalid module.");
+  }
+
+  @Test
+  void getAppConfPathShouldRejectBlankModule() {
+    assertThatThrownBy(() -> projectService.getAppConfPath(1L, " "))
+        .isInstanceOf(ApiAlertException.class)
+        .hasMessage("Invalid module.");
+  }
+
+  @Test
+  void getAppConfPathShouldResolveValidModule() throws Exception {
+    Path distHome = Files.createDirectory(tempDir.resolve("dist"));
+    Files.createDirectories(distHome.resolve("app"));
+    when(projectMapper.selectById(1L)).thenReturn(project(1L, distHome, null));
+
+    String confPath = projectService.getAppConfPath(1L, "app");
+
+    assertThat(confPath).isEqualTo(distHome.resolve("app").toFile().getAbsolutePath());
+  }
+
+  private Project project(Long id, Path distHome, String module) {
+    return new Project() {
+      {
+        setId(id);
+        if (module != null) {
+          setModule(module);
+        }
+      }
+
+      @Override
+      public File getDistHome() {
+        return distHome.toFile();
+      }
+    };
+  }
+}


### PR DESCRIPTION
## What changes are in this PR?

This PR tightens input handling on a few project/application endpoints so that the resolved file path is always confined to the expected project directory.

### 1. Refactor: extract `PathUtils` (`72ef4919a`)
Move the `isDescendantPath` / `isDirectChildPath` canonical-path checks out of `ApplicationServiceImpl` (where they were `private`) into a shared `base/util/PathUtils` class so the same logic can be reused. Pure refactor, no behavior change.

### 2. Improve: validate module name (`6b8d60f90`)
- `ProjectServiceImpl.jars()` / `listConf()` / `getAppConfPath()`: validate the `module` name (reject blank values, path separators, and non-direct-child paths) before resolving it under the project distribution home, via the new `resolveModuleDir` helper that reuses `PathUtils`.
- `listConf`: the validation now runs **before** the file-operation `try` block so an invalid name is rejected explicitly instead of being swallowed by the catch.
- `ApplicationController`: remove the unused `checkjar` endpoint that had no callers.
- Add `ProjectServiceImplTest` covering module-name validation (relative-path rejection, separator rejection, valid-name acceptance).

## How was it tested?

- `./mvnw -pl streampark-console/streampark-console-service -am test -Dtest=MybatisPagerTest,ApplicationServiceImplTest,ProjectServiceImplTest`
- All 15 tests pass (`ProjectServiceImplTest` 7 + `ApplicationServiceImplTest` 6 + `MybatisPagerTest` 2).
- `spotless:apply` clean, checkstyle 0 violations.

## Checklist
- [x] Code follows the project's style (spotless + checkstyle clean)
- [x] Added/updated tests
- [x] Tests pass locally