### PR TITLE
[Flink] Fix Flink 2.x Flink SQL on Yarn/K8s Application mode

### DIFF
--- a/streampark-common/src/main/java/org/apache/streampark/common/util/StreamParkLoggerFactory.java
+++ b/streampark-common/src/main/java/org/apache/streampark/common/util/StreamParkLoggerFactory.java
@@ -29,7 +29,7 @@ import org.apache.streampark.shaded.org.slf4j.ILoggerFactory;
 import org.apache.streampark.shaded.org.slf4j.spi.LoggerFactoryBinder;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
@@ -97,26 +97,25 @@ public final class StreamParkLoggerFactory implements LoggerFactoryBinder {
         public void configureByResource(URL url) {
             AssertUtils.notNull(url, "URL argument cannot be null");
             String path = url.getPath();
-            if (path.endsWith("xml")) {
-                JoranConfigurator configurator = new JoranConfigurator();
-                configurator.setContext(loggerContext);
-                try {
-                    String text =
-                        FileUtils.readFile(new File(path))
-                            .replaceAll("org.slf4j", SHADED_PACKAGE + ".org.slf4j")
-                            .replaceAll("ch.qos.logback", SHADED_PACKAGE + ".ch.qos.logback")
-                            .replaceAll("org.apache.log4j", SHADED_PACKAGE + ".org.apache.log4j");
-                    ByteArrayInputStream input =
-                        new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
-                    configurator.doConfigure(input);
-                } catch (Exception e) {
-                    throw new LogbackException("Failed to configure logger context from " + url, e);
-                }
-            } else {
+            if (path == null || !path.endsWith("xml")) {
                 throw new LogbackException(
                     "Unexpected filename extension of file ["
                         + url
                         + "]. Should be .xml");
+            }
+            JoranConfigurator configurator = new JoranConfigurator();
+            configurator.setContext(loggerContext);
+            try (InputStream inputStream = url.openStream()) {
+                String text =
+                    new String(inputStream.readAllBytes(), StandardCharsets.UTF_8)
+                        .replaceAll("org.slf4j", SHADED_PACKAGE + ".org.slf4j")
+                        .replaceAll("ch.qos.logback", SHADED_PACKAGE + ".ch.qos.logback")
+                        .replaceAll("org.apache.log4j", SHADED_PACKAGE + ".org.apache.log4j");
+                ByteArrayInputStream input =
+                    new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+                configurator.doConfigure(input);
+            } catch (Exception e) {
+                throw new LogbackException("Failed to configure logger context from " + url, e);
             }
         }
     }

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/application/impl/FlinkApplicationActionServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/application/impl/FlinkApplicationActionServiceImpl.java
@@ -661,8 +661,11 @@ public class FlinkApplicationActionServiceImpl
                         : String.format("yaml://%s", applicationConfig.getContent());
                 // 3) client
                 if (FlinkDeployMode.YARN_APPLICATION == deployModeEnum) {
-                    String clientPath = Workspace.remote().APP_CLIENT();
-                    flinkUserJar = String.format("%s/%s", clientPath, sqlDistJar);
+                    flinkUserJar =
+                        application.getAppHome()
+                            + "/streampark-flinkjob_"
+                            + application.getJobName().replaceAll("\\s+", "_")
+                            + ".jar";
                 }
                 break;
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/application/impl/FlinkApplicationBuildPipelineServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/application/impl/FlinkApplicationBuildPipelineServiceImpl.java
@@ -367,8 +367,9 @@ public class FlinkApplicationBuildPipelineServiceImpl
                     yarnProvidedPath = app.getAppHome();
                     localWorkspace = app.getLocalAppHome();
                 }
-                FlinkYarnApplicationBuildRequest yarnAppRequest = buildFlinkYarnApplicationBuildRequest(app, mainClass,
-                    localWorkspace, yarnProvidedPath);
+                FlinkYarnApplicationBuildRequest yarnAppRequest =
+                    buildFlinkYarnApplicationBuildRequest(
+                        app, mainClass, localWorkspace, yarnProvidedPath, flinkEnv);
                 log.info("Submit params to building pipeline : {}", yarnAppRequest);
                 return FlinkYarnApplicationBuildPipeline.of(yarnAppRequest);
             case YARN_PER_JOB:
@@ -400,13 +401,21 @@ public class FlinkApplicationBuildPipelineServiceImpl
                                                                                    @Nonnull FlinkApplication app,
                                                                                    String mainClass,
                                                                                    String localWorkspace,
