### PR TITLE
[Build] Allow the legacy SecurityManager for FlinkClient#submit on JDK 18+

### DIFF
--- a/streampark-console/streampark-console-service/src/main/assembly/bin/jvm_opts.sh
+++ b/streampark-console/streampark-console-service/src/main/assembly/bin/jvm_opts.sh
@@ -27,3 +27,9 @@
 # Required for dynamic classpath (ClassLoaderUtils) on JDK 9+. Ignored on JDK 8.
 --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
 --add-opens jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED
+
+# Required for FlinkClient#submit's ExitSecurityManager (used to intercept System.exit()
+# calls made by the Flink CLI during in-process job submission) on JDK 18+, where
+# System.setSecurityManager() throws UnsupportedOperationException unless explicitly
+# allowed (JEP 411). Ignored on JDK 17 and earlier.
+-Djava.security.manager=allow


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #4482

Fixes every `POST /flink/app/start` failing silently on JDK 18+ with `UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release`, thrown from `FlinkClient#submit()`'s `System.setSecurityManager(new ExitSecurityManager())` call.

## Brief change log

- Add `-Djava.security.manager=allow` to `jvm_opts.sh`, next to the existing JDK 9+/17+ compatibility flags (`--add-opens ...`) already there for `ClassLoaderUtils`. This re-enables dynamically setting a `SecurityManager` at runtime, which [JEP 411](https://openjdk.org/jeps/411) disabled by default starting Java 18.

## Verifying this change

Manually verified against a real Flink 2.2.1 standalone cluster, JDK 21 console:

- Before this change: `POST /flink/app/start` returns HTTP 200 (accepted), but the application flips to `FAILED` ~5s later; `POST /flink/app/opt_log` shows `UnsupportedOperationException` at `System.setSecurityManager`, invisible in `logs/error.*.log` and `logs/streampark.out`.
- After this change: the `UnsupportedOperationException` is gone; job submission proceeds past `FlinkClient#submit()`'s security manager setup (submission then hits a separate, unrelated classloading issue tracked in #4483, not fixed by this PR).

This is a plain JVM system property — harmless and effectively a no-op on JDK 8-17 (SecurityManager is either unaffected or already dynamically settable there), required on JDK 18+.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- Anything that affects deployment: yes — adds one JVM flag to the console's own startup options (`jvm_opts.sh`), same category as the existing `--add-opens` flags
- The persistence of application state: no
- The direction of network connections: no
- Anything that affects any api: no
