### PR TITLE
[Flink] Fix Flink SQL job submission failures on the client path

### DIFF
--- a/streampark-common/src/main/java/org/apache/streampark/common/util/ClassLoaderUtils.java
+++ b/streampark-common/src/main/java/org/apache/streampark/common/util/ClassLoaderUtils.java
@@ -39,11 +39,12 @@ public final class ClassLoaderUtils {
     }
 
     public static <R> R runAsClassLoader(ClassLoader targetClassLoader, Supplier<R> supplier) {
+        ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(targetClassLoader);
             return supplier.get();
         } finally {
-            Thread.currentThread().setContextClassLoader(ORIGINAL_CLASS_LOADER);
+            Thread.currentThread().setContextClassLoader(previousClassLoader);
         }
     }
 

--- a/streampark-console/streampark-console-service/pom.xml
+++ b/streampark-console/streampark-console-service/pom.xml
@@ -372,6 +372,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.streampark</groupId>
+            <artifactId>streampark-flink-shims-base-v2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Ensure all Flink shims are built when console-service is built with -am -->
         <dependency>
             <groupId>org.apache.streampark</groupId>

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-api/src/main/java/org/apache/streampark/flink/client/bean/SubmitRequest.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-api/src/main/java/org/apache/streampark/flink/client/bean/SubmitRequest.java
@@ -296,7 +296,8 @@ public class SubmitRequest implements Serializable {
             } else {
                 checkBuildResult();
                 ShadedBuildResponse shadedBuildResult = buildResult.as(ShadedBuildResponse.class);
-                userJarFile = new File(shadedBuildResult.shadedJarPath());
+                String shadedJarPath = shadedBuildResult.shadedJarPath();
+                userJarFile = shadedJarPath == null ? null : new File(shadedJarPath);
             }
         }
         return userJarFile;

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/impl/RemoteClient.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/impl/RemoteClient.java
@@ -17,6 +17,7 @@
 
 package org.apache.streampark.flink.client.impl;
 
+import org.apache.streampark.common.util.ClassLoaderUtils;
 import org.apache.streampark.flink.client.bean.CancelRequest;
 import org.apache.streampark.flink.client.bean.CancelResponse;
 import org.apache.streampark.flink.client.bean.SavepointRequestTrait;