-                                                                                   String yarnProvidedPath) {
+                                                                                   String yarnProvidedPath,
+                                                                                   FlinkEnv flinkEnv) {
+        String sqlDistJar = ServiceHelper.getFlinkSqlClientJar(flinkEnv);
+        String localSqlClientJar =
+            Workspace.local().APP_CLIENT().concat("/").concat(sqlDistJar);
         return new FlinkYarnApplicationBuildRequest(
             app.getJobName(),
             mainClass,
+            app.getLocalAppHome(),
             localWorkspace,
             yarnProvidedPath,
+            localSqlClientJar,
             app.getJobTypeEnum(),
+            app.getDeployModeEnum(),
+            flinkEnv.getFlinkVersion(),
             getMergedDependencyInfo(app));
     }
 

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkClusterServiceImpl.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/service/impl/FlinkClusterServiceImpl.java
@@ -417,7 +417,7 @@ public class FlinkClusterServiceImpl extends ServiceImpl<FlinkClusterMapper, Fli
             flinkCluster.getId(),
             getKubernetesDeployDesc(flinkCluster, "shutdown"));
         Future<ShutDownResponse> future = executorService.submit(() -> FlinkClient.shutdown(stopRequest));
-        return future.get(60, TimeUnit.SECONDS);
+        return future.get(300, TimeUnit.SECONDS);
     }
 
     private DeployResponse deployInternal(FlinkCluster flinkCluster) throws InterruptedException, ExecutionException, TimeoutException {
@@ -430,7 +430,7 @@ public class FlinkClusterServiceImpl extends ServiceImpl<FlinkClusterMapper, Fli
             getKubernetesDeployDesc(flinkCluster, "start"));
         log.info("Deploy cluster request {}", deployRequest);
         Future<DeployResponse> future = executorService.submit(() -> FlinkClient.deploy(deployRequest));
