### PR TITLE
[Fix] Fix memory sizes config not taking effect in Yarn mode

### DIFF
--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/trait/FlinkClientTrait.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/trait/FlinkClientTrait.java
@@ -329,6 +329,7 @@ public abstract class FlinkClientTrait extends LoggerSupport {
         applyCheckpointDefaults(submitRequest, flinkConfig);
         applySavepointConfig(submitRequest, flinkConfig);
         applyEnvProperties(submitRequest, flinkConfig);
+        applyAppProperties(submitRequest, flinkConfig);
         return flinkConfig;
     }
 
@@ -452,6 +453,21 @@ public abstract class FlinkClientTrait extends LoggerSupport {
                 logInfo("env opts:  " + entry.getKey() + ": " + entry.getValue());
                 flinkConfig.setString(entry.getKey(), entry.getValue().toString());
             }
+        }
+    }
+
+    private void applyAppProperties(SubmitRequest submitRequest, Configuration flinkConfig) {
+        Map<String, String> appProperties = submitRequest.appProperties();
+        if (MapUtils.isEmpty(appProperties)) {
+            return;
+        }
+        for (Map.Entry<String, String> entry : appProperties.entrySet()) {
+            logInfo(
+                "appProperties: "
+                    + entry.getKey()
+                    + " : "
+                    + entry.getValue());
+            flinkConfig.setString(entry.getKey(), entry.getValue());
         }
     }
 

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/test/java/org/apache/streampark/flink/client/test/SubmitRequestTest.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/test/java/org/apache/streampark/flink/client/test/SubmitRequestTest.java
@@ -23,6 +23,7 @@ import org.apache.streampark.common.constants.Constants;
 import org.apache.streampark.common.enums.ApplicationType;
 import org.apache.streampark.common.enums.FlinkDeployMode;
 import org.apache.streampark.common.enums.FlinkJobType;
+import org.apache.streampark.common.util.DeflaterUtils;
 import org.apache.streampark.flink.client.bean.SubmitApplicationSpec;
 import org.apache.streampark.flink.client.bean.SubmitRequest;
 
@@ -132,6 +133,83 @@ class SubmitRequestTest {
     void allowNonRestoredStateShouldDefaultToFalse() {
         SubmitRequest request = createRequest(FlinkJobType.FLINK_JAR, null);
         assertThat(request.allowNonRestoredState()).isFalse();
+    }
+
+    @Test
+    void appPropertiesWithMemoryConfigFromYamlConf() {
+        String yamlContent =
+            "flink.property.jobmanager.memory.process.size: 2048m\n"
+                + "flink.property.taskmanager.memory.process.size: 4096m\n";
+        String appConf = "yaml://" + DeflaterUtils.zipString(yamlContent);
+        SubmitApplicationSpec application =
+            SubmitApplicationSpec.builder()
+                .jobType(FlinkJobType.FLINK_JAR)
+                .appConf(appConf)
+                .build();
+        SubmitRequest request =
+            new SubmitRequest(
+                FLINK_VERSION,
+                FlinkDeployMode.YARN_APPLICATION,
+                Collections.emptyMap(),
+                application,
+                null,
+                null,
+                null);
+
+        assertThat(request.appProperties())
+            .containsEntry("jobmanager.memory.process.size", "2048m")
+            .containsEntry("taskmanager.memory.process.size", "4096m");
+    }
+
+    @Test
+    void appPropertiesWithMemoryConfigFromJsonConf() {
+        String jmKey = ConfigKeys.KEY_FLINK_PROPERTY_PREFIX() + "jobmanager.memory.process.size";
+        String tmKey = ConfigKeys.KEY_FLINK_PROPERTY_PREFIX() + "taskmanager.memory.process.size";
+        String appConf = "json://{\"" + jmKey + "\":\"2g\",\"" + tmKey + "\":\"4g\"}";
+        SubmitApplicationSpec application =
+            SubmitApplicationSpec.builder()
+                .jobType(FlinkJobType.FLINK_JAR)
+                .appConf(appConf)
+                .build();
+        SubmitRequest request =
+            new SubmitRequest(
+                FLINK_VERSION,
+                FlinkDeployMode.YARN_APPLICATION,
+                Collections.emptyMap(),
+                application,
+                null,
+                null,
+                null);
+
+        assertThat(request.appProperties())
+            .containsEntry("jobmanager.memory.process.size", "2g")
+            .containsEntry("taskmanager.memory.process.size", "4g");
+    }
+
+    @Test
+    void appPropertiesWithMemoryConfigFromPropertiesConf() {
+        String propertiesContent =
+            "flink.property.jobmanager.memory.process.size=1024m\n"
+                + "flink.property.taskmanager.memory.process.size=2048m\n";
+        String appConf = "prop://" + DeflaterUtils.zipString(propertiesContent);
+        SubmitApplicationSpec application =
+            SubmitApplicationSpec.builder()
+                .jobType(FlinkJobType.FLINK_JAR)
+                .appConf(appConf)
+                .build();
+        SubmitRequest request =
+            new SubmitRequest(
+                FLINK_VERSION,
+                FlinkDeployMode.YARN_APPLICATION,
+                Collections.emptyMap(),
+                application,
+                null,
+                null,
+                null);
+
+        assertThat(request.appProperties())
+            .containsEntry("jobmanager.memory.process.size", "1024m")
+            .containsEntry("taskmanager.memory.process.size", "2048m");
     }
 
     private static SubmitRequest createRequest(FlinkJobType jobType, String appConf) {


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #3617: The memory sizes configuration in Application Conf (e.g., `jobmanager.memory.process.size`, `taskmanager.memory.process.size`) was not taking effect when submitting Flink jobs in Yarn mode.

## Root Cause

In `FlinkClientTrait.prepareConfig()`, the `appProperties()` from the Application Conf (parsed with `flink.property.` prefix) were never applied to the Flink configuration. While `submitRequest.properties()` (dynamic properties from the web UI) were correctly passed as `-D` flags via `buildCliArgs()`, the Application Conf properties were silently ignored.

## Fix

Added `applyAppProperties()` method in `FlinkClientTrait` that applies all `appProperties()` from the Application Conf to the Flink configuration. This method is called in `prepareConfig()` after `applyEnvProperties()`, ensuring that all Flink configuration properties set in the Application Conf are properly propagated to the submit request.

## Changes

- **streampark-flink-client-core**: Added `applyAppProperties()` method to `FlinkClientTrait` and called it in `prepareConfig()`
- **streampark-flink-client-core test**: Added 3 test cases for `SubmitRequestTest` covering memory config parsing from YAML, JSON, and Properties format Application Conf

## Verification

- All existing tests pass (12/12 in SubmitRequestTest)
- New tests cover memory configs in YAML, JSON, and Properties formats