### PR TITLE
[Console] Fix streampark-flink-sqlclient artifactId mismatch in assembly packaging and jar lookup

### DIFF
--- a/streampark-console/streampark-console-service/src/main/assembly/assembly.xml
+++ b/streampark-console/streampark-console-service/src/main/assembly/assembly.xml
@@ -30,7 +30,7 @@
             <useProjectArtifact>true</useProjectArtifact>
             <outputDirectory>lib</outputDirectory>
             <excludes>
-                <exclude>org.apache.streampark:streampark-flink-sqlclient_${scala.binary.version}</exclude>
+                <exclude>org.apache.streampark:streampark-flink-sqlclient</exclude>
                 <exclude>org.apache.streampark:streampark-spark-sqlclient_${scala.binary.version}</exclude>
                 <exclude>javax.servlet:servlet-api</exclude>
             </excludes>
@@ -38,7 +38,7 @@
         <dependencySet>
             <outputDirectory>client</outputDirectory>
             <includes>
-                <include>org.apache.streampark:streampark-flink-sqlclient_${scala.binary.version}</include>
+                <include>org.apache.streampark:streampark-flink-sqlclient</include>
                 <include>org.apache.streampark:streampark-spark-sqlclient_${scala.binary.version}</include>
             </includes>
         </dependencySet>

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/util/ServiceHelper.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/util/ServiceHelper.java
@@ -64,7 +64,7 @@ public class ServiceHelper {
             ApiAlertException.throwIfFalse(
                 localClient.exists(), "[StreamPark] " + localClient + " no exists. please check.");
 
-            String regex = String.format("streampark-flink-sqlclient_%s-.*\\.jar", flinkEnv.getScalaVersion());
+            String regex = "streampark-flink-sqlclient-.*\\.jar";
 
             List<String> jars = Arrays.stream(Objects.requireNonNull(localClient.list()))
                 .filter(x -> x.matches(regex))


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #4480

Fixes `POST /flink/pipe/build` failing with `can't found streampark-flink-sqlclient jar in .../client` for every Flink SQL application.

#4462 dropped the Scala cross-build suffix from `streampark-flink-sqlclient`'s artifactId, but two other places that reference the old, suffixed coordinate were never updated to match:

1. `streampark-console-service/src/main/assembly/assembly.xml`'s `dependencySet` `<exclude>`/`<include>` patterns (which decide whether the jar lands in `lib/` vs `client/`).
2. `ServiceHelper#getFlinkSqlClientJar()`'s filename-matching regex (used at runtime to locate the jar once the console is deployed).

Both fixes are required together — fixing only the assembly descriptor still leaves the console unable to find the (correctly placed) jar via the stale regex.

## Brief change log

- `assembly.xml`: change `org.apache.streampark:streampark-flink-sqlclient_${scala.binary.version}` → `org.apache.streampark:streampark-flink-sqlclient` in both the `lib/` exclude list and the `client/` include list. `streampark-spark-sqlclient` is untouched (still Scala cross-built, keeps its suffix).
- `ServiceHelper.java`: change the regex from `streampark-flink-sqlclient_%s-.*\.jar` (formatted with `flinkEnv.getScalaVersion()`) to the literal `streampark-flink-sqlclient-.*\.jar`.

## Verifying this change

Manually verified end-to-end against a real Flink 2.2.1 standalone cluster:

- Before this change: fresh `dist` build's `client/` only contains `streampark-spark-sqlclient_2.12-*.jar`; `streampark-flink-sqlclient-*.jar` incorrectly ends up in `lib/`. `POST /flink/pipe/build` fails immediately with `can't found streampark-flink-sqlclient jar in .../client`.
- After this change: rebuilt `dist` tarball's `client/` contains both `streampark-flink-sqlclient-3.0.0-SNAPSHOT.jar` and `streampark-spark-sqlclient_2.12-3.0.0-SNAPSHOT.jar`; startup log shows `EnvInitializer` successfully loading `streampark-flink-sqlclient-3.0.0-SNAPSHOT.jar to /data/streampark/workspace/client`; `POST /flink/pipe/build` proceeds past the jar-lookup step (see #4481 for the next bug it then hits, fixed separately in the PR for that issue).

`./mvnw -pl streampark-console/streampark-console-service clean compile checkstyle:check spotless:check` passes with 0 violations.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- Anything that affects deployment: yes — changes which jar lands in `client/` vs `lib/` in the distribution tarball (this is the bug fix itself: `streampark-flink-sqlclient` was landing in the wrong directory)
- The persistence of application state: no
- The direction of network connections: no
- Anything that affects any api: no