-        return future.get(60, TimeUnit.SECONDS);
+        return future.get(300, TimeUnit.SECONDS);
     }
 
     private void checkActiveIfNeeded(FlinkCluster flinkCluster) {

--- a/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkClusterWatcher.java
+++ b/streampark-console/streampark-console-service/src/main/java/org/apache/streampark/console/core/watcher/FlinkClusterWatcher.java
@@ -196,6 +196,7 @@ public class FlinkClusterWatcher {
     private ClusterState httpClusterState(FlinkCluster flinkCluster) {
         switch (flinkCluster.getFlinkDeployModeEnum()) {
             case REMOTE:
+            case KUBERNETES_NATIVE_SESSION:
                 return httpRemoteClusterState(flinkCluster);
             case YARN_SESSION:
                 return httpYarnSessionClusterState(flinkCluster);

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/impl/KubernetesNativeSessionClient.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/impl/KubernetesNativeSessionClient.java
@@ -119,9 +119,9 @@ public final class KubernetesNativeSessionClient extends KubernetesNativeClientT
                         flinkConfig,
                         jarFile,
                         () -> getK8sClusterDescriptor(flinkConfig)
-                            .retrieve(flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID))
+                            .retrieve(flinkConfig.get(KubernetesConfigOptions.CLUSTER_ID))
                             .getClusterClient(),
-                        () -> flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID));
+                        () -> flinkConfig.get(KubernetesConfigOptions.CLUSTER_ID));
                 logInfo(
                     "[flink-submit] flink job has been submitted. "
                         + flinkConfIdentifierInfo(flinkConfig)

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/impl/YarnApplicationClient.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/impl/YarnApplicationClient.java
@@ -69,8 +69,10 @@ public final class YarnApplicationClient extends YarnClientTrait {
         providedLibs.add(hdfsWorkspace.appJars());
 
         if (submitRequest.jobType() == FlinkJobType.FLINK_SQL) {
-            providedLibs.add(
-                WORKSPACE.APP_SHIMS() + "/flink-" + submitRequest.flinkVersion().majorVersion());
+            // Flink SQL yarn-application builds a fat jar that already shades version-specific
+            // shims. Adding the HDFS shims directory here makes parent-first classloading pick
+            // shims-base ahead of shims-base-v2 and breaks Flink 2.x (NoSuchMethodError on
+            // FlinkConfiguration).
             String jobLib = WORKSPACE.APP_WORKSPACE() + "/" + submitRequest.id() + "/lib";
             try {
                 if (HdfsUtils.exists(jobLib)) {

--- a/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/impl/YarnSessionClient.java
+++ b/streampark-flink/streampark-flink-client/streampark-flink-client-core/src/main/java/org/apache/streampark/flink/client/impl/YarnSessionClient.java
@@ -34,11 +34,9 @@ import org.apache.streampark.flink.client.trait.YarnClientTrait;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.DeploymentOptionsInternal;
-import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.yarn.YarnClusterDescriptor;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
@@ -90,36 +88,17 @@ public final class YarnSessionClient extends YarnClientTrait {
 
     @Override
     public SubmitResponse doSubmit(SubmitRequest submitRequest, Configuration flinkConfig) throws FlinkException {
-        return callAsFlinkException(
-            () -> {
-                Tuple2<ApplicationId, YarnClusterDescriptor> yarnClusterDescriptor =
-                    getYarnClusterDescriptor(flinkConfig);
-                ApplicationId yarnClusterId = yarnClusterDescriptor._1();
-                YarnClusterDescriptor clusterDescriptor = yarnClusterDescriptor._2();
-
-                Tuple2<PackagedProgram, JobGraph> programJobGraph =
-                    getJobGraph(flinkConfig, submitRequest, submitRequest.userJarFile());
-                PackagedProgram packageProgram = programJobGraph._1();
-                JobGraph jobGraph = programJobGraph._2();
-
-                ClusterClient<ApplicationId> client =
-                    clusterDescriptor.retrieve(yarnClusterId).getClusterClient();
-                String jobId = client.submitJob(jobGraph).get().toString();
-                String jobManagerUrl = client.getWebInterfaceURL();
-
-                logInfo(
-                    String.format(
-                        "%n-------------------------<<applicationId>>------------------------%n"
-                            + "Flink Job Started: jobId: %s , applicationId: %s%n"
-                            + "__________________________________________________________________%n",
-                        jobId, yarnClusterId));
-
-                SubmitResponse resp =
-                    new SubmitResponse(
-                        yarnClusterId.toString(), flinkConfig.toMap(), jobId, jobManagerUrl);
-                closeSubmit(submitRequest, packageProgram, client, clusterDescriptor);
-                return resp;
-            });
+        Tuple2<ApplicationId, YarnClusterDescriptor> yarnClusterDescriptor =
+            getYarnClusterDescriptor(flinkConfig);
+        ApplicationId yarnClusterId = yarnClusterDescriptor._1();
+        YarnClusterDescriptor clusterDescriptor = yarnClusterDescriptor._2();
+        return submitJobGraphToCluster(
+            submitRequest,
+            flinkConfig,
+            submitRequest.userJarFile(),
+            () -> clusterDescriptor.retrieve(yarnClusterId).getClusterClient(),
+            () -> yarnClusterId.toString(),
+            clusterDescriptor);
     }
 
     @Override

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/docker/FlinkDockerfileTemplate.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/docker/FlinkDockerfileTemplate.java
@@ -62,7 +62,7 @@ public class FlinkDockerfileTemplate extends FlinkDockerfileTemplateTrait {
     public String offerDockerfileContent() {
         return "FROM " + flinkBaseImage + "\n"
             + "RUN mkdir -p " + FLINK_HOME + "/usrlib\n"
-            + "COPY " + extraLibName() + " " + FLINK_HOME + "/lib/\n"
+            + "COPY " + extraLibName() + "/. " + FLINK_HOME + "/lib/\n"
             + "COPY " + mainJarName() + " " + FLINK_HOME + "/usrlib/" + mainJarName() + "\n";
     }
 }

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/docker/FlinkHadoopDockerfileTemplate.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/docker/FlinkHadoopDockerfileTemplate.java
@@ -106,7 +106,7 @@ public class FlinkHadoopDockerfileTemplate extends FlinkDockerfileTemplateTrait 
         dockerfile
             .append("COPY ")
             .append(extraLibName())
-            .append(" ")
+            .append("/. ")
             .append(FLINK_HOME)
             .append("/lib/\n")
             .append("COPY ")

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/maven/MavenTool.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/maven/MavenTool.java
@@ -57,6 +57,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -145,7 +146,7 @@ public final class MavenTool extends LoggerSupport {
                 "[StreamPark] streampark-packer: failed to delete existing uber jar: "
                     + outFatJarPath);
         }
-        Set<File> jarSet = new HashSet<>();
+        Set<File> jarSet = new LinkedHashSet<>();
         for (String lib : jarLibs) {
             File libFile = new File(lib);
             if (!libFile.exists()) {
@@ -156,11 +157,14 @@ public final class MavenTool extends LoggerSupport {
             } else if (libFile.isDirectory()) {
                 File[] files = libFile.listFiles();
                 if (files != null) {
+                    List<File> dirJars = new ArrayList<>();
                     for (File f : files) {
                         if (isJarFile(f)) {
-                            jarSet.add(f);
+                            dirJars.add(f);
                         }
                     }
+                    dirJars.sort(ShimJarMergeOrder.COMPARATOR);
+                    jarSet.addAll(dirJars);
                 }
             }
         }

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/maven/ShimJarMergeOrder.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/maven/ShimJarMergeOrder.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.packer.maven;
+
+import java.io.File;
+import java.util.Comparator;
+
+/** Controls duplicate class resolution when shading StreamPark shims into a fat jar. */
+final class ShimJarMergeOrder {
+
+    private static final String SHIMS_BASE_PREFIX = "streampark-flink-shims-base-";
+    private static final String SHIMS_BASE_V2_PREFIX = "streampark-flink-shims-base-v2-";
+
+    static final Comparator<File> COMPARATOR = Comparator.comparingInt(ShimJarMergeOrder::mergeOrder);
+
+    private ShimJarMergeOrder() {
+    }
+
+    private static int mergeOrder(File jar) {
+        String name = jar.getName();
+        if (name.startsWith(SHIMS_BASE_V2_PREFIX)) {
+            return 0;
+        }
+        if (name.startsWith(SHIMS_BASE_PREFIX)) {
+            return 1;
+        }
+        return 2;
+    }
+}

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/FlinkSqlDependencySupport.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/FlinkSqlDependencySupport.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.packer.pipeline;
+
+import org.apache.streampark.flink.packer.maven.Artifact;
+import org.apache.streampark.flink.packer.maven.DependencyInfo;
+import org.apache.streampark.flink.packer.maven.MavenTool;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Shared dependency helpers for Flink SQL build pipelines. */
+public final class FlinkSqlDependencySupport {
+
+    private static final Artifact SNAKEYAML = new Artifact("org.yaml", "snakeyaml", "2.0");
+
+    private FlinkSqlDependencySupport() {
+    }
+
+    public static DependencyInfo withSnakeyaml(DependencyInfo dependencyInfo) {
+        Set<String> extJarLibs = new HashSet<>(dependencyInfo.extJarLibs());
+        addSnakeyaml(extJarLibs);
+        return new DependencyInfo(dependencyInfo.mavenArts(), extJarLibs);
+    }
+
+    public static void addSnakeyaml(Set<String> extJarLibs) {
+        String appHome = System.getProperty("app.home", "/streampark");
+        File snakeyaml = new File(appHome, "lib/snakeyaml-2.0.jar");
+        if (snakeyaml.isFile()) {
+            extJarLibs.add(snakeyaml.getAbsolutePath());
+            return;
+        }
+        try {
+            MavenTool.resolveArtifacts(Collections.singleton(SNAKEYAML))
+                .stream()
+                .map(File::getAbsolutePath)
+                .forEach(extJarLibs::add);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to resolve snakeyaml for Flink SQL application build", e);
+        }
+    }
+}

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/FlinkYarnApplicationBuildRequest.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/FlinkYarnApplicationBuildRequest.java
@@ -17,30 +17,44 @@
 
 package org.apache.streampark.flink.packer.pipeline;
 
+import org.apache.streampark.common.conf.FlinkVersion;
+import org.apache.streampark.common.enums.FlinkDeployMode;
 import org.apache.streampark.common.enums.FlinkJobType;
 import org.apache.streampark.flink.packer.maven.DependencyInfo;
 
-public class FlinkYarnApplicationBuildRequest implements BuildParam {
+public class FlinkYarnApplicationBuildRequest implements FlinkBuildParam {
 
     private final String appName;
     private final String mainClass;
+    private final String localAppHome;
     private final String localWorkspace;
     private final String yarnProvidedPath;
+    private final String customFlinkUserJar;
     private final FlinkJobType flinkJobType;
+    private final FlinkDeployMode deployMode;
+    private final FlinkVersion flinkVersion;
     private final DependencyInfo dependencyInfo;
 
     public FlinkYarnApplicationBuildRequest(
                                             String appName,
                                             String mainClass,
+                                            String localAppHome,
                                             String localWorkspace,
                                             String yarnProvidedPath,
+                                            String customFlinkUserJar,
                                             FlinkJobType flinkJobType,
+                                            FlinkDeployMode deployMode,
+                                            FlinkVersion flinkVersion,
                                             DependencyInfo dependencyInfo) {
         this.appName = appName;
         this.mainClass = mainClass;
+        this.localAppHome = localAppHome;
         this.localWorkspace = localWorkspace;
         this.yarnProvidedPath = yarnProvidedPath;
+        this.customFlinkUserJar = customFlinkUserJar;
         this.flinkJobType = flinkJobType;
+        this.deployMode = deployMode;
+        this.flinkVersion = flinkVersion;
         this.dependencyInfo = dependencyInfo;
     }
 
@@ -54,6 +68,40 @@ public class FlinkYarnApplicationBuildRequest implements BuildParam {
         return mainClass;
     }
 
+    @Override
+    public String workspace() {
+        return localAppHome;
+    }
+
+    @Override
+    public FlinkDeployMode deployMode() {
+        return deployMode;
+    }
+
+    @Override
+    public FlinkJobType flinkJobType() {
+        return flinkJobType;
+    }
+
+    @Override
+    public FlinkVersion flinkVersion() {
+        return flinkVersion;
+    }
+
+    @Override
+    public DependencyInfo dependencyInfo() {
+        return dependencyInfo;
+    }
+
+    @Override
+    public String customFlinkUserJar() {
+        return customFlinkUserJar;
+    }
+
+    public String localAppHome() {
+        return localAppHome;
+    }
+
     public String localWorkspace() {
         return localWorkspace;
     }
@@ -62,11 +110,10 @@ public class FlinkYarnApplicationBuildRequest implements BuildParam {
         return yarnProvidedPath;
     }
 
-    public FlinkJobType flinkJobType() {
-        return flinkJobType;
-    }
-
-    public DependencyInfo dependencyInfo() {
-        return dependencyInfo;
+    public String remoteAppHome() {
+        if (yarnProvidedPath.endsWith("/lib")) {
+            return yarnProvidedPath.substring(0, yarnProvidedPath.length() - 4);
+        }
+        return yarnProvidedPath;
     }
 }

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkK8sApplicationBuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkK8sApplicationBuildPipeline.java
@@ -17,6 +17,7 @@
 
 package org.apache.streampark.flink.packer.pipeline.impl;
 
+import org.apache.streampark.common.enums.FlinkJobType;
 import org.apache.streampark.common.fs.LfsOperator;
 import org.apache.streampark.flink.kubernetes.PodTemplateTool;
 import org.apache.streampark.flink.kubernetes.ingress.IngressController;
@@ -24,6 +25,7 @@ import org.apache.streampark.flink.packer.docker.DockerConf;
 import org.apache.streampark.flink.packer.docker.FlinkDockerfileTemplate;
 import org.apache.streampark.flink.packer.docker.FlinkDockerfileTemplateTrait;
 import org.apache.streampark.flink.packer.docker.FlinkHadoopDockerfileTemplate;
+import org.apache.streampark.flink.packer.maven.Artifact;
 import org.apache.streampark.flink.packer.maven.MavenTool;
 import org.apache.streampark.flink.packer.pipeline.DockerImageBuildResponse;
 import org.apache.streampark.flink.packer.pipeline.FlinkK8sApplicationBuildRequest;
@@ -33,6 +35,8 @@ import org.apache.streampark.flink.packer.pipeline.PipelineTypeEnum;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -94,12 +98,24 @@ public class FlinkK8sApplicationBuildPipeline extends AbstractK8sApplicationBuil
                     logInfo("Output shaded flink job jar: " + jar.getAbsolutePath());
                     return jar;
                 });
-        final Set<String> extJarLibs = request.dependencyInfo().extJarLibs();
-
         Object[] dockerResult =
             execStep(
                 4,
                 () -> {
+                    Set<String> extJarLibs = new HashSet<>(request.dependencyInfo().extJarLibs());
+                    if (request.flinkJobType() == FlinkJobType.FLINK_SQL) {
+                        String appHome = System.getProperty("app.home", "/streampark");
+                        File snakeyaml = new File(appHome, "lib/snakeyaml-2.0.jar");
+                        if (snakeyaml.isFile()) {
+                            extJarLibs.add(snakeyaml.getAbsolutePath());
+                        } else {
+                            MavenTool.resolveArtifacts(
+                                Collections.singleton(new Artifact("org.yaml", "snakeyaml", "2.0")))
+                                .stream()
+                                .map(File::getAbsolutePath)
+                                .forEach(extJarLibs::add);
+                        }
+                    }
                     FlinkDockerfileTemplateTrait template;
                     if (request.integrateWithHadoop()) {
                         template =

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkK8sApplicationBuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkK8sApplicationBuildPipeline.java
@@ -25,17 +25,16 @@ import org.apache.streampark.flink.packer.docker.DockerConf;
 import org.apache.streampark.flink.packer.docker.FlinkDockerfileTemplate;
 import org.apache.streampark.flink.packer.docker.FlinkDockerfileTemplateTrait;
 import org.apache.streampark.flink.packer.docker.FlinkHadoopDockerfileTemplate;
-import org.apache.streampark.flink.packer.maven.Artifact;
 import org.apache.streampark.flink.packer.maven.MavenTool;
 import org.apache.streampark.flink.packer.pipeline.DockerImageBuildResponse;
 import org.apache.streampark.flink.packer.pipeline.FlinkK8sApplicationBuildRequest;
+import org.apache.streampark.flink.packer.pipeline.FlinkSqlDependencySupport;
 import org.apache.streampark.flink.packer.pipeline.K8sDockerBuildSupport;
 import org.apache.streampark.flink.packer.pipeline.PipelineTypeEnum;
 
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -104,17 +103,7 @@ public class FlinkK8sApplicationBuildPipeline extends AbstractK8sApplicationBuil
                 () -> {
                     Set<String> extJarLibs = new HashSet<>(request.dependencyInfo().extJarLibs());
                     if (request.flinkJobType() == FlinkJobType.FLINK_SQL) {
-                        String appHome = System.getProperty("app.home", "/streampark");
-                        File snakeyaml = new File(appHome, "lib/snakeyaml-2.0.jar");
-                        if (snakeyaml.isFile()) {
-                            extJarLibs.add(snakeyaml.getAbsolutePath());
-                        } else {
-                            MavenTool.resolveArtifacts(
-                                Collections.singleton(new Artifact("org.yaml", "snakeyaml", "2.0")))
-                                .stream()
-                                .map(File::getAbsolutePath)
-                                .forEach(extJarLibs::add);
-                        }
+                        FlinkSqlDependencySupport.addSnakeyaml(extJarLibs);
                     }
                     FlinkDockerfileTemplateTrait template;
                     if (request.integrateWithHadoop()) {

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkYarnApplicationBuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkYarnApplicationBuildPipeline.java
@@ -18,10 +18,20 @@
 package org.apache.streampark.flink.packer.pipeline.impl;
 
 import org.apache.streampark.common.enums.FlinkJobType;
+import org.apache.streampark.common.fs.FsOperator;
+import org.apache.streampark.flink.packer.maven.Artifact;
+import org.apache.streampark.flink.packer.maven.DependencyInfo;
+import org.apache.streampark.flink.packer.maven.MavenTool;
 import org.apache.streampark.flink.packer.pipeline.BuildPipeline;
 import org.apache.streampark.flink.packer.pipeline.FlinkYarnApplicationBuildRequest;
 import org.apache.streampark.flink.packer.pipeline.PipelineTypeEnum;
 import org.apache.streampark.flink.packer.pipeline.SimpleBuildResponse;
+import org.apache.streampark.flink.packer.pipeline.YarnJarUploader;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /** Building pipeline for flink yarn application mode */
 public class FlinkYarnApplicationBuildPipeline extends BuildPipeline {
@@ -47,12 +57,49 @@ public class FlinkYarnApplicationBuildPipeline extends BuildPipeline {
         boolean sqlMode =
             request.flinkJobType() == FlinkJobType.FLINK_SQL
                 || request.flinkJobType() == FlinkJobType.PYFLINK;
+        DependencyInfo dependencyInfo = request.dependencyInfo();
+        if (request.flinkJobType() == FlinkJobType.FLINK_SQL) {
+            Set<String> extJarLibs = new HashSet<>(dependencyInfo.extJarLibs());
+            String appHome = System.getProperty("app.home", "/streampark");
+            File snakeyaml = new File(appHome, "lib/snakeyaml-2.0.jar");
+            if (snakeyaml.isFile()) {
+                extJarLibs.add(snakeyaml.getAbsolutePath());
+            } else {
+                try {
+                    MavenTool.resolveArtifacts(
+                        Collections.singleton(new Artifact("org.yaml", "snakeyaml", "2.0")))
+                        .stream()
+                        .map(File::getAbsolutePath)
+                        .forEach(extJarLibs::add);
+                } catch (Exception e) {
+                    throw new IllegalStateException("Failed to resolve snakeyaml for Flink SQL yarn application", e);
+                }
+            }
+            dependencyInfo = new DependencyInfo(dependencyInfo.mavenArts(), extJarLibs);
+            buildAndUploadSqlFatJar();
+        }
         runYarnSqlBuildSteps(
             request.localWorkspace(),
             request.yarnProvidedPath(),
             sqlMode,
-            request.dependencyInfo());
+            dependencyInfo);
         return new SimpleBuildResponse();
+    }
+
+    private void buildAndUploadSqlFatJar() {
+        try {
+            String shadedJarOutputPath = request.getShadedJarPath(request.localAppHome());
+            File jar =
+                MavenTool.buildFatJar(
+                    request.mainClass(),
+                    request.providedLibs(),
+                    shadedJarOutputPath);
+            logInfo("Output shaded flink SQL jar: " + jar.getAbsolutePath());
+            YarnJarUploader.uploadJarToHdfsOrLfs(
+                FsOperator.hdfs(), jar.getAbsolutePath(), request.remoteAppHome());
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to build Flink SQL fat jar for yarn application", e);
+        }
     }
 
     public static FlinkYarnApplicationBuildPipeline of(FlinkYarnApplicationBuildRequest request) {

--- a/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkYarnApplicationBuildPipeline.java
+++ b/streampark-flink/streampark-flink-packer/src/main/java/org/apache/streampark/flink/packer/pipeline/impl/FlinkYarnApplicationBuildPipeline.java
@@ -19,19 +19,16 @@ package org.apache.streampark.flink.packer.pipeline.impl;
 
 import org.apache.streampark.common.enums.FlinkJobType;
 import org.apache.streampark.common.fs.FsOperator;
-import org.apache.streampark.flink.packer.maven.Artifact;
 import org.apache.streampark.flink.packer.maven.DependencyInfo;
 import org.apache.streampark.flink.packer.maven.MavenTool;
 import org.apache.streampark.flink.packer.pipeline.BuildPipeline;
+import org.apache.streampark.flink.packer.pipeline.FlinkSqlDependencySupport;
 import org.apache.streampark.flink.packer.pipeline.FlinkYarnApplicationBuildRequest;
 import org.apache.streampark.flink.packer.pipeline.PipelineTypeEnum;
 import org.apache.streampark.flink.packer.pipeline.SimpleBuildResponse;
 import org.apache.streampark.flink.packer.pipeline.YarnJarUploader;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 /** Building pipeline for flink yarn application mode */
 public class FlinkYarnApplicationBuildPipeline extends BuildPipeline {
@@ -59,23 +56,7 @@ public class FlinkYarnApplicationBuildPipeline extends BuildPipeline {
                 || request.flinkJobType() == FlinkJobType.PYFLINK;
         DependencyInfo dependencyInfo = request.dependencyInfo();
         if (request.flinkJobType() == FlinkJobType.FLINK_SQL) {
-            Set<String> extJarLibs = new HashSet<>(dependencyInfo.extJarLibs());
-            String appHome = System.getProperty("app.home", "/streampark");
-            File snakeyaml = new File(appHome, "lib/snakeyaml-2.0.jar");
-            if (snakeyaml.isFile()) {
-                extJarLibs.add(snakeyaml.getAbsolutePath());
-            } else {
-                try {
-                    MavenTool.resolveArtifacts(
-                        Collections.singleton(new Artifact("org.yaml", "snakeyaml", "2.0")))
-                        .stream()
-                        .map(File::getAbsolutePath)
-                        .forEach(extJarLibs::add);
-                } catch (Exception e) {
-                    throw new IllegalStateException("Failed to resolve snakeyaml for Flink SQL yarn application", e);
-                }
-            }
-            dependencyInfo = new DependencyInfo(dependencyInfo.mavenArts(), extJarLibs);
+            dependencyInfo = FlinkSqlDependencySupport.withSnakeyaml(dependencyInfo);
             buildAndUploadSqlFatJar();
         }
         runYarnSqlBuildSteps(

--- a/streampark-flink/streampark-flink-packer/src/test/java/org/apache/streampark/flink/packer/FlinkDockerfileTemplateTest.java
+++ b/streampark-flink/streampark-flink-packer/src/test/java/org/apache/streampark/flink/packer/FlinkDockerfileTemplateTest.java
@@ -61,7 +61,7 @@ class FlinkDockerfileTemplateTest {
         String expected =
             "FROM 1.13-scala_2.11\n"
                 + "RUN mkdir -p $FLINK_HOME/usrlib\n"
-                + "COPY lib $FLINK_HOME/lib/\n"
+                + "COPY lib/. $FLINK_HOME/lib/\n"
                 + "COPY WordCountSQL.jar $FLINK_HOME/usrlib/WordCountSQL.jar\n";
         assertEquals(expected, template.offerDockerfileContent());
     }
@@ -74,7 +74,7 @@ class FlinkDockerfileTemplateTest {
         String expected =
             "FROM 1.13-scala_2.11\n"
                 + "RUN mkdir -p $FLINK_HOME/usrlib\n"
-                + "COPY lib $FLINK_HOME/lib/\n"
+                + "COPY lib/. $FLINK_HOME/lib/\n"
                 + "COPY WordCountSQL.jar $FLINK_HOME/usrlib/WordCountSQL.jar\n";
         File outFile = template.writeDockerfile();
         assertEquals("Dockerfile", outFile.getName());
@@ -89,7 +89,7 @@ class FlinkDockerfileTemplateTest {
         String expected =
             "FROM 1.13-scala_2.11\n"
                 + "RUN mkdir -p $FLINK_HOME/usrlib\n"
-                + "COPY lib $FLINK_HOME/lib/\n"
+                + "COPY lib/. $FLINK_HOME/lib/\n"
                 + "COPY WordCountSQL.jar $FLINK_HOME/usrlib/WordCountSQL.jar\n";
         File outFile = template.writeDockerfile("Dockerfile");
         assertEquals("Dockerfile", outFile.getName());

--- a/streampark-flink/streampark-flink-sqlclient/src/main/java/org/apache/streampark/flink/cli/FlinkParameterToolBridge.java
+++ b/streampark-flink/streampark-flink-sqlclient/src/main/java/org/apache/streampark/flink/cli/FlinkParameterToolBridge.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.streampark.flink.cli;
+
+import java.lang.reflect.Method;
+
+/** Loads Flink {@code ParameterTool} across 1.x and 2.x package relocations. */
+final class FlinkParameterToolBridge {
+
+    private static final String[] PARAMETER_TOOL_CLASSES =
+        new String[]{
+                "org.apache.flink.util.ParameterTool",
+                "org.apache.flink.api.java.utils.ParameterTool"
+        };
+
+    private final Object delegate;
+
+    private FlinkParameterToolBridge(Object delegate) {
+        this.delegate = delegate;
+    }
+
+    static FlinkParameterToolBridge fromArgs(String[] args) {
+        for (String className : PARAMETER_TOOL_CLASSES) {
+            try {
+                Class<?> clazz = Class.forName(className);
+                Method fromArgs = clazz.getMethod("fromArgs", String[].class);
+                return new FlinkParameterToolBridge(fromArgs.invoke(null, (Object) args));
+            } catch (ClassNotFoundException ignored) {
+                // try next package
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException("Failed to parse program arguments", e);
+            }
+        }
+        throw new IllegalStateException("ParameterTool not found on classpath");
+    }
+
+    String get(String key) {
+        return get(key, null);
+    }
+
+    String get(String key, String defaultValue) {
+        try {
+            Method get = delegate.getClass().getMethod("get", String.class, String.class);
+            return (String) get.invoke(delegate, key, defaultValue);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to read parameter: " + key, e);
+        }
+    }
+}

--- a/streampark-flink/streampark-flink-sqlclient/src/main/java/org/apache/streampark/flink/cli/SqlClient.java
+++ b/streampark-flink/streampark-flink-sqlclient/src/main/java/org/apache/streampark/flink/cli/SqlClient.java
@@ -48,7 +48,7 @@ public final class SqlClient {
     public static void main(String[] args) {
         List<String> arguments = new ArrayList<>(Arrays.asList(args));
 
-        ParameterTool parameterTool = ParameterTool.fromArgs(args);
+        FlinkParameterToolBridge parameterTool = FlinkParameterToolBridge.fromArgs(args);
 
         String sqlKey = ConfigKeys.KEY_FLINK_SQL();
         String sql = parameterTool.get(sqlKey);
@@ -69,7 +69,7 @@ public final class SqlClient {
 
         String defaultMode = RuntimeExecutionMode.STREAMING.name();
         String mode =
-            resolveExecutionMode(parameterTool, sets, arguments, defaultMode);
+            resolveExecutionMode(parameterTool::get, sets, arguments, defaultMode);
 
         switch (mode) {
             case "STREAMING":
@@ -87,6 +87,14 @@ public final class SqlClient {
 
     static String resolveExecutionMode(
                                        ParameterTool parameterTool,
+                                       List<SqlCommandCall> sets,
+                                       List<String> arguments,
+                                       String defaultMode) {
+        return resolveExecutionMode(parameterTool::get, sets, arguments, defaultMode);
+    }
+
+    static String resolveExecutionMode(
+                                       ParameterLookup parameterTool,
                                        List<SqlCommandCall> sets,
                                        List<String> arguments,
                                        String defaultMode) {
@@ -118,6 +126,16 @@ public final class SqlClient {
         }
         arguments.add("-D" + ExecutionOptions.RUNTIME_MODE.key() + "=" + runtimeMode);
         return runtimeMode;
+    }
+
+    @FunctionalInterface
+    interface ParameterLookup {
+
+        String get(String key, String defaultValue);
+
+        default String get(String key) {
+            return get(key, null);
+        }
     }
 
     private static final class BatchSqlApp {


### PR DESCRIPTION
## Summary

- Build and upload a per-application fat jar for **Yarn Application** Flink SQL jobs, pointing `flinkUserJar` at the app workspace artifact instead of the shared SqlClient jar.
- Bundle **snakeyaml** into Yarn/K8s Application build pipelines so Flink SQL YAML parsing works in container images.
- Add **`FlinkParameterToolBridge`** so SqlClient resolves `ParameterTool` across Flink 1.x (`org.apache.flink.api.java.utils`) and Flink 2.x (`org.apache.flink.util`) package relocations.
- Fix **`StreamParkLoggerFactory`** to load logback XML from classpath URL streams and rewrite shaded class names, avoiding file-path failures under parent-first classloading on K8s Application mode.
- Introduce **`ShimJarMergeOrder`** and update **`MavenTool`** so Flink 2.x shims win over 1.x entries when merging fat jars.
- Stop adding shims artifacts to Yarn Application **`provided.lib.dirs`** in `YarnApplicationClient`.
- Treat **Kubernetes Session** clusters as HTTP-remotable in `FlinkClusterWatcher` for REST health checks.
- Increase Kubernetes session cluster deploy/shutdown timeout from 60s to 300s for slow cluster startup.

Closes #4508.

## Test plan

- [x] Verified `FlinkSQL200OnYarnTest` (Flink 2.0.2 Yarn Application + Session) locally — 10/10 passed
- [ ] Manual: create/release/start/cancel a Flink SQL app on Yarn Application mode with Flink 2.x
- [ ] Manual: create/release/start/cancel a Flink SQL app on Kubernetes Application mode with Flink 2.x
- [ ] `./mvnw -pl streampark-flink/streampark-flink-sqlclient,streampark-flink/streampark-flink-packer -am test -DskipTests` (compile)


Made with [Cursor](https://cursor.com)