@@ -165,13 +166,25 @@ public final class RemoteClient extends FlinkClientTrait {
 
     private Tuple2<StandaloneClusterId, StandaloneClusterDescriptor> getStandAloneClusterDescriptor(
                                                                                                     Configuration flinkConfig) {
-        DefaultClusterClientServiceLoader serviceLoader = new DefaultClusterClientServiceLoader();
-        ClusterClientFactory<StandaloneClusterId> clientFactory =
-            serviceLoader.getClusterClientFactory(flinkConfig);
-        StandaloneClusterId standaloneClusterId = clientFactory.getClusterId(flinkConfig);
-        StandaloneClusterDescriptor standaloneClusterDescriptor =
-            (StandaloneClusterDescriptor) clientFactory.createClusterDescriptor(flinkConfig);
-        return new Tuple2<>(standaloneClusterId, standaloneClusterDescriptor);
+        // DefaultClusterClientServiceLoader is bound to the Flink version bundled with this module
+        // (loaded by this class's own classloader), but the calling thread's context classloader may
+        // currently be a target-version shims classloader (see FlinkShimsProxy). Its internal
+        // ServiceLoader.load(ClusterClientFactory.class) resolves providers via the context
+        // classloader, so leaving it as the shims classloader here would load a ClusterClientFactory
+        // implementation from a different Flink version than the interface bundled here, throwing
+        // ServiceConfigurationError ("not a subtype"). Force it back to this class's own classloader
+        // for the duration of this call.
+        return ClassLoaderUtils.runAsClassLoader(
+            RemoteClient.class.getClassLoader(),
+            () -> {
+                DefaultClusterClientServiceLoader serviceLoader = new DefaultClusterClientServiceLoader();
+                ClusterClientFactory<StandaloneClusterId> clientFactory =
+                    serviceLoader.getClusterClientFactory(flinkConfig);
+                StandaloneClusterId standaloneClusterId = clientFactory.getClusterId(flinkConfig);
+                StandaloneClusterDescriptor standaloneClusterDescriptor =
+                    (StandaloneClusterDescriptor) clientFactory.createClusterDescriptor(flinkConfig);
+                return new Tuple2<>(standaloneClusterId, standaloneClusterDescriptor);
+            });
     }
 
     @FunctionalInterface

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/trait/FlinkClientTrait.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/trait/FlinkClientTrait.java
@@ -26,6 +26,7 @@ import org.apache.streampark.common.enums.FlinkJobType;
 import org.apache.streampark.common.enums.FlinkRestoreMode;
 import org.apache.streampark.common.fs.FsOperator;
 import org.apache.streampark.common.util.AssertUtils;
+import org.apache.streampark.common.util.ClassLoaderUtils;
 import org.apache.streampark.common.util.DeflaterUtils;
 import org.apache.streampark.common.util.ExceptionUtils;
 import org.apache.streampark.common.util.FlinkConfigurationUtils;
@@ -533,8 +534,18 @@ public abstract class FlinkClientTrait extends LoggerSupport {
             }
         } else {
             builder.setJarFile(jarFile);
-            // BUG: https://github.com/apache/streampark/issues/3761
-            // .setUserClassPaths(Lists.newArrayList(submitRequest.classPaths()))
+            if (submitRequest.jobType() == FlinkJobType.FLINK_SQL) {
+                // FLINK_SQL fat jar only bundles the SQL client + shims; it does not contain the
+                // target Flink version's own connector/runtime jars, so those must be added
+                // explicitly. Scoped to FLINK_SQL only, unlike the blanket disable from
+                // https://github.com/apache/streampark/issues/3761, which was never verified
+                // against this job type on REMOTE mode specifically. Note this does not help
+                // resolve org.apache.flink.* classes themselves: Flink's classloader always
+                // resolves that package parent-first, and PackagedProgram's parent is
+                // console's own bundled (baseline-version) flink-clients, not the target
+                // version, so those still fail when target and baseline Flink versions diverge.
+                builder.setUserClassPaths(Lists.newArrayList(submitRequest.classPaths()));
+            }
         }
 
         PackagedProgram packageProgram = builder.build();
