### PR TITLE
[Console] Fix four DTO/entity defects that break Spark and Flink SQL app management

### DIFF
--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/SparkApplication.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/SparkApplication.java
@@ -127,8 +127,8 @@ public class SparkApplication extends BaseEntity implements ApplicationEntitySup
     /** spark docker base image */
     private String k8sContainerImage;
 
-    /** k8s image pull policy */
-    private int k8sImagePullPolicy;
+    /** k8s image pull policy — nullable, matching t_spark_app.k8s_image_pull_policy */
+    private Integer k8sImagePullPolicy;
 
     /** k8s spark service account */
     private String k8sServiceAccount;

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/SparkEnv.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/SparkEnv.java
@@ -73,10 +73,11 @@ public class SparkEnv implements Serializable {
     public void doSetSparkConf() throws ApiDetailException {
         try {
             File yaml = new File(this.sparkHome.concat("/conf/spark-defaults.conf"));
-            if (yaml.exists()) {
-                String sparkConf = FileUtils.readFileToString(yaml, StandardCharsets.UTF_8);
-                this.sparkConf = DeflaterUtils.zipString(sparkConf);
-            }
+            // A stock Spark distribution ships only spark-defaults.conf.template, so an absent file
+            // is the normal case, not an error — but t_spark_env.spark_conf is NOT NULL, so it still
+            // has to be written as an empty conf rather than left null.
+            String sparkConf = yaml.exists() ? FileUtils.readFileToString(yaml, StandardCharsets.UTF_8) : "";
+            this.sparkConf = DeflaterUtils.zipString(sparkConf);
         } catch (Exception e) {
             throw new ApiDetailException(e);
         }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/enums/SparkAppStateEnum.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/enums/SparkAppStateEnum.java
@@ -78,6 +78,9 @@ public enum SparkAppStateEnum {
     }
 
     public static SparkAppStateEnum of(Integer state) {
+        if (state == null) {
+            return SparkAppStateEnum.OTHER;
+        }
         for (SparkAppStateEnum appState : values()) {
             if (appState.value == state) {
                 return appState;

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/request/flink/FlinkAppCreateRequest.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/request/flink/FlinkAppCreateRequest.java
@@ -54,6 +54,8 @@ public class FlinkAppCreateRequest implements Serializable {
 
     private String flinkSql;
 
+    private Long sqlId;
+
     @NotNull
     @ApiParam(description = "Application type", required = true)
     private Integer appType;


### PR DESCRIPTION
## What is the purpose of the change

Four small DTO/entity defects, each of which makes a normal UI operation fail outright on a clean install. They are unrelated to each other in cause but identical in shape — a field that does not line up between the request DTO, the entity, and the column — so they are grouped in one PR.

Closes #4491
Closes #4492
Closes #4493
Closes #4494

## Brief change log

1. **`FlinkAppCreateRequest` declares `sqlId`** (#4491). The frontend sends it and `updateFlinkSqlJob()` requires it, but the DTO had no such field, so `BeanUtils.copyProperties` skipped it and saving any already-started Flink SQL application failed with `Flink sql is null, update flink sql job failed.` `SparkAppCreateRequest` and `FlinkAppResponse` already declare it — this was a one-sided omission.

2. **`SparkAppStateEnum.of(Integer)` returns `OTHER` for null** (#4492). It compared with `appState.value == state`, which unboxes; `SparkAppListQueryRequest`'s scalar `state` is null for an unfiltered list, so `/spark/app/list` returned 500 for everyone. `FlinkAppStateEnum.getState(Integer)` has the same unboxing shape but nothing reaches it with a null today, so it is deliberately left alone here.

3. **`SparkEnv.doSetSparkConf()` stores an empty conf when the file is absent** (#4493). A stock Spark distribution ships only `spark-defaults.conf.template`, so `sparkConf` stayed null and the insert failed on `t_spark_env.spark_conf` (`NOT NULL`, no default) — no Spark home could be registered at all.

4. **`SparkApplication.k8sImagePullPolicy` is `Integer`** (#4494), matching its nullable column and the `Integer` in `SparkAppCreateRequest`. As a primitive it unboxed the null the Spark frontend never sends, so `/spark/app/create` returned 500 for every UI-created application.

## Verifying this change

- (1) and (2) were verified against a running console: the same update request goes from always-failing to succeeding, and `/spark/app/list` from 500 to 200.
- (3) was verified by the inverse — creating an empty `conf/spark-defaults.conf` in an otherwise stock Spark home makes registration succeed with the file's existence as the only changed variable.
- `mvn test` on `streampark-console-service` passes (93 tests, 0 failures).

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): **no**
- The public API: **yes, minor** — `FlinkAppCreateRequest` gains an optional `sqlId`, and `SparkApplication.getK8sImagePullPolicy()` now returns `Integer` rather than `int`.
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment: **no**

## Documentation

- Does this pull request introduce a new feature? **no**
