### PR TITLE
[Flink] Fix REMOTE Session JobGraph submission for Flink 1.x/2.x SQL and uploaded JAR jobs

### DIFF
--- a/streampark-common/src/main/java/org/apache/streampark/common/util/DeflaterUtils.java
+++ b/streampark-common/src/main/java/org/apache/streampark/common/util/DeflaterUtils.java
@@ -53,7 +53,12 @@ public final class DeflaterUtils {
     }
 
     public static String unzipString(String zipString) {
-        byte[] decode = Base64.getDecoder().decode(zipString);
+        byte[] decode;
+        try {
+            decode = Base64.getDecoder().decode(zipString);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
         Inflater inflater = new Inflater();
         inflater.setInput(decode);
         byte[] bytes = new byte[256];
@@ -70,5 +75,28 @@ public final class DeflaterUtils {
             inflater.end();
         }
         return outputStream.toString();
+    }
+
+    /** Returns plain text, repeatedly decoding when the input is compressed multiple times. */
+    public static String toPlainText(String text) {
+        if (StringUtils.isBlank(text)) {
+            return text;
+        }
+        String current = text;
+        while (true) {
+            String decoded = unzipString(current);
+            if (decoded == null) {
+                return current;
+            }
+            current = decoded;
+        }
+    }
+
+    /** Stores SQL/conf text as a single compressed blob regardless of input encoding. */
+    public static String compressForStorage(String text) {
+        if (StringUtils.isBlank(text)) {
+            return "";
+        }
+        return zipString(toPlainText(text));
     }
 }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/assembler/FlinkApplicationAssembler.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/assembler/FlinkApplicationAssembler.java
@@ -86,9 +86,11 @@ public final class FlinkApplicationAssembler {
         FlinkApplication app = new FlinkApplication();
         app.setId(request.getId());
         app.setTeamId(request.getTeamId());
-        app.setRestoreOrTriggerSavepoint(request.getRestoreOrTriggerSavepoint());
+        app.setRestoreOrTriggerSavepoint(
+            request.getRestoreOrTriggerSavepoint() != null ? request.getRestoreOrTriggerSavepoint() : false);
         app.setSavepointPath(request.getSavepointPath());
-        app.setAllowNonRestored(request.getAllowNonRestored());
+        app.setAllowNonRestored(
+            request.getAllowNonRestored() != null ? request.getAllowNonRestored() : false);
         return app;
     }
 
@@ -99,9 +101,10 @@ public final class FlinkApplicationAssembler {
         FlinkApplication app = new FlinkApplication();
         app.setId(request.getId());
         app.setTeamId(request.getTeamId());
-        app.setRestoreOrTriggerSavepoint(request.getRestoreOrTriggerSavepoint());
-        app.setDrain(request.getDrain());
-        app.setNativeFormat(request.getNativeFormat());
+        app.setRestoreOrTriggerSavepoint(
+            request.getRestoreOrTriggerSavepoint() != null ? request.getRestoreOrTriggerSavepoint() : false);
+        app.setDrain(request.getDrain() != null ? request.getDrain() : false);
+        app.setNativeFormat(request.getNativeFormat() != null ? request.getNativeFormat() : false);
         app.setSavepointPath(request.getSavepointPath());
         return app;
     }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/FlinkSql.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/entity/FlinkSql.java
@@ -21,6 +21,8 @@ import org.apache.streampark.common.util.DeflaterUtils;
 import org.apache.streampark.console.core.bean.Dependency;
 import org.apache.streampark.console.core.enums.ChangeTypeEnum;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
