### PR TITLE
[Flink] Fix BuildPipeline.execStep NPE on steps that return null

### DIFF
--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/BuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/BuildPipeline.java
@@ -110,7 +110,7 @@ public abstract class BuildPipeline extends LoggerSupport
         }
     }
 
-    protected <R> java.util.Optional<R> execStep(int seq, Callable<R> process) {
+    protected <R> R execStep(int seq, Callable<R> process) {
         try {
             curStep = seq;
             stepsStatus.put(
@@ -132,7 +132,7 @@ public abstract class BuildPipeline extends LoggerSupport
                     PipelineStepStatusEnum.SUCCESS, System.currentTimeMillis()));
             logInfo("Building pipeline step[" + seq + "/" + allSteps() + "] success");
             notifyStepChange();
-            return java.util.Optional.of(result);
+            return result;
         } catch (Exception cause) {
             stepsStatus.put(
                 seq,
@@ -148,7 +148,7 @@ public abstract class BuildPipeline extends LoggerSupport
                     + "] failure => "
                     + pipeType().getSteps().get(seq));
             notifyStepChange();
-            return java.util.Optional.empty();
+            throw pipelineException();
         }
     }
 
@@ -275,8 +275,7 @@ public abstract class BuildPipeline extends LoggerSupport
                 }
                 logInfo("Recreate building workspace: " + yarnProvidedPath);
                 return null;
-            })
-                .orElseThrow(this::pipelineException);
+            });
 
         List<String> mavenJars =
             execStep(
@@ -290,8 +289,7 @@ public abstract class BuildPipeline extends LoggerSupport
                         mavenArts.stream().map(File::getAbsolutePath).collect(Collectors.toList());
                     paths.addAll(dependencyInfo.extJarLibs());
                     return paths;
-                })
-                    .orElseThrow(this::pipelineException);
+                });
 
         execStep(
             3,
@@ -301,8 +299,7 @@ public abstract class BuildPipeline extends LoggerSupport
                     YarnJarUploader.uploadJarToHdfsOrLfs(FsOperator.hdfs(), jar, yarnProvidedPath);
                 }
                 return null;
-            })
-                .orElseThrow(this::pipelineException);
+            });
     }
 
     /** intercept snapshot */

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/AbstractK8sApplicationBuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/AbstractK8sApplicationBuildPipeline.java
@@ -65,8 +65,7 @@ abstract class AbstractK8sApplicationBuildPipeline extends BuildPipeline {
                     this::logInfo,
                     checkLocalImageFirst);
                 return null;
-            })
-                .orElseThrow(this::pipelineException);
+            });
 
         execStep(
             6,
@@ -79,8 +78,7 @@ abstract class AbstractK8sApplicationBuildPipeline extends BuildPipeline {
                     dockerProcessWatcher,
                     this::logInfo);
                 return null;
-            })
-                .orElseThrow(this::pipelineException);
+            });
 
         execStep(
             7,
@@ -88,8 +86,7 @@ abstract class AbstractK8sApplicationBuildPipeline extends BuildPipeline {
                 K8sDockerBuildSupport.pushImage(
                     dockerConf, pushImageTag, dockerProcess, dockerProcessWatcher, this::logInfo);
                 return null;
-            })
-                .orElseThrow(this::pipelineException);
+            });
     }
 
     protected Map<String, String> preparePodTemplateStep(
@@ -112,7 +109,6 @@ abstract class AbstractK8sApplicationBuildPipeline extends BuildPipeline {
                         + " podTemplates: "
                         + String.join(",", podTemplateFiles.values()));
                 return podTemplateFiles;
-            })
-                .orElseThrow(this::pipelineException);
+            });
     }
 }

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkK8sApplicationBuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkK8sApplicationBuildPipeline.java
@@ -70,8 +70,7 @@ public class FlinkK8sApplicationBuildPipeline extends AbstractK8sApplicationBuil
                     LfsOperator.mkCleanDirs(workspace);
                     logInfo("Recreate building workspace: " + workspace);
                     return workspace;
