### PR TITLE
[Flink] Fix shims classloader isolation and result serialization for Flink SQL verify

### DIFF
--- a/streampark-flink/streampark-flink-proxy/src/main/java/org/apache/streampark/flink/proxy/FlinkShimsProxy.java
+++ b/streampark-flink/streampark-flink-proxy/src/main/java/org/apache/streampark/flink/proxy/FlinkShimsProxy.java
@@ -60,6 +60,8 @@ public final class FlinkShimsProxy extends LoggerSupport {
 
     private static final String FLINK_SHIMS_PREFIX = "streampark-flink-shims_flink";
 
+    private static final String FLINK_SHIMS_BASE_PREFIX = "streampark-flink-shims-base";
+
     private static final List<String> PARENT_FIRST_PATTERNS = Collections.unmodifiableList(
         Arrays.asList(
             "java.",
@@ -196,6 +198,9 @@ public final class FlinkShimsProxy extends LoggerSupport {
         if (jarName.startsWith(FLINK_SHIMS_PREFIX)) {
             String prefixVer = FLINK_SHIMS_PREFIX + "-" + majorVersion + "_" + scalaVersion;
             return jarName.startsWith(prefixVer) ? "Include flink shims jar lib: " : null;
+        }
+        if (jarName.startsWith(FLINK_SHIMS_BASE_PREFIX)) {
+            return "Include flink shims base jar lib: ";
         }
         if (INCLUDE_PATTERN.matcher(jarName).matches()) {
             return "Include jar lib: ";

--- a/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/src/main/java/org/apache/streampark/flink/core/FlinkSqlValidationResult.java
+++ b/streampark-flink/streampark-flink-shims/streampark-flink-shims-base/src/main/java/org/apache/streampark/flink/core/FlinkSqlValidationResult.java
@@ -19,8 +19,12 @@ package org.apache.streampark.flink.core;
 
 import org.apache.streampark.common.enums.FlinkSqlValidationFailedType;
 
+import java.io.Serializable;
+
 /** Flink SQL validation result. */
-public class FlinkSqlValidationResult {
+public class FlinkSqlValidationResult implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     public final boolean success;
     public final FlinkSqlValidationFailedType failedType;


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #4479

Fixes two chained bugs that make `POST /flink/sql/verify` fail for every Flink version on `dev`:

1. `FlinkShimsProxy#matchShimIncludeReason()` never matched `streampark-flink-shims-base-*.jar`, so `FlinkSqlValidator` fell back to loading via the console's own `AppClassLoader` (no Calcite on its classpath) instead of the intended per-Flink-version `ChildFirstClassLoader`, causing `NoClassDefFoundError: org/apache/calcite/sql/validate/SqlConformance`.
2. `FlinkSqlValidationResult` never implemented `Serializable`, so once (1) is fixed, `FlinkShimsProxy#getObject()`'s cross-classloader `ObjectOutputStream` marshaling fails with `NotSerializableException` on every successful validation.

Both are regressions from #4461 (Scala→Java shims migration), which moved these classes into the newly split-out `streampark-flink-shims-base` module without preserving the classloader-inclusion behavior or `Serializable` semantics the Scala code had.

## Brief change log

- Add a `streampark-flink-shims-base` prefix match to `FlinkShimsProxy#matchShimIncludeReason()`, alongside the existing `streampark-flink-shims_flink<version>` match, so the base module loads child-first through the same per-version classloader that already resolves `flink-table-planner` from `$FLINK_HOME/lib`/`opt`.
- Add `implements Serializable` (+ `serialVersionUID`) to `FlinkSqlValidationResult`. All fields are `boolean`/`int`/`String`/enum, so this is a plain marker-interface change with a stable field layout.

## Verifying this change

Manually verified against a real Flink 2.2.1 standalone cluster (official binary distribution — `opt/flink-table-planner_2.12-2.2.1.jar` present, per the documented 1.15+ `table-planner-loader` isolation mechanism):

- Before this change: `POST /flink/sql/verify` against a batch `datagen → print` SQL statement fails 3/3 times with `NoClassDefFoundError: org/apache/calcite/sql/validate/SqlConformance` (reproduced against the unmodified `dev` build).
- After fix (1) alone: the `NoClassDefFoundError` is gone; verification now fails with `NotSerializableException: org.apache.streampark.flink.core.FlinkSqlValidationResult`.
- After both fixes: `POST /flink/sql/verify` against the same SQL statement returns `{"status":"success","code":"200","data":true}`.

`./mvnw -pl streampark-flink/streampark-flink-proxy,streampark-flink/streampark-flink-shims/streampark-flink-shims-base clean compile checkstyle:check spotless:check` passes with 0 violations.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- Anything that affects deployment: no
- The persistence of application state: no
- The direction of network connections: no
- Anything that affects any api: no (fixes a broken existing API endpoint, no signature/contract change)