@@ -85,7 +87,7 @@ public class FlinkSql {
     }
 
     public void decode() {
-        this.setSql(DeflaterUtils.unzipString(this.sql));
+        this.setSql(DeflaterUtils.toPlainText(this.sql));
     }
 
     public void setToApplication(FlinkApplication application) {
@@ -105,8 +107,17 @@ public class FlinkSql {
     }
 
     public ChangeTypeEnum checkChange(FlinkSql target) {
+        if (target == null) {
+            return ChangeTypeEnum.NONE;
+        }
         // 1) determine if sql statement has changed
-        boolean sqlDifference = !this.getSql().trim().equals(target.getSql().trim());
+        String sourceSql =
+            StringUtils.trimToEmpty(DeflaterUtils.toPlainText(this.getSql()));
+        String targetSql =
+            target.getSql() == null
+                ? sourceSql
+                : StringUtils.trimToEmpty(DeflaterUtils.toPlainText(target.getSql()));
+        boolean sqlDifference = !sourceSql.equals(targetSql);
         // 2) determine if dependency has changed
         Dependency thisDependency = Dependency.toDependency(this.getDependency());
         Dependency targetDependency = Dependency.toDependency(target.getDependency());

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvInitializer.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/runner/EnvInitializer.java
@@ -74,6 +74,10 @@ public class EnvInitializer implements ApplicationRunner {
         "^streampark-flink-shims_flink-(1\\.1[7-9]|1\\.2[0-9]|2\\.[0-3])-(.*).jar$",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
+    private static final Pattern PATTERN_FLINK_SHIMS_BASE_JAR = Pattern.compile(
+        "^streampark-flink-shims-base(-v2)?-(.*)\\.jar$",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
     @SneakyThrows
     @Override
     public void run(ApplicationArguments args) throws Exception {
@@ -184,6 +188,10 @@ public class EnvInitializer implements ApplicationRunner {
         String appShims = workspace.APP_SHIMS();
         fsOperator.delete(appShims);
 
+        File[] shimsBaseJars =
+            WebUtils.getAppLibDir().listFiles(
+                pathname -> pathname.getName().matches(PATTERN_FLINK_SHIMS_BASE_JAR.pattern()));
+
         for (File file : shims) {
             Matcher matcher = PATTERN_FLINK_SHIMS_JAR.matcher(file.getName());
             if (matcher.matches()) {
@@ -192,7 +200,23 @@ public class EnvInitializer implements ApplicationRunner {
                 fsOperator.mkdirs(shimsPath);
                 log.info("load shims:{} to {}", file.getName(), shimsPath);
                 fsOperator.upload(file.getAbsolutePath(), shimsPath);
+                if (isFlink2MajorVersion(version) && shimsBaseJars != null) {
+                    uploadShimsBaseJars(fsOperator, shimsBaseJars, shimsPath);
+                }
             }
+        }
+    }
+
+    private static boolean isFlink2MajorVersion(String majorVersion) {
+        int dot = majorVersion.indexOf('.');
+        String major = dot < 0 ? majorVersion : majorVersion.substring(0, dot);
+        return "2".equals(major);
+    }
+
+    private void uploadShimsBaseJars(FsOperator fsOperator, File[] shimsBaseJars, String shimsPath) {
+        for (File baseJar : shimsBaseJars) {
+            log.info("load shims base:{} to {}", baseJar.getName(), shimsPath);
+            fsOperator.upload(baseJar.getAbsolutePath(), shimsPath);
         }
     }
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/application/impl/FlinkApplicationActionServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/application/impl/FlinkApplicationActionServiceImpl.java
@@ -261,7 +261,7 @@ public class FlinkApplicationActionServiceImpl
         applicationLog.setClusterId(application.getClusterId());
         applicationLog.setUserId(ServiceHelper.getUserId());
 
-        if (appParam.getRestoreOrTriggerSavepoint()) {
+        if (Boolean.TRUE.equals(appParam.getRestoreOrTriggerSavepoint())) {
             FlinkAppHttpWatcher.addSavepoint(application.getId());
             application.setOptionState(OptionStateEnum.SAVEPOINTING.getValue());
         } else {
@@ -280,7 +280,7 @@ public class FlinkApplicationActionServiceImpl
 
         // infer savepoint
         String customSavepoint = null;
-        if (appParam.getRestoreOrTriggerSavepoint()) {
+        if (Boolean.TRUE.equals(appParam.getRestoreOrTriggerSavepoint())) {
             customSavepoint = appParam.getSavepointPath();
             if (StringUtils.isBlank(customSavepoint)) {
                 customSavepoint = savepointService.getSavePointPath(appParam);
@@ -315,10 +315,10 @@ public class FlinkApplicationActionServiceImpl
                 properties,
                 new JobClientTarget(clusterId, application.getJobId(), namespace),
                 new SavepointCancelOptions(
-                    appParam.getRestoreOrTriggerSavepoint(),
-                    appParam.getDrain(),
+                    Boolean.TRUE.equals(appParam.getRestoreOrTriggerSavepoint()),
+                    Boolean.TRUE.equals(appParam.getDrain()),
                     customSavepoint,
-                    appParam.getNativeFormat()));
+                    Boolean.TRUE.equals(appParam.getNativeFormat())));
 
         final Date triggerTime = new Date();
         CompletableFuture<CancelResponse> cancelFuture =
@@ -344,7 +344,7 @@ public class FlinkApplicationActionServiceImpl
                         application.setState(FlinkAppStateEnum.FAILED.getValue());
                         updateById(application);
 
-                        if (appParam.getRestoreOrTriggerSavepoint()) {
+                        if (Boolean.TRUE.equals(appParam.getRestoreOrTriggerSavepoint())) {
                             savepointService.expire(application.getId());
                         }
                         // re-tracking flink job on kubernetes and logging exception
@@ -436,10 +436,8 @@ public class FlinkApplicationActionServiceImpl
         String flinkUserJar = userJarAndAppConf.t1;
         String appConf = userJarAndAppConf.t2;
 
-        BuildResult buildResult = buildPipeline.getBuildResult();
-        if (FlinkDeployMode.YARN_APPLICATION == application.getDeployModeEnum()) {
-            buildResult = new ShadedBuildResponse(null, flinkUserJar, true);
-        }
+        BuildResult buildResult =
+            resolveBuildResultForSubmit(application, buildPipeline.getBuildResult(), flinkUserJar);
 
         // Get the args after placeholder replacement
         String args =
@@ -635,6 +633,41 @@ public class FlinkApplicationActionServiceImpl
         application.setState(FlinkAppStateEnum.STARTING.getValue());
         application.setOptionTime(new Date());
         updateById(application);
+    }
+
+    private BuildResult resolveBuildResultForSubmit(
+                                                    FlinkApplication application,
+                                                    BuildResult buildResult,
+                                                    String flinkUserJar) {
+        if (FlinkDeployMode.YARN_APPLICATION == application.getDeployModeEnum()) {
+            return new ShadedBuildResponse(null, flinkUserJar, true);
+        }
+        if (!(buildResult instanceof ShadedBuildResponse)) {
+            return buildResult;
+        }
+        ShadedBuildResponse shaded = (ShadedBuildResponse) buildResult;
+        if (StringUtils.isNotBlank(shaded.shadedJarPath())) {
+            return shaded;
+        }
+        String workspace =
+            StringUtils.defaultIfBlank(shaded.workspacePath(), application.getLocalAppHome());
+        String jarPath =
+            workspace
+                + "/streampark-flinkjob_"
+                + application.getJobName().replaceAll("\\s+", "_")
+                + ".jar";
+        File jarFile = new File(jarPath);
+        if (!jarFile.isFile()
+            && application.isUploadResource()
+            && StringUtils.isNotBlank(application.getJar())) {
+            jarFile = new File(workspace, application.getJar());
+        }
+        ApiAlertException.throwIfTrue(
+            !jarFile.isFile(),
+            "[StreamPark] Shaded jar not found at "
+                + jarPath
+                + ", please rebuild the application.");
+        return new ShadedBuildResponse(workspace, jarPath, shaded.pass());
     }
 
     private Tuple2<String, String> getUserJarAndAppConf(
@@ -835,7 +868,7 @@ public class FlinkApplicationActionServiceImpl
     }
 
     private String getSavepointPath(FlinkApplication appParam) {
-        if (appParam.getRestoreOrTriggerSavepoint()) {
+        if (Boolean.TRUE.equals(appParam.getRestoreOrTriggerSavepoint())) {
             if (StringUtils.isBlank(appParam.getSavepointPath())) {
                 FlinkSavepoint savepoint = savepointService.getLatest(appParam.getId());
                 if (savepoint != null) {

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/application/impl/FlinkApplicationBuildPipelineServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/application/impl/FlinkApplicationBuildPipelineServiceImpl.java
@@ -215,7 +215,7 @@ public class FlinkApplicationBuildPipelineServiceImpl
                             app.getJar(),
                             app.getAppHome(),
                             app.getAppLib(),
-                            app.getDistHome(),
+                            app.isUploadResource() ? null : app.getDistHome(),
                             app.getFsOperator(),
                             appUploads,
                             app.isUploadResource(),

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkClusterServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkClusterServiceImpl.java
@@ -233,6 +233,9 @@ public class FlinkClusterServiceImpl extends ServiceImpl<FlinkClusterMapper, Fli
     private void updateFlinkClusterForRemoteMode(
                                                  FlinkCluster paramOfCluster, FlinkCluster flinkCluster) {
         flinkCluster.setAddress(paramOfCluster.getAddress());
+        if (paramOfCluster.getVersionId() != null) {
+            flinkCluster.setVersionId(paramOfCluster.getVersionId());
+        }
         flinkCluster.setClusterState(ClusterState.RUNNING.getState());
         flinkCluster.setStartTime(new Date());
         flinkCluster.setEndTime(null);

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkSqlServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkSqlServiceImpl.java
@@ -72,7 +72,7 @@ public class FlinkSqlServiceImpl extends ServiceImpl<FlinkSqlMapper, FlinkSql>
     public FlinkSql getEffective(Long appId, boolean decode) {
         FlinkSql flinkSql = baseMapper.getEffective(appId);
         if (flinkSql != null && decode) {
-            flinkSql.setSql(DeflaterUtils.unzipString(flinkSql.getSql()));
+            flinkSql.setSql(DeflaterUtils.toPlainText(flinkSql.getSql()));
         }
         return flinkSql;
     }
@@ -90,7 +90,7 @@ public class FlinkSqlServiceImpl extends ServiceImpl<FlinkSqlMapper, FlinkSql>
             .map(
                 flinkSql -> {
                     if (decode) {
-                        flinkSql.setSql(DeflaterUtils.unzipString(flinkSql.getSql()));
+                        flinkSql.setSql(DeflaterUtils.toPlainText(flinkSql.getSql()));
                     }
                     return flinkSql;
                 })
@@ -101,8 +101,7 @@ public class FlinkSqlServiceImpl extends ServiceImpl<FlinkSqlMapper, FlinkSql>
     public void create(FlinkSql flinkSql) {
         Integer version = this.baseMapper.getLatestVersion(flinkSql.getAppId());
         flinkSql.setVersion(version == null ? 1 : version + 1);
-        String sql = DeflaterUtils.zipString(flinkSql.getSql());
-        flinkSql.setSql(sql);
+        flinkSql.setSql(DeflaterUtils.compressForStorage(flinkSql.getSql()));
         this.save(flinkSql);
         this.setCandidate(CandidateTypeEnum.NEW, flinkSql.getAppId(), flinkSql.getId());
     }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/util/ApplicationBuildPipelineUtils.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/util/ApplicationBuildPipelineUtils.java
@@ -155,23 +155,29 @@ public final class ApplicationBuildPipelineUtils {
                                          boolean tempDirFallback) {
         fsOperator.delete(appHome);
         if (!fromUpload) {
+            ApiAlertException.throwIfTrue(
+                StringUtils.isBlank(distHome),
+                "[StreamPark] distHome is required for build-resource jar jobs");
             fsOperator.upload(distHome, appHome);
             return;
         }
 
-        String uploadJar = appUploads.concat("/").concat(jar);
-        File localJar = new File(String.format("%s/%d/%s", Workspace.local().APP_UPLOADS(), teamId, jar));
+        String teamUploads = appUploads.concat("/").concat(String.valueOf(teamId));
+        String uploadJar = teamUploads.concat("/").concat(jar);
+        File localJar = new File(uploadJar);
         if (!localJar.exists()) {
             Resource resource = resourceService.findByResourceName(teamId, jar);
             if (resource != null && StringUtils.isNotBlank(resource.getFilePath())) {
                 localJar = new File(resource.getFilePath());
-                uploadJar = appUploads.concat("/").concat(localJar.getName());
+                uploadJar = teamUploads.concat("/").concat(localJar.getName());
             } else if (tempDirFallback) {
                 localJar = new File(WebUtils.getAppTempDir(), jar);
-                uploadJar = appUploads.concat("/").concat(localJar.getName());
             }
         }
-        checkOrElseUploadJar(fsOperator, localJar, uploadJar, appUploads);
+        if (!localJar.isFile()) {
+            throw new ApiAlertException("Missing jar file: " + jar + ", please upload again");
+        }
+        checkOrElseUploadJar(fsOperator, localJar, uploadJar, teamUploads);
 
         switch (applicationType) {
             case STREAMPARK_FLINK:

--- a/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/assembler/FlinkApplicationAssemblerTest.java
+++ b/streampark-console/streampark-console-service/src/test/java/org/apache/streampark/console/core/assembler/FlinkApplicationAssemblerTest.java
@@ -51,6 +51,18 @@ class FlinkApplicationAssemblerTest {
     }
 
     @Test
+    void shouldDefaultNullStartFlagsToFalse() {
+        FlinkAppStartRequest request = new FlinkAppStartRequest();
+        request.setId(1L);
+        request.setTeamId(100000L);
+
+        FlinkApplication app = FlinkApplicationAssembler.toEntity(request);
+
+        Assertions.assertFalse(app.getRestoreOrTriggerSavepoint());
+        Assertions.assertFalse(app.getAllowNonRestored());
+    }
+
+    @Test
     void shouldConvertStartRequestToEntity() {
         FlinkAppStartRequest request = new FlinkAppStartRequest();
         request.setId(1L);

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-api/src/main/java/org/apache/streampark/flink/client/ExitSecurityManager.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-api/src/main/java/org/apache/streampark/flink/client/ExitSecurityManager.java
@@ -34,4 +34,9 @@ public final class ExitSecurityManager extends SecurityManager {
     public void checkPermission(Permission perm) {
         // no-op
     }
+
+    @Override
+    public void checkPermission(Permission perm, Object context) {
+        // no-op
+    }
 }

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-api/src/main/java/org/apache/streampark/flink/client/FlinkClient.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-api/src/main/java/org/apache/streampark/flink/client/FlinkClient.java
@@ -58,9 +58,15 @@ public final class FlinkClient {
     }
 
     public static SubmitResponse submit(SubmitRequest submitRequest) {
-        SecurityManager securityManager = System.getSecurityManager();
+        SecurityManager previousSecurityManager = System.getSecurityManager();
+        boolean exitGuardInstalled = false;
         try {
-            System.setSecurityManager(new ExitSecurityManager());
+            try {
+                System.setSecurityManager(new ExitSecurityManager());
+                exitGuardInstalled = true;
+            } catch (UnsupportedOperationException ignored) {
+                // JDK 17+ may reject SecurityManager unless -Djava.security.manager=allow is set.
+            }
             return invokeClient(
                 submitRequest,
                 submitRequest.flinkVersion(),
@@ -68,7 +74,9 @@ public final class FlinkClient {
                 "submit",
                 SubmitResponse.class);
         } finally {
-            System.setSecurityManager(securityManager);
+            if (exitGuardInstalled) {
+                System.setSecurityManager(previousSecurityManager);
+            }
         }
     }
 

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-api/src/main/java/org/apache/streampark/flink/client/bean/SubmitRequest.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-api/src/main/java/org/apache/streampark/flink/client/bean/SubmitRequest.java
@@ -202,6 +202,10 @@ public class SubmitRequest implements Serializable {
                 appMain = Constants.PYTHON_FLINK_DRIVER_CLASS_NAME;
             } else {
                 appMain = appProperties().get(ConfigKeys.KEY_FLINK_APPLICATION_MAIN_CLASS());
+                if (appMain == null && appConf() != null) {
+                    String format = appConf().substring(0, Math.min(appConf().length(), 7));
+                    appMain = loadAppConfMap(format).get(ConfigKeys.KEY_FLINK_APPLICATION_MAIN_CLASS());
+                }
             }
         }
         return appMain;

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/tool/FlinkSessionSubmitHelper.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/tool/FlinkSessionSubmitHelper.java
@@ -21,26 +21,34 @@ import org.apache.streampark.common.util.AssertUtils;
 import org.apache.streampark.common.util.JsonUtils;
 import org.apache.streampark.common.util.LoggerSupport;
 import org.apache.streampark.flink.client.conf.FlinkSavepointOptions;
-import org.apache.streampark.flink.kubernetes.KubernetesRetriever;
 
 import org.apache.streampark.shaded.com.fasterxml.jackson.databind.JsonNode;
 
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
-import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
-import org.apache.hc.client5.http.fluent.Request;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.io.entity.StringEntity;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+import java.time.Duration;
 import java.util.List;
 
 /** Submit Flink jobs to session clusters via the REST API. */
 public final class FlinkSessionSubmitHelper extends LoggerSupport {
 
     private static final FlinkSessionSubmitHelper INSTANCE = new FlinkSessionSubmitHelper();
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(30);
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofMinutes(5);
 
     private FlinkSessionSubmitHelper() {
     }
@@ -60,21 +68,25 @@ public final class FlinkSessionSubmitHelper extends LoggerSupport {
     }
 
     private String doSubmitViaRestApi(String jmRestUrl, File flinkJobJar, Configuration flinkConfig) throws Exception {
+        HttpClient httpClient =
+            HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+
+        String boundary = "----StreamParkBoundary" + System.currentTimeMillis();
+        HttpRequest uploadRequest =
+            HttpRequest.newBuilder()
+                .uri(URI.create(jmRestUrl + "/jars/upload"))
+                .timeout(REQUEST_TIMEOUT)
+                .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+                .POST(HttpRequest.BodyPublishers.ofByteArray(buildMultipartBody(boundary, flinkJobJar)))
+                .build();
+
         String uploadResult =
-            Request.post(jmRestUrl + "/jars/upload")
-                .connectTimeout(KubernetesRetriever.FLINK_REST_AWAIT_TIMEOUT_SEC)
-                .responseTimeout(KubernetesRetriever.FLINK_CLIENT_TIMEOUT_SEC)
-                .body(
-                    MultipartEntityBuilder.create()
-                        .addBinaryBody(
-                            "jarfile",
-                            flinkJobJar,
-                            ContentType.create("application/java-archive"),
-                            flinkJobJar.getName())
-                        .build())
-                .execute()
-                .returnContent()
-                .asString(StandardCharsets.UTF_8);
+            AccessController.doPrivileged(
+                (PrivilegedExceptionAction<String>) () -> httpClient
+                    .send(
+                        uploadRequest,
+                        HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
+                    .body());
 
         JarUploadResponse jarUploadResponse = parseJarUploadResponse(uploadResult);
 
@@ -85,16 +97,50 @@ public final class FlinkSessionSubmitHelper extends LoggerSupport {
                 + ", response="
                 + jarUploadResponse);
 
-        String resp =
-            Request.post(jmRestUrl + "/jars/" + jarUploadResponse.jarId() + "/run")
-                .connectTimeout(KubernetesRetriever.FLINK_REST_AWAIT_TIMEOUT_SEC)
-                .responseTimeout(KubernetesRetriever.FLINK_CLIENT_TIMEOUT_SEC)
-                .body(new StringEntity(JsonUtils.write(new JarRunRequest(flinkConfig))))
-                .execute()
-                .returnContent()
-                .asString(StandardCharsets.UTF_8);
+        HttpRequest runRequest =
+            HttpRequest.newBuilder()
+                .uri(URI.create(jmRestUrl + "/jars/" + jarUploadResponse.jarId() + "/run"))
+                .timeout(REQUEST_TIMEOUT)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(JsonUtils.write(new JarRunRequest(flinkConfig))))
+                .build();
 
-        return parseJobId(resp);
+        String resp =
+            AccessController.doPrivileged(
+                (PrivilegedExceptionAction<String>) () -> httpClient
+                    .send(
+                        runRequest,
+                        HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
+                    .body());
+
+        String jobId = parseJobId(resp);
+        if (jobId == null || jobId.isBlank()) {
+            throw new IllegalStateException(
+                "[flink-submit] submit flink job via rest api failed, jmRestUrl="
+                    + jmRestUrl
+                    + ", response="
+                    + resp);
+        }
+        return jobId;
+    }
+
+    private byte[] buildMultipartBody(String boundary, File jarFile) throws IOException {
+        String header =
+            "--"
+                + boundary
+                + "\r\n"
+                + "Content-Disposition: form-data; name=\"jarfile\"; filename=\""
+                + jarFile.getName()
+                + "\"\r\n"
+                + "Content-Type: application/java-archive\r\n\r\n";
+        byte[] headerBytes = header.getBytes(StandardCharsets.UTF_8);
+        byte[] fileBytes = Files.readAllBytes(jarFile.toPath());
+        byte[] footerBytes = ("\r\n--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8);
+        byte[] body = new byte[headerBytes.length + fileBytes.length + footerBytes.length];
+        System.arraycopy(headerBytes, 0, body, 0, headerBytes.length);
+        System.arraycopy(fileBytes, 0, body, headerBytes.length, fileBytes.length);
+        System.arraycopy(footerBytes, 0, body, headerBytes.length + fileBytes.length, footerBytes.length);
+        return body;
     }
 
     private JarUploadResponse parseJarUploadResponse(String uploadResult) {
@@ -111,7 +157,16 @@ public final class FlinkSessionSubmitHelper extends LoggerSupport {
     private String parseJobId(String resp) {
         try {
             JsonNode node = JsonUtils.read(resp, JsonNode.class);
-            return node.has("jobid") ? node.get("jobid").asText(null) : null;
+            if (node.has("errors") && node.get("errors").size() > 0) {
+                return null;
+            }
+            if (node.has("jobid")) {
+                return node.get("jobid").asText(null);
+            }
+            if (node.has("jobId")) {
+                return node.get("jobId").asText(null);
+            }
+            return null;
         } catch (Exception e) {
             return null;
         }

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/trait/FlinkClientTrait.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/trait/FlinkClientTrait.java
@@ -78,6 +78,7 @@ import com.google.common.collect.Lists;
 
 import java.io.File;
 import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -509,6 +510,9 @@ public abstract class FlinkClientTrait extends LoggerSupport {
             logInfo("[flink-submit] Submit job with JobGraph Plan.");
             return jobGraphFunc.apply(submitRequest, flinkConfig, jarFile);
         } catch (FlinkException e) {
+            logWarn(
+                "[flink-submit] JobGraph submit plan failed, falling back to Rest API submit plan: "
+                    + ExceptionUtils.stringifyException(e));
             try {
                 return restApiFunc.apply(submitRequest, flinkConfig, jarFile);
             } catch (FlinkException fallbackException) {
@@ -545,6 +549,81 @@ public abstract class FlinkClientTrait extends LoggerSupport {
         return configuration;
     }
 
+    /**
+     * Parent-first patterns for FLINK_SQL fat jars, which bundle a SQL client but not the target
+     * Flink distribution. Without delegating {@code org.apache.flink.*} and {@code org.yaml.*}
+     * to the registered Flink version's lib directory, shaded YAML/Jackson classes from the jar
+     * collide with Flink's own copies and fail with {@code LinkageError}.
+     */
+    private static Configuration flinkSqlParentFirstConfig() {
+        Configuration configuration = new Configuration();
+        configuration.setString(
+            "classloader.parent-first-patterns.additional",
+            "org.apache.streampark.;org.apache.flink.;org.yaml.");
+        return configuration;
+    }
+
+    /**
+     * Parent for {@link org.apache.flink.client.program.PackagedProgram}'s user-code classloader.
+     *
+     * <p>Flink's parent-first patterns delegate matching classes to this loader before the SQL fat
+     * jar. The fat jar bundles an unshaded {@code org.yaml.snakeyaml} copy that clashes with Flink
+     * 2.x's shaded YAML stack, and it omits {@code org.apache.flink.*} entirely. StreamPark shims
+     * carry the registered Flink version's classes; the console classpath carries snakeyaml.
+     */
+    private static ClassLoader packagedProgramParentClassLoader(ClassLoader shimsClassLoader) {
+        ClassLoader consoleClassLoader = FlinkClientTrait.class.getClassLoader();
+        return new ClassLoader(shimsClassLoader) {
+
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                synchronized (getClassLoadingLock(name)) {
+                    Class<?> loaded = findLoadedClass(name);
+                    if (loaded == null) {
+                        if (name.startsWith("org.apache.streampark.")
+                            || name.startsWith("org.apache.flink.")) {
+                            loaded = getParent().loadClass(name);
+                        } else if (name.startsWith("org.yaml.")) {
+                            loaded = consoleClassLoader.loadClass(name);
+                        }
+                    }
+                    if (loaded == null) {
+                        loaded = super.loadClass(name, resolve);
+                    } else if (resolve) {
+                        resolveClass(loaded);
+                    }
+                    return loaded;
+                }
+            }
+        };
+    }
+
+    private static List<URL> jobGraphUserClassPaths(SubmitRequest submitRequest) {
+        return jobGraphUserClassPaths(submitRequest, false);
+    }
+
+    /**
+     * Classpath entries for {@link PackagedProgram} when building a JobGraph locally.
+     *
+     * @param includeFlinkDist keep {@code flink-dist} on the classpath; required for thin uploaded
+     *     JARs on Flink 1.20+ where runtime classes live in {@code flink-dist} rather than {@code
+     *     flink-core}. FLINK_SQL fat jars omit it to avoid snakeyaml clashes and rely on parent-first
+     *     delegation instead.
+     */
+    private static List<URL> jobGraphUserClassPaths(
+                                                    SubmitRequest submitRequest, boolean includeFlinkDist) {
+        List<URL> classPaths = new ArrayList<>(submitRequest.classPaths());
+        classPaths.removeIf(
+            url -> {
+                String name = url.getPath();
+                if (name.contains("flink-shaded-force-shading")) {
+                    return true;
+                }
+                return !includeFlinkDist && name.contains("flink-dist");
+            });
+        return classPaths;
+    }
+
     public Tuple2<PackagedProgram, JobGraph> getJobGraph(
                                                          Configuration flinkConfig, SubmitRequest submitRequest,
                                                          File jarFile) throws Exception {
@@ -570,32 +649,40 @@ public abstract class FlinkClientTrait extends LoggerSupport {
             }
         } else {
             builder.setJarFile(jarFile);
-            if (submitRequest.jobType() == FlinkJobType.FLINK_SQL) {
-                // The FLINK_SQL fat jar bundles only the SQL client and the shims it was built
-                // against; it carries none of the target Flink version's own jars, so those have to
-                // be handed to the program explicitly. Scoped to FLINK_SQL, unlike the blanket
-                // disable from https://github.com/apache/streampark/issues/3761, which was never
-                // verified against this job type.
-                builder.setUserClassPaths(Lists.newArrayList(submitRequest.classPaths()));
-                // ...and the StreamPark classes must come from the parent — this thread runs under
-                // the shims classloader for the *registered* Flink version, whereas the fat jar
-                // carries whichever shims it happened to be built with. Loading both ends in a
-                // LinkageError as soon as one references the other, and silently mixes Flink
-                // versions when it does not.
-                builder.setConfiguration(streamParkParentFirstConfig());
-            }
+            boolean flinkSqlJob = submitRequest.jobType() == FlinkJobType.FLINK_SQL;
+            // Thin user JARs (Flink examples, uploaded jobs) and FLINK_SQL fat jars both rely on the
+            // registered Flink version's lib/ at JobGraph build time. Parent-first delegation keeps
+            // org.apache.streampark.* on the shims classloader for SQL; uploaded JARs also need
+            // flink-dist when the target Flink version bundles runtime classes there (1.20+).
+            builder.setUserClassPaths(
+                jobGraphUserClassPaths(submitRequest, !flinkSqlJob));
+            builder.setConfiguration(flinkSqlParentFirstConfig());
         }
 
-        PackagedProgram packageProgram = builder.build();
-        JobGraph jobGraph =
-            PackagedProgramUtils.createJobGraph(
-                packageProgram,
-                flinkConfig,
-                getParallelism(submitRequest),
-                null,
-                false);
+        ClassLoader shimsClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader programParent =
+            submitRequest.jobType() == FlinkJobType.PYFLINK
+                ? shimsClassLoader
+                : packagedProgramParentClassLoader(shimsClassLoader);
+        Thread.currentThread().setContextClassLoader(programParent);
+        try {
+            PackagedProgram packageProgram = builder.build();
+            Configuration jobGraphConfig = new Configuration(flinkConfig);
+            if (submitRequest.jobType() != FlinkJobType.PYFLINK) {
+                jobGraphConfig.addAll(flinkSqlParentFirstConfig());
+            }
+            JobGraph jobGraph =
+                PackagedProgramUtils.createJobGraph(
+                    packageProgram,
+                    jobGraphConfig,
+                    getParallelism(submitRequest),
+                    null,
+                    false);
 
-        return new Tuple2<>(packageProgram, jobGraph);
+            return new Tuple2<>(packageProgram, jobGraph);
+        } finally {
+            Thread.currentThread().setContextClassLoader(shimsClassLoader);
+        }
     }
 
     public JobID getJobID(String jobId) throws CliArgsException {
@@ -856,6 +943,19 @@ public abstract class FlinkClientTrait extends LoggerSupport {
                     programArgs.add(submitRequest.appConf());
                 }
             } else if (shouldAddAppConf(submitRequest.appConf())) {
+                programArgs.add(paramKeyAppConf);
+                programArgs.add(submitRequest.appConf());
+            }
+        } else if (submitRequest.jobType() == FlinkJobType.FLINK_SQL) {
+            programArgs.add(paramKeyFlinkConf);
+            programArgs.add(submitRequest.flinkYaml());
+            programArgs.add(paramKeyAppName);
+            programArgs.add(DeflaterUtils.zipString(submitRequest.effectiveAppName()));
+            programArgs.add(paramKeyFlinkParallelism);
+            programArgs.add(getParallelism(submitRequest).toString());
+            programArgs.add(paramKeyFlinkSql);
+            programArgs.add(submitRequest.flinkSQL());
+            if (submitRequest.appConf() != null) {
                 programArgs.add(paramKeyAppConf);
                 programArgs.add(submitRequest.appConf());
             }

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/test/java/org/apache/streampark/flink/client/test/SubmitRequestTest.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/test/java/org/apache/streampark/flink/client/test/SubmitRequestTest.java
@@ -53,6 +53,17 @@ class SubmitRequestTest {
     }
 
     @Test
+    void appMainForFlinkJarFromJsonConf() {
+        String mainClass = "org.apache.flink.streaming.examples.windowing.TopSpeedWindowing";
+        String appConf =
+            String.format(
+                "json://{\"%s\":\"%s\"}",
+                ConfigKeys.KEY_FLINK_APPLICATION_MAIN_CLASS(), mainClass);
+        SubmitRequest request = createRequest(FlinkJobType.FLINK_JAR, appConf);
+        assertThat(request.appMain()).isEqualTo(mainClass);
+    }
+
+    @Test
     void savepointRestoreSettingsWithoutSavepoint() {
         SubmitRequest request = createRequest(FlinkJobType.FLINK_JAR, null);
         assertThat(request.savepointRestoreSettings()).isEqualTo(SavepointRestoreSettings.none());

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/maven/MavenTool.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/maven/MavenTool.java
@@ -306,7 +306,10 @@ public final class MavenTool extends LoggerSupport {
             boolean isFilteredState =
                 name.startsWith("META-INF/") && name.endsWith(".SF")
                     || name.endsWith(".DSA")
-                    || name.endsWith(".RSA");
+                    || name.endsWith(".RSA")
+                    || name.startsWith("org/yaml/")
+                    || name.startsWith("META-INF/versions/")
+                        && name.contains("/org/yaml/");
             if (isFilteredState) {
                 INSTANCE.logInfo("shade ignore file: " + name);
                 return true;

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/BuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/BuildPipeline.java
@@ -86,12 +86,8 @@ public abstract class BuildPipeline extends LoggerSupport
         return this;
     }
 
-    private void notifyStart() {
-        try {
-            watcher.onStart(snapshot());
-        } catch (Exception e) {
-            logError("Pipeline watcher onStart callback failed", e);
-        }
+    private void notifyStart() throws Exception {
+        watcher.onStart(snapshot());
     }
 
     private void notifyStepChange() {
@@ -201,6 +197,13 @@ public abstract class BuildPipeline extends LoggerSupport
             notifyFinish(result);
             return result;
         } catch (TimeoutException e) {
+            pipeStatus = PipelineStatusEnum.FAILURE;
+            error = PipeError.of(e.getMessage(), e);
+            logError("Building pipeline has failed.", e);
+            BuildResult result = new ErrorResult();
+            notifyFinish(result);
+            return result;
+        } catch (Exception e) {
             pipeStatus = PipelineStatusEnum.FAILURE;
             error = PipeError.of(e.getMessage(), e);
             logError("Building pipeline has failed.", e);

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/ShadedBuildResponse.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/ShadedBuildResponse.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ShadedBuildResponse extends AbstractFlinkBuildResponse {
 
+    @JsonProperty("shadedJarPath")
     private String shadedJarPath;
 
     public ShadedBuildResponse(String workspacePath, String shadedJarPath) {

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkRemoteBuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkRemoteBuildPipeline.java
@@ -20,6 +20,7 @@ package org.apache.streampark.flink.packer.pipeline.impl;
 import org.apache.streampark.common.enums.FlinkJobType;
 import org.apache.streampark.common.fs.FsOperator;
 import org.apache.streampark.common.fs.LfsOperator;
+import org.apache.streampark.flink.packer.maven.Artifact;
 import org.apache.streampark.flink.packer.maven.MavenTool;
 import org.apache.streampark.flink.packer.pipeline.BuildPipeline;
 import org.apache.streampark.flink.packer.pipeline.FlinkRemotePerJobBuildRequest;
@@ -53,6 +54,11 @@ public class FlinkRemoteBuildPipeline extends BuildPipeline {
     @Override
     public ShadedBuildResponse buildProcess() {
         if (request.skipBuild()) {
+            File userJar = new File(request.customFlinkUserJar());
+            if (!userJar.isFile()) {
+                logError("User jar not found for skipBuild: " + request.customFlinkUserJar());
+                return new ShadedBuildResponse(request.workspace(), request.customFlinkUserJar(), false);
+            }
             return new ShadedBuildResponse(request.workspace(), request.customFlinkUserJar());
         }
 
@@ -78,7 +84,7 @@ public class FlinkRemoteBuildPipeline extends BuildPipeline {
                     return new File(request.customFlinkUserJar());
                 });
 
-        List<String> mavenJars =
+        List<String> extraLibJars =
             execStep(
                 3,
                 () -> {
@@ -92,17 +98,26 @@ public class FlinkRemoteBuildPipeline extends BuildPipeline {
                         paths.addAll(request.dependencyInfo().extJarLibs());
                         return paths;
                     }
+                    if (request.flinkJobType() == FlinkJobType.FLINK_SQL) {
+                        List<File> snakeyaml =
+                            MavenTool.resolveArtifacts(
+                                Collections.singleton(new Artifact("org.yaml", "snakeyaml", "2.0")));
+                        return snakeyaml.stream()
+                            .map(File::getAbsolutePath)
+                            .collect(Collectors.toList());
+                    }
                     return Collections.<String>emptyList();
                 });
 
         execStep(
             4,
             () -> {
-                if (request.flinkJobType() == FlinkJobType.PYFLINK) {
+                if (request.flinkJobType() == FlinkJobType.PYFLINK
+                    || request.flinkJobType() == FlinkJobType.FLINK_SQL) {
                     FsOperator lfs = FsOperator.lfs();
                     String lib = request.workspace().concat("/lib");
                     lfs.mkdirsIfNotExists(lib);
-                    for (String jar : mavenJars) {
+                    for (String jar : extraLibJars) {
                         File originFile = new File(jar);
                         if (originFile.isFile()) {
                             lfs.copy(originFile.getAbsolutePath(), lib);

--- a/streampark-flink/streampark-flink-proxy/src/main/java/org/apache/streampark/flink/proxy/FlinkShimsProxy.java
+++ b/streampark-flink/streampark-flink-proxy/src/main/java/org/apache/streampark/flink/proxy/FlinkShimsProxy.java
@@ -82,6 +82,7 @@ public final class FlinkShimsProxy extends LoggerSupport {
             "org.apache.commons.cli",
             "ch.qos.logback",
             "org.xml",
+            "org.yaml",
             "org.w3c",
             "org.apache.hadoop"));
 

--- a/streampark-flink/streampark-flink-sqlclient/pom.xml
+++ b/streampark-flink/streampark-flink-sqlclient/pom.xml
@@ -93,6 +93,7 @@
                             <exclude>com.google.code.findbugs:jsr305</exclude>
                             <exclude>org.slf4j:*</exclude>
                             <exclude>log4j:*</exclude>
+                            <exclude>org.yaml:snakeyaml</exclude>
                         </excludes>
                     </artifactSet>
                     <filters>


### PR DESCRIPTION
## Summary

Fixes REMOTE Session JobGraph submission for Flink **1.17–1.20** and **2.x** SQL / uploaded JAR applications (Closes #4506).

This PR builds on #4500, which already landed the Flink 2.x REMOTE JobGraph baseline on `dev`. This change adds the remaining cross-version fixes discovered during local e2e validation.

### SQL
- Normalize storage/decoding with `DeflaterUtils.toPlainText` / `compressForStorage`
- Harden `FlinkSql.checkChange` for null/compressed input
- Sync remote cluster `versionId` on update

### Uploaded JAR
- Skip `distHome` for upload resources; fix team-scoped upload paths
- Resolve shaded jar fallback for upload jobs
- Add Flink runtime classpath + parent-first classloading for JobGraph build (including Flink 1.20 `flink-dist`)

### Client / packer / shims (1.x + 2.x)
- Read main class from JSON `appConf` (`SubmitRequest.appMain`)
- Fix `ShadedBuildResponse` JSON mapping
- SQL fat-jar snakeyaml handling (`sqlclient` shade, `MavenTool`, build pipeline lib copy)
- Flink 2.x shims-base upload in `EnvInitializer`
- `FlinkShimsProxy` parent-first for `org.yaml`
- JDK 17 SecurityManager tolerance; REST fallback via `HttpClient`

## Relationship to #4500

| Layer | PR | Responsibility |
|-------|----|----------------|
| Baseline | #4500 (merged) | Flink 2.x REMOTE JobGraph submit path, classloader/ServiceLoader fixes |
| This PR | #4507 | SQL storage, upload JAR build/submit, snakeyaml/classpath, 1.20 `flink-dist`, console fixes |

## Test plan

- [x] Flink 1.20.5 REMOTE Session: SQL build + start → RUNNING via JobGraph (no REST fallback)
- [x] Flink 1.20.5 REMOTE Session: uploaded JAR (Flink 1.20-compatible examples jar) → RUNNING via JobGraph
- [x] Flink 2.x REMOTE Session: SQL + JAR regression verified in local e2e (on top of #4500)
- [ ] CI

**Note:** uploaded JARs must match the target Flink version.