-                })
-                    .orElseThrow(this::pipelineException);
+                });
 
         Map<String, String> podTemplatePaths =
             preparePodTemplateStep(
@@ -94,8 +93,7 @@ public class FlinkK8sApplicationBuildPipeline extends AbstractK8sApplicationBuil
                             shadedJarOutputPath);
                     logInfo("Output shaded flink job jar: " + jar.getAbsolutePath());
                     return jar;
-                })
-                    .orElseThrow(this::pipelineException);
+                });
         final Set<String> extJarLibs = request.dependencyInfo().extJarLibs();
 
         Object[] dockerResult =
@@ -125,8 +123,7 @@ public class FlinkK8sApplicationBuildPipeline extends AbstractK8sApplicationBuil
                             + ", content: \n"
                             + template.offerDockerfileContent());
                     return new Object[]{dockerFile, template};
-                })
-                    .orElseThrow(this::pipelineException);
+                });
         File dockerfile = (File) dockerResult[0];
         FlinkDockerfileTemplateTrait dockerFileTemplate = (FlinkDockerfileTemplateTrait) dockerResult[1];
 
@@ -154,8 +151,7 @@ public class FlinkK8sApplicationBuildPipeline extends AbstractK8sApplicationBuil
                             buildWorkspace, request.ingressTemplate());
                     logInfo("Export flink ingress: " + ingressOutputPath);
                     return ingressOutputPath;
-                })
-                    .orElseThrow(this::pipelineException);
+                });
         }
 
         return new DockerImageBuildResponse(

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkK8sSessionBuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkK8sSessionBuildPipeline.java
@@ -60,10 +60,7 @@ public class FlinkK8sSessionBuildPipeline extends BuildPipeline {
                     LfsOperator.mkCleanDirs(workspace);
                     logInfo("Recreate building workspace: " + workspace);
                     return workspace;
-                })
-                    .orElseThrow(() -> {
-                        throw pipelineException();
-                    });
+                });
 
         File shadedJar =
             execStep(
@@ -76,10 +73,7 @@ public class FlinkK8sSessionBuildPipeline extends BuildPipeline {
                             request.getShadedJarPath(buildWorkspace));
                     logInfo("Output shaded flink job jar: " + output.getAbsolutePath());
                     return output;
-                })
-                    .orElseThrow(() -> {
-                        throw pipelineException();
-                    });
+                });
 
         return new ShadedBuildResponse(buildWorkspace, shadedJar.getAbsolutePath());
     }

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkRemoteBuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkRemoteBuildPipeline.java
@@ -60,8 +60,6 @@ public class FlinkRemoteBuildPipeline extends BuildPipeline {
             LfsOperator.mkCleanDirs(request.workspace());
             logInfo("Recreate building workspace: " + request.workspace());
             return null;
-        }).orElseThrow(() -> {
-            throw pipelineException();
         });
 
         File shadedJar =
@@ -78,10 +76,7 @@ public class FlinkRemoteBuildPipeline extends BuildPipeline {
                         return output;
                     }
                     return new File(request.customFlinkUserJar());
-                })
-                    .orElseThrow(() -> {
-                        throw pipelineException();
-                    });
+                });
 
         List<String> mavenJars =
             execStep(
@@ -98,10 +93,7 @@ public class FlinkRemoteBuildPipeline extends BuildPipeline {
                         return paths;
                     }
                     return Collections.<String>emptyList();
-                })
-                    .orElseThrow(() -> {
-                        throw pipelineException();
-                    });
+                });
 
         execStep(
             4,
@@ -118,10 +110,7 @@ public class FlinkRemoteBuildPipeline extends BuildPipeline {
                     }
                 }
                 return null;
-            })
-                .orElseThrow(() -> {
-                    throw pipelineException();
-                });
+            });
 
         return new ShadedBuildResponse(request.workspace(), shadedJar.getAbsolutePath());
     }

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/SparkK8sApplicationBuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/SparkK8sApplicationBuildPipeline.java
@@ -63,8 +63,7 @@ public class SparkK8sApplicationBuildPipeline extends AbstractK8sApplicationBuil
                     LfsOperator.mkCleanDirs(workspace);
                     logInfo("Recreate building workspace: " + workspace);
                     return workspace;