@@ -587,7 +598,17 @@ public abstract class FlinkClientTrait extends LoggerSupport {
     List<CustomCommandLine> getCustomCommandLines(String flinkHome) {
         Configuration flinkDefaultConfiguration = getFlinkDefaultConfiguration(flinkHome);
         String confDir = flinkHome + "/conf";
-        return CliFrontend.loadCustomCommandLines(flinkDefaultConfiguration, confDir);
+        // CliFrontend/GenericCLI are bound to the Flink version bundled with this module (loaded by
+        // this class's own classloader), but the calling thread's context classloader may currently
+        // be a target-version shims classloader (see FlinkShimsProxy). GenericCLI's internal
+        // ServiceLoader.load(PipelineExecutorFactory.class) resolves providers via the context
+        // classloader, so leaving it as the shims classloader here would load a PipelineExecutorFactory
+        // implementation from a different Flink version than the interface bundled here, throwing
+        // ServiceConfigurationError ("not a subtype"). Force it back to this class's own classloader
+        // for the duration of this call.
+        return ClassLoaderUtils.runAsClassLoader(
+            FlinkClientTrait.class.getClassLoader(),
+            () -> CliFrontend.loadCustomCommandLines(flinkDefaultConfiguration, confDir));
     }
 
     public Integer getParallelism(SubmitRequest submitRequest) {

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/AbstractFlinkBuildResponse.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/AbstractFlinkBuildResponse.java
@@ -40,11 +40,13 @@ abstract class AbstractFlinkBuildResponse implements FlinkBuildResult, Serializa
     }
 
     @Override
+    @JsonProperty("workspacePath")
     public String workspacePath() {
         return workspacePath;
     }
 
     @Override
+    @JsonProperty("pass")
     public boolean pass() {
         return pass;
     }

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/DockerImageBuildResponse.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/DockerImageBuildResponse.java
@@ -52,14 +52,17 @@ public class DockerImageBuildResponse extends AbstractFlinkBuildResponse {
         this.dockerInnerMainJarPath = dockerInnerMainJarPath;
     }
 
+    @JsonProperty("flinkImageTag")
     public String flinkImageTag() {
         return flinkImageTag;
     }
 
+    @JsonProperty("podTemplatePaths")
     public Map<String, String> podTemplatePaths() {
         return podTemplatePaths;
     }
 
+    @JsonProperty("dockerInnerMainJarPath")
     public String dockerInnerMainJarPath() {
         return dockerInnerMainJarPath;
     }

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/K8sAppModeBuildResponse.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/K8sAppModeBuildResponse.java
@@ -44,14 +44,17 @@ public class K8sAppModeBuildResponse extends AbstractFlinkBuildResponse {
         this.extraLibJarPaths = extraLibJarPaths;
     }
 
+    @JsonProperty("flinkBaseImage")
     public String flinkBaseImage() {
         return flinkBaseImage;
     }
 
+    @JsonProperty("mainJarPath")
     public String mainJarPath() {
         return mainJarPath;
     }
 
+    @JsonProperty("extraLibJarPaths")
     public Set<String> extraLibJarPaths() {
         return extraLibJarPaths;
     }

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/ShadedBuildResponse.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/ShadedBuildResponse.java
@@ -37,6 +37,7 @@ public class ShadedBuildResponse extends AbstractFlinkBuildResponse {
     public ShadedBuildResponse() {
     }
 
+    @JsonProperty("shadedJarPath")
     public String shadedJarPath() {
         return shadedJarPath;
     }


### PR DESCRIPTION
## What is the purpose of the change

Six defects on the path that turns a saved Flink SQL application into a submitted job. They are independent of each other, but each one only becomes reachable after the previous is fixed, which is why they are together here — each was found by submitting a real Flink SQL job to a standalone cluster and fixing whatever failed next.

Closes #4483
Closes #4488
Closes #4489
Closes #4490

## Brief change log

1. **`ClassLoaderUtils.runAsClassLoader` restores the caller's own context classloader** (#4489). It previously restored a `static final` field captured at class-initialisation time — whichever thread first loaded the class. On pooled threads that silently installs an unrelated classloader and leaves it there. `ORIGINAL_CLASS_LOADER` stays, since `cloneClassLoader()` still uses it.

2. **`FlinkClientTrait.getCustomCommandLines` and `RemoteClient.getStandAloneClusterDescriptor` run under their own class's classloader** (#4483). Both call Flink classes bound to the Flink version bundled with this module, while the calling thread's context classloader is `FlinkShimsProxy`'s target-version shims classloader. Their internal `ServiceLoader` lookups therefore resolved providers from a different Flink version than the interfaces bundled here, throwing `ServiceConfigurationError: ... not a subtype`.

3. **Build-response getters carry `@JsonProperty`** (#4488). They do not follow JavaBean naming, so Jackson silently omitted them: every persisted build result lost `shadedJarPath`/`workspacePath`, and only `pass` appeared to survive — by the coincidence that its field default is already `true`. Method names are unchanged, so no caller is affected. The K8s and Docker build responses had the same defect and are fixed with it.

4. **`SubmitRequest.userJarFile()` tolerates a null `shadedJarPath`** instead of passing it to `new File(...)`.

5. **`streampark-console-service` depends on `streampark-flink-shims-base-v2`** (#4490), so `FlinkTableInitializerV2` reaches the console's `lib/`. Only the v1 module was declared, so every Flink 2.x SQL job failed with `NoClassDefFoundError`.

6. **`setUserClassPaths` is re-enabled for `FLINK_SQL` jobs only.** It was disabled wholesale for #3761, whose reported scenario is a different deploy mode; a SQL job needs its connector jars on the client classpath. Every other job type keeps the current behaviour.

## Verifying this change

- Verified by submitting real Flink SQL jobs to a standalone Flink cluster, one defect at a time: each fix was built, deployed, and confirmed to make its specific failure disappear before the next one was investigated.
- `ShadedBuildResponse` serialisation was checked by round-tripping it through a plain `ObjectMapper` in `jshell` against the built jar — `shadedJarPath` is absent from the JSON before the change and present after.
- `mvn install` over `streampark-common`, `streampark-flink-client-api`, `streampark-flink-client-core` and `streampark-flink-packer` passes, spotless/checkstyle/scalastyle included.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): **no**
- The public API: **no** (method names and signatures unchanged; only annotations and call-site classloader scoping)
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment: **yes** — `streampark-flink-shims-base-v2` is now packaged into the console distribution.

## Documentation

- Does this pull request introduce a new feature? **no**
