### PR TITLE
[Bug] Fix Spark application list pagination restoration

### DIFF
--- a/streampark-console/streampark-console-webapp/src/views/spark/app/hooks/useSparkTableAction.ts
+++ b/streampark-console/streampark-console-webapp/src/views/spark/app/hooks/useSparkTableAction.ts
@@ -205,7 +205,7 @@ export const useSparkTableAction = (handlePageDataReload: Fn, optionApps: Record
   /* Click to edit */
   function handleEdit(app: SparkApplication, currentPageNo: number) {
     // Record the current page number
-    sessionStorage.setItem('sparkAppPageNo', String(currentPageNo || 1));
+    sessionStorage.setItem('appPageNo', String(currentPageNo || 1));
     router.push({ path: '/spark/app/edit', query: { appId: app.id } });
   }
 

--- a/streampark-console/streampark-console-webapp/src/views/spark/app/hooks/useSparkTableAction.ts
+++ b/streampark-console/streampark-console-webapp/src/views/spark/app/hooks/useSparkTableAction.ts
@@ -205,7 +205,7 @@ export const useSparkTableAction = (handlePageDataReload: Fn, optionApps: Record
   /* Click to edit */
   function handleEdit(app: SparkApplication, currentPageNo: number) {
     // Record the current page number
-    sessionStorage.setItem('appPageNo', String(currentPageNo || 1));
+    sessionStorage.setItem('sparkAppPageNo', String(currentPageNo || 1));
     router.push({ path: '/spark/app/edit', query: { appId: app.id } });
   }
 

--- a/streampark-console/streampark-console-webapp/src/views/spark/app/index.vue
+++ b/streampark-console/streampark-console-webapp/src/views/spark/app/index.vue
@@ -92,7 +92,7 @@
       }
       Object.assign(params, searchRef.value);
       currentTablePage.value = params.pageNum;
-      // sessionStorage.setItem('appPageNo', params.pageNum);
+      // sessionStorage.setItem('sparkAppPageNo', params.pageNum);
       const res = await fetchSparkAppRecord(params);
 
       const timestamp = new Date().getTime();
@@ -232,12 +232,12 @@
 
   onMounted(() => {
     // If there is a page, jump to the page number of the record
-    const currentPage = sessionStorage.getItem('appPageNo');
+    const currentPage = sessionStorage.getItem('sparkAppPageNo');
     if (currentPage) {
       setPagination({
         current: Number(currentPage) || 1,
       });
-      sessionStorage.removeItem('appPageNo');
+      sessionStorage.removeItem('sparkAppPageNo');
     }
   });
 


### PR DESCRIPTION
## What changes were proposed in this pull request

Issue Number: close #4513

Align the session storage key read by the Spark application list with the Spark-specific key written by the edit action. This restores the previous page after returning from edit without sharing pagination state with the Flink application module.

## Brief change log

- Read and remove `sparkAppPageNo` when the Spark application list mounts.
- Keep Spark and Flink pagination state isolated.

## Verifying this change

- Ran ESLint on both modified Spark application files with zero warnings.
- Ran `git diff --check` successfully.
- Verified the edit action, list restoration, and cleanup all use `sparkAppPageNo`.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no