-                })
-                    .orElseThrow(this::pipelineException);
+                });
 
         Map<String, String> podTemplatePaths =
             preparePodTemplateStep(
@@ -84,8 +83,7 @@ public class SparkK8sApplicationBuildPipeline extends AbstractK8sApplicationBuil
                     LfsOperator.copy(request.mainJar(), path);
                     logInfo("Prepared spark job jar: " + path);
                     return path;
-                })
-                    .orElseThrow(this::pipelineException);
+                });
         final Set<String> extJarLibs = new HashSet<>();
 
         Object[] dockerResult =
@@ -115,8 +113,7 @@ public class SparkK8sApplicationBuildPipeline extends AbstractK8sApplicationBuil
                             + ", content: \n"
                             + template.offerDockerfileContent());
                     return new Object[]{dockerFile, template};
-                })
-                    .orElseThrow(this::pipelineException);
+                });
         File dockerfile = (File) dockerResult[0];
         SparkDockerfileTemplateTrait dockerFileTemplate = (SparkDockerfileTemplateTrait) dockerResult[1];
 


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #4481

Fixes `BuildPipeline#execStep()` throwing `NullPointerException` whenever a pipeline step's `Callable` legitimately returns `null` — which is the normal case for steps that only perform a side effect (e.g. "create/clean the build workspace") and have nothing meaningful to hand to the next step. This breaks the build/release pipeline for a Flink SQL application (and, per the ~20 affected call sites, potentially every deploy mode) at its very first step.

## Brief change log

- `BuildPipeline#execStep()`: return `R` directly instead of `Optional<R>`, and throw `pipelineException()` directly from the `catch` block on failure, instead of returning `Optional.empty()` for the caller to detect via `.orElseThrow(...)`. This removes the null ambiguity entirely — Java `Optional` cannot distinguish "empty because the step failed" from "empty because it succeeded with a `null` value," which is exactly what made a one-line `Optional.of` → `Optional.ofNullable` swap insufficient (it would just make `.orElseThrow()` mis-fire on every successful null-returning step instead of crashing at `Optional.of`).
- Drop the now-redundant `.orElseThrow(() -> pipelineException())` / `.orElseThrow(this::pipelineException)` at all ~20 call sites: `BuildPipeline#runYarnSqlBuildSteps`, `FlinkRemoteBuildPipeline`, `FlinkK8sSessionBuildPipeline`, `AbstractK8sApplicationBuildPipeline`, `FlinkK8sApplicationBuildPipeline`, `SparkK8sApplicationBuildPipeline`.

No caller had extra logic in its `orElseThrow` lambda beyond `throw pipelineException();` — every occurrence checked and removed identically.

## Verifying this change

Manually verified against a real Flink 2.2.1 standalone cluster:

- Before this change: `POST /flink/pipe/build` for a Flink SQL application always fails at step 1/2 ("Create building workspace") with `NullPointerException` at `Optional.of(null)`, even though the workspace directory is genuinely created on disk. The failure is invisible via the REST API (`hasError: false`, `errorSummary: null`) and only shows up in raw stdout (`streampark.out`), not the console's own error log — because the exception is thrown from a background thread pool task before `GlobalExceptionHandler` is ever involved.
- After this change: `POST /flink/pipe/build` for the same application completes with `pipeStatus: SUCCESS` for both steps, and produces a real 6.2 MB shaded jar at `workspace/workspace/<appId>/streampark-flinkjob_<jobName>.jar`.

`./mvnw -pl streampark-flink/streampark-flink-packer,streampark-console/streampark-console-service -am clean compile checkstyle:check spotless:check` passes with 0 violations across all touched modules.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- Anything that affects deployment: no
- The persistence of application state: no
- The direction of network connections: no
- Anything that affects any api: no (internal `BuildPipeline` contract used only within `streampark-flink-packer` and its console caller; `execStep`/`runYarnSqlBuildSteps` are `protected`, not part of any public/external